### PR TITLE
Fix cell content in time trial lap table

### DIFF
--- a/src/static/js/timeTrialDataPopulator.js
+++ b/src/static/js/timeTrialDataPopulator.js
@@ -139,7 +139,7 @@ class TimeTrialDataPopulator {
             row.appendChild(sector1Cell);
 
             const sector2Cell = document.createElement('td');
-            sector2Cell.textContent = (lap["sector-2-time-in-ms"]) ? (lap["sector-1-time-str"]) : ('---');
+            sector2Cell.textContent = (lap["sector-2-time-in-ms"]) ? (lap["sector-2-time-str"]) : ('---');
             this.applyColourToCell(sector2Cell, lapNum, bestS2TimeLapNum, lapValidBitFlags & s2ValidMask);
             row.appendChild(sector2Cell);
 


### PR DESCRIPTION
#### Bug Fix

The time for the _second sector_ after time trial session ends was displaying the _first sector_.

## Summary by Sourcery

Bug Fixes:
- Corrected the second sector time display to show the actual second sector time instead of the first sector time