### PR TITLE
Fuel calc enhancements

### DIFF
--- a/lib/f1_types/common.py
+++ b/lib/f1_types/common.py
@@ -27,9 +27,9 @@
 ## F1 24 - https://answers.ea.com/t5/General-Discussion/F1-24-UDP-Specification/td-p/13745220
 
 
-from enum import Enum
-from typing import List, Any, Dict, Optional, Set
 import struct
+from enum import Enum, IntEnum
+from typing import Any, Dict, List, Optional, Set
 
 # ------------------------- PRIVATE FUNCTIONS ----------------------------------
 
@@ -445,7 +445,7 @@ class VisualTyreCompound(Enum):
             return True  # It's already an instance of VisualTyreCompound
         return any(visual_tyre_compound == member.value for member in VisualTyreCompound)
 
-class SafetyCarType(Enum):
+class SafetyCarType(IntEnum):
     """
     Enumeration representing different safety car statuses.
 

--- a/lib/fuel_rate_recommender.py
+++ b/lib/fuel_rate_recommender.py
@@ -64,25 +64,39 @@ class FuelRemainingPerLap:
             "desc": self.m_desc
         }
 
-class FuelRateRecommender:
-    """Class representing the fuel rate recommender.
+    def __str__(self) -> str:
+        """Return a string representation of the object."""
+        lap_type = "Racing" if self.m_is_racing_lap else "Safety Car"
+        return f"Lap {self.m_lap_number}: {self.m_fuel_remaining:.2f}kg ({lap_type})"
 
-    Attributes:
-        m_fuel_remaining_history (List[FuelRemainingPerLap]): List of fuel remaining per lap.
-        m_total_laps (int): Total number of laps in the race.
-        m_min_fuel_kg (float): Minimum fuel required in the car
+class FuelRateRecommender:
+    """Class representing the fuel rate recommender with discontinuity handling."""
+    """
+    ALGORITHM EXPLANATION:
+
+    1. Data Storage:
+    - Maintains history of fuel readings with lap number, fuel remaining, and lap type
+
+    2. Fuel Rate Calculation:
+    - Groups racing laps into consecutive segments to handle safety car interruptions
+    - Calculates fuel usage within each segment separately
+    - Derives overall rate from total fuel used across segments divided by racing lap count
+
+    3. Target Calculation:
+    - Computes target fuel rate to finish with minimum required fuel
+    - Determines surplus/deficit laps based on current consumption
+    - Calculates adaptive target for next lap
+
+    4. Prediction:
+    - Projects final fuel level using current racing fuel rate
+    - Assumes all remaining laps are racing laps
+
+    5. Recomputation:
+    - Refreshes all calculations when new data is added
+    - Sequence: last lap usage → racing rate → current state → targets → predictions
     """
 
     def __init__(self, fuel_remaining_history: List[FuelRemainingPerLap], total_laps: int, min_fuel_kg: float) -> None:
-        """
-        Initialize a FuelRateRecommender object.
-
-        Args:
-            fuel_remaining_history (List[FuelRemainingPerLap]): List of fuel remaining per lap.
-            total_laps (int): Total number of laps in the race.
-            min_fuel_kg (float): Minimum fuel required in the car
-        """
-
         self.m_fuel_remaining_history: List[FuelRemainingPerLap] = fuel_remaining_history
         self.m_total_laps: int = total_laps
         self.m_min_fuel_kg: float = min_fuel_kg
@@ -92,9 +106,8 @@ class FuelRateRecommender:
         self.m_target_fuel_rate: Optional[float] = None
         self.m_target_next_lap_fuel_usage: Optional[float] = None
         self.m_surplus_laps: Optional[float] = None
-        self.m_safety_car_fuel_rate: Optional[float] = None
         self.m_fuel_used_last_lap: Optional[float] = None
-        self.m_predicted_final_fuel: Dict[int, float] = {}  # Keyed by expected safety car laps
+        self.m_predicted_final_fuel: Dict[int, float] = {}
 
         self._recompute()
 
@@ -104,23 +117,23 @@ class FuelRateRecommender:
         Returns:
             bool: True if sufficient
         """
-        # We need 2 data points since we also include 0th lap data point
-        return (len(self.m_fuel_remaining_history) >= 2) and (self.m_total_laps is not None)
+        racing_laps = [lap for lap in self.m_fuel_remaining_history if lap.m_is_racing_lap]
+        return len(racing_laps) >= 2 and self.m_total_laps is not None
 
     def clear(self) -> None:
         """Clear the fuel rate recommender's data
         """
         self.m_fuel_remaining_history.clear()
-        self._reset_computed_values()
+        self.m_total_laps = None
+        self._clearComputedValues()
 
-    def _reset_computed_values(self) -> None:
-        """Reset all pre-computed values
+    def _clearComputedValues(self) -> None:
+        """Clear the computed values
         """
         self.m_curr_fuel_rate = None
         self.m_target_fuel_rate = None
         self.m_target_next_lap_fuel_usage = None
         self.m_surplus_laps = None
-        self.m_safety_car_fuel_rate = None
         self.m_fuel_used_last_lap = None
         self.m_predicted_final_fuel = {}
 
@@ -159,15 +172,6 @@ class FuelRateRecommender:
             Optional[float]: The surplus laps count (can be positive, negative, fractional)
         """
         return self.m_surplus_laps
-
-    @property
-    def safety_car_fuel_rate(self) -> Optional[float]:
-        """Get the average fuel rate during safety car periods
-
-        Returns:
-            Optional[float]: Average safety car fuel rate. None if not available
-        """
-        return self.m_safety_car_fuel_rate
 
     @property
     def fuel_used_last_lap(self) -> Optional[float]:
@@ -213,66 +217,55 @@ class FuelRateRecommender:
         )
         self._recompute()
 
-    def predict_final_fuel(self, expected_safety_car_laps: int = 0) -> Optional[float]:
-        """Get the predicted final fuel remaining
-
-        Args:
-            expected_safety_car_laps (int, optional): Expected number of safety car laps. Defaults to 0.
-
-        Returns:
-            Optional[float]: Predicted final fuel remaining, None if not enough data
-        """
-        return self.m_predicted_final_fuel.get(expected_safety_car_laps)
-
-    def _compute_last_lap_fuel_usage(self) -> None:
-        """Compute fuel used in the last lap"""
-
-        if len(self.m_fuel_remaining_history) >= 2:
-            self.m_fuel_used_last_lap = (self.m_fuel_remaining_history[-2].m_fuel_remaining -
-                                        self.m_fuel_remaining_history[-1].m_fuel_remaining)
+    def predict_final_fuel(self) -> Optional[float]:
+        """Get the predicted final fuel remaining"""
+        return self.m_predicted_final_fuel.get(0)
 
     def _compute_racing_fuel_rate(self, racing_laps: List[FuelRemainingPerLap]) -> None:
-        """Compute average fuel rate for racing laps
-
-        Args:
-            racing_laps (List[FuelRemainingPerLap]): List of racing laps
-        """
+        """Compute average fuel rate using ONLY racing laps, handling discontinuities"""
         if len(racing_laps) <= 1:
             return
 
-        # Sort by lap number to ensure correct order
+        # Sort by lap number
         racing_laps.sort(key=lambda x: x.m_lap_number)
 
-        # Use the most recent racing lap and the first racing lap for calculation
-        last_racing_lap = racing_laps[-1]
-        first_racing_lap = racing_laps[0]
+        # Find consecutive racing lap segments
+        consecutive_segments = []
+        current_segment = [racing_laps[0]]
 
-        fuel_used = first_racing_lap.m_fuel_remaining - last_racing_lap.m_fuel_remaining
-        laps_completed = last_racing_lap.m_lap_number - first_racing_lap.m_lap_number
+        for i in range(1, len(racing_laps)):
+            # Check if laps are consecutive
+            if racing_laps[i].m_lap_number == racing_laps[i-1].m_lap_number + 1:
+                current_segment.append(racing_laps[i])
+            else:
+                # Non-consecutive laps indicate a discontinuity (safety car period)
+                if len(current_segment) > 1:
+                    consecutive_segments.append(current_segment)
+                current_segment = [racing_laps[i]]
 
-        if laps_completed > 0:
-            self.m_curr_fuel_rate = fuel_used / laps_completed
+        # Add the last segment if it has more than one lap
+        if len(current_segment) > 1:
+            consecutive_segments.append(current_segment)
 
-    def _compute_safety_car_fuel_rate(self, safety_car_laps: List[FuelRemainingPerLap]) -> None:
-        """Compute average fuel rate for safety car laps
+        # Calculate fuel rate from all consecutive segments
+        total_fuel_used = 0
+        total_racing_laps = 0
 
-        Args:
-            safety_car_laps (List[FuelRemainingPerLap]): List of safety car laps
-        """
-        if len(safety_car_laps) > 1:
-            # Sort by lap number to ensure correct order
-            safety_car_laps.sort(key=lambda x: x.m_lap_number)
+        for segment in consecutive_segments:
+            segment_fuel_used = segment[0].m_fuel_remaining - segment[-1].m_fuel_remaining
+            segment_laps = segment[-1].m_lap_number - segment[0].m_lap_number
+            total_fuel_used += segment_fuel_used
+            total_racing_laps += segment_laps
 
-            # Calculate total fuel used during safety car periods
-            total_fuel_used = safety_car_laps[0].m_fuel_remaining - safety_car_laps[-1].m_fuel_remaining
-            total_sc_laps = safety_car_laps[-1].m_lap_number - safety_car_laps[0].m_lap_number
+        # If we have valid segments, calculate the rate
+        if total_racing_laps > 0:
+            self.m_curr_fuel_rate = total_fuel_used / total_racing_laps
 
-            if total_sc_laps > 0:
-                self.m_safety_car_fuel_rate = total_fuel_used / total_sc_laps
-        # If no safety car laps data but we have racing data, estimate safety car fuel rate
-        elif self.m_curr_fuel_rate is not None:
-            # Safety car typically uses about 60-70% of racing fuel
-            self.m_safety_car_fuel_rate = self.m_curr_fuel_rate * 0.65
+    def _compute_last_lap_fuel_usage(self) -> None:
+        """Compute fuel used in the last lap"""
+        if len(self.m_fuel_remaining_history) >= 2:
+            self.m_fuel_used_last_lap = (self.m_fuel_remaining_history[-2].m_fuel_remaining -
+                                         self.m_fuel_remaining_history[-1].m_fuel_remaining)
 
     def _compute_target_values(self, current_fuel: float, laps_left: int) -> None:
         """Compute target fuel rate and related values
@@ -281,6 +274,7 @@ class FuelRateRecommender:
             current_fuel (float): Current fuel level
             laps_left (int): Number of laps left
         """
+
         if laps_left <= 0:
             return
 
@@ -292,7 +286,7 @@ class FuelRateRecommender:
             laps_at_current_rate = available_fuel / self.m_curr_fuel_rate
             self.m_surplus_laps = laps_at_current_rate - laps_left
 
-        # Calculate target fuel usage for next lap
+        # Calculate target fuel usage for next lap (restored from original)
         if self.m_curr_fuel_rate is not None and self.m_target_fuel_rate is not None:
             fuel_rate_difference = self.m_curr_fuel_rate - self.m_target_fuel_rate
             adjustment_factor = 0.5
@@ -310,19 +304,13 @@ class FuelRateRecommender:
         if self.m_curr_fuel_rate is None:
             return
 
-        max_sc_laps_to_compute = min(6, laps_left + 1)  # Compute for 0 to min(5, laps_left)
-
-        for sc_laps in range(max_sc_laps_to_compute):
-            racing_laps_left = laps_left - sc_laps
-
-            racing_fuel_usage = racing_laps_left * self.m_curr_fuel_rate
-            safety_car_fuel_usage = sc_laps * (self.m_safety_car_fuel_rate or 0)
-
-            self.m_predicted_final_fuel[sc_laps] = current_fuel - racing_fuel_usage - safety_car_fuel_usage
+        # Only make one prediction - assuming all remaining laps are racing laps
+        self.m_predicted_final_fuel[0] = current_fuel - (laps_left * self.m_curr_fuel_rate)
 
     def _recompute(self) -> None:
         """Recompute all values for fuel predictions."""
-        self._reset_computed_values()
+        # Reset computed values
+        self._clearComputedValues()
 
         if not self.isDataSufficient():
             return
@@ -330,13 +318,9 @@ class FuelRateRecommender:
         # Compute fuel used in last lap
         self._compute_last_lap_fuel_usage()
 
-        # Split laps by type
+        # Only use racing laps for calculations
         racing_laps = [lap for lap in self.m_fuel_remaining_history if lap.m_is_racing_lap]
-        safety_car_laps = [lap for lap in self.m_fuel_remaining_history if not lap.m_is_racing_lap]
-
-        # Compute fuel rates
         self._compute_racing_fuel_rate(racing_laps)
-        self._compute_safety_car_fuel_rate(safety_car_laps)
 
         # Get current fuel and laps left
         current_fuel = self.m_fuel_remaining_history[-1].m_fuel_remaining
@@ -347,3 +331,33 @@ class FuelRateRecommender:
 
         # Compute fuel predictions
         self._compute_fuel_predictions(current_fuel, laps_left)
+
+    def __str__(self) -> str:
+        """String representation with predictions"""
+        if not self.isDataSufficient():
+            return "Insufficient data for predictions"
+
+        current_lap = self.m_fuel_remaining_history[-1].m_lap_number
+        current_fuel = self.m_fuel_remaining_history[-1].m_fuel_remaining
+        predicted_fuel = self.predict_final_fuel()
+
+        result = [
+            f"Current lap: {current_lap if current_lap is not None else 'None'}/"
+            f"{self.m_total_laps if self.m_total_laps is not None else 'None'}",
+
+            f"Current fuel: {current_fuel:.2f} kg" if current_fuel is not None else "Current fuel: None",
+
+            f"Racing fuel rate: {self.m_curr_fuel_rate:.3f} kg/lap"
+            if self.m_curr_fuel_rate is not None else "Racing fuel rate: None",
+
+            f"Target fuel rate: {self.m_target_fuel_rate:.3f} kg/lap"
+            if self.m_target_fuel_rate is not None else "Target fuel rate: None",
+
+            f"Predicted final fuel: {predicted_fuel:.2f} kg"
+            if predicted_fuel is not None else "Predicted final fuel: None",
+        ]
+
+        if self.m_surplus_laps is not None:
+            result.append(f"Fuel {'surplus' if self.m_surplus_laps >= 0 else 'deficit'}: {abs(self.m_surplus_laps):.2f} laps")
+
+        return "\n".join(result)

--- a/src/data_per_driver/data_per_driver.py
+++ b/src/data_per_driver/data_per_driver.py
@@ -371,14 +371,11 @@ class DataPerDriver:
         self.m_per_lap_snapshots[old_lap_number] = PerLapSnapshotEntry(
             car_damage=self.m_packet_copies.m_packet_car_damage,
             car_status=self.m_packet_copies.m_packet_car_status,
-            sc_status=self.m_driver_info.m_curr_lap_sc_status,
+            max_sc_status=self.m_driver_info.m_curr_lap_max_sc_status,
             tyre_sets=self.m_packet_copies.m_packet_tyre_sets,
             track_position=self.m_driver_info.position,
             top_speed_kmph=self.m_lap_info.m_top_speed_kmph_this_lap,
         )
-
-        # Now clear the top speed
-        self.m_lap_info.m_top_speed_kmph_this_lap = None
 
         # Add the tyre wear data into the tyre stint history
         if old_lap_number and self.m_tyre_info.m_tyre_set_history_manager.length:
@@ -388,7 +385,7 @@ class DataPerDriver:
                 rl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_LEFT],
                 rr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_RIGHT],
                 lap_number=old_lap_number,
-                is_racing_lap=self.m_driver_info.m_curr_lap_sc_status,
+                is_racing_lap=self.m_driver_info.m_curr_lap_max_sc_status,
                 desc=f"end of lap {old_lap_number} snapshot"
             ))
 
@@ -400,7 +397,7 @@ class DataPerDriver:
                 rl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_LEFT],
                 rr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_RIGHT],
                 lap_number=old_lap_number,
-                is_racing_lap=(self.m_driver_info.m_curr_lap_sc_status == SafetyCarType.NO_SAFETY_CAR),
+                is_racing_lap=(self.m_driver_info.m_curr_lap_max_sc_status == SafetyCarType.NO_SAFETY_CAR),
                 desc=tyre_set_id
             ))
 
@@ -409,9 +406,13 @@ class DataPerDriver:
             self.m_car_info.m_fuel_rate_recommender.add(
                 self.m_packet_copies.m_packet_car_status.m_fuelInTank,
                 old_lap_number,
-                (self.m_driver_info.m_curr_lap_sc_status == SafetyCarType.NO_SAFETY_CAR), # is_racing_lap
+                (self.m_driver_info.m_curr_lap_max_sc_status == SafetyCarType.NO_SAFETY_CAR), # is_racing_lap
                 desc=f"end of lap {old_lap_number} snapshot"
             )
+
+        # Now clear the per lap max stuff
+        self.m_lap_info.m_top_speed_kmph_this_lap = None
+        self.m_driver_info.m_curr_lap_max_sc_status = None
 
     def isZerothLapSnapshotDataAvailable(self) -> bool:
         """
@@ -427,7 +428,7 @@ class DataPerDriver:
             self.m_packet_copies.m_packet_tyre_sets and
             self.m_driver_info.position and
             (self.m_lap_info.m_top_speed_kmph_this_lap is not None) and
-            (self.m_driver_info.m_curr_lap_sc_status is not None)
+            (self.m_driver_info.m_curr_lap_max_sc_status is not None)
         )
 
     def updateTyreSetData(self, fitted_index: int) -> None:

--- a/src/data_per_driver/data_per_driver.py
+++ b/src/data_per_driver/data_per_driver.py
@@ -400,7 +400,7 @@ class DataPerDriver:
                 rl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_LEFT],
                 rr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_RIGHT],
                 lap_number=old_lap_number,
-                is_racing_lap=self.m_driver_info.m_curr_lap_sc_status,
+                is_racing_lap=(self.m_driver_info.m_curr_lap_sc_status == SafetyCarType.NO_SAFETY_CAR),
                 desc=tyre_set_id
             ))
 
@@ -426,7 +426,8 @@ class DataPerDriver:
             self.m_packet_copies.m_packet_car_status and
             self.m_packet_copies.m_packet_tyre_sets and
             self.m_driver_info.position and
-            (self.m_lap_info.m_top_speed_kmph_this_lap is not None)
+            (self.m_lap_info.m_top_speed_kmph_this_lap is not None) and
+            (self.m_driver_info.m_curr_lap_sc_status is not None)
         )
 
     def updateTyreSetData(self, fitted_index: int) -> None:

--- a/src/data_per_driver/data_per_driver.py
+++ b/src/data_per_driver/data_per_driver.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from lib.collisions_analyzer import (CollisionAnalyzer, CollisionAnalyzerMode,
                                      CollisionRecord)
-from lib.f1_types import F1Utils, LapData, TelemetrySetting
+from lib.f1_types import F1Utils, LapData, TelemetrySetting, SafetyCarType
 from lib.tyre_wear_extrapolator import TyreWearPerLap
 from src.data_per_driver import (CarInfo, DriverInfo, LapInfo, PacketCopies,
                                  PerLapSnapshotEntry, TyreInfo,
@@ -409,7 +409,7 @@ class DataPerDriver:
             self.m_car_info.m_fuel_rate_recommender.add(
                 self.m_packet_copies.m_packet_car_status.m_fuelInTank,
                 old_lap_number,
-                self.m_driver_info.m_curr_lap_sc_status,
+                (self.m_driver_info.m_curr_lap_sc_status == SafetyCarType.NO_SAFETY_CAR), # is_racing_lap
                 desc=f"end of lap {old_lap_number} snapshot"
             )
 
@@ -582,7 +582,6 @@ class DataPerDriver:
                 "target-fuel-rate-average" : self.m_car_info.m_fuel_rate_recommender.target_fuel_rate,
                 "target-fuel-rate-next-lap" : self.m_car_info.m_fuel_rate_recommender.target_next_lap_fuel_usage,
                 "surplus-laps" : self.m_car_info.m_fuel_rate_recommender.surplus_laps,
-                "safety-car-fuel-rate" : self.m_car_info.m_fuel_rate_recommender.safety_car_fuel_rate,
             }
 
         return {

--- a/src/data_per_driver/driver_info.py
+++ b/src/data_per_driver/driver_info.py
@@ -58,4 +58,4 @@ class DriverInfo:
     driver_number: Optional[int] = None
     m_num_pitstops: Optional[int] = None
     m_dnf_status_code: Optional[str] = None
-    m_curr_lap_sc_status: Optional[SafetyCarType] = None
+    m_curr_lap_max_sc_status: Optional[SafetyCarType] = None

--- a/src/data_per_driver/per_lap_snapshot.py
+++ b/src/data_per_driver/per_lap_snapshot.py
@@ -43,14 +43,14 @@ class PerLapSnapshotEntry:
         m_car_status_packet (CarStatusData): The Car Status packet
         m_track_position (int): The lap's track position
         m_tyre_sets_packet (Optional[PacketTyreSetsData]): The Tyre Sets packet
-        m_sc_status (PacketSessionData.SafetyCarStatus): The lap's safety car status
+        m_max_sc_status (PacketSessionData.SafetyCarStatus): The lap's maximum safety car status value
         m_top_speed_kmph (float): The lap's top speed in kmph
     """
 
     def __init__(self,
         car_damage : CarDamageData,
         car_status : CarStatusData,
-        sc_status  : SafetyCarType,
+        max_sc_status  : SafetyCarType,
         tyre_sets  : PacketTyreSetsData,
         track_position: int,
         top_speed_kmph: float = 0.0):
@@ -59,7 +59,7 @@ class PerLapSnapshotEntry:
         Args:
             car_damage (CarDamageData): The Car damage packet
             car_status (CarStatusData): The Car Status packet
-            sc_status (PacketSessionData.SafetyCarStatus): The lap's safety car status
+            max_sc_status (PacketSessionData.SafetyCarStatus): The lap's maximum safety car status value
             tyre_sets (PacketTyreSetsData): The Tyre Sets packet
             track_position (int): The lap's track position
             top_speed_kmph (float): The lap's top speed in kmph
@@ -67,7 +67,7 @@ class PerLapSnapshotEntry:
 
         self.m_car_damage_packet: CarDamageData = car_damage
         self.m_car_status_packet: CarStatusData = car_status
-        self.m_sc_status: SafetyCarType = sc_status
+        self.m_max_sc_status: SafetyCarType = max_sc_status
         self.m_tyre_sets_packet: PacketTyreSetsData = tyre_sets
         self.m_track_position: int = track_position
         self.m_top_speed_kmph: float = top_speed_kmph
@@ -86,7 +86,7 @@ class PerLapSnapshotEntry:
             "lap-number" : lap_number,
             "car-damage-data" : self.m_car_damage_packet.toJSON() if self.m_car_damage_packet else None,
             "car-status-data" : self.m_car_status_packet.toJSON() if self.m_car_status_packet else None,
-            "safety-car-status" : str(self.m_sc_status) if self.m_sc_status else None,
+            "max-safety-car-status" : str(self.m_max_sc_status) if self.m_max_sc_status else None,
             "tyre-sets-data" : self.m_tyre_sets_packet.toJSON() if self.m_tyre_sets_packet else None,
             "track-position" : self.m_track_position or None,
             "top-speed-kmph" : self.m_top_speed_kmph,

--- a/src/static/js/engView.js
+++ b/src/static/js/engView.js
@@ -282,7 +282,7 @@ class EngViewRaceTableRow {
         return [
             { value: fuelInfo["fuel-in-tank"] == null ? "N/A" : formatFloatWithTwoDecimals(fuelInfo["fuel-in-tank"]) },
             { value: fuelInfo["curr-fuel-rate"] == null ? "N/A" : formatFloatWithTwoDecimals(fuelInfo["curr-fuel-rate"]) },
-            { value: fuelInfo["curr-fuel-rate"] == null ? "N/A" : formatFloatWithTwoDecimals(fuelInfo["curr-fuel-rate"]), border: true } // TODO: fix
+            { value: fuelInfo["surplus-laps"] == null ? "N/A" : formatFloatWithTwoDecimalsSigned(fuelInfo["surplus-laps"]), border: true }
         ];
     }
 

--- a/src/telemetry_data.py
+++ b/src/telemetry_data.py
@@ -402,9 +402,13 @@ class DriverData:
                 driver_data.m_tyre_info.m_tyre_wear_extrapolator.total_laps = self.m_session_info.m_total_laps
                 driver_data.m_car_info.m_fuel_rate_recommender.total_laps = self.m_session_info.m_total_laps
 
-        # Update the SC status for all drivers
-        for driver_data in self.m_driver_data.values():
-            driver_data.m_driver_info.m_curr_lap_sc_status = packet.m_safetyCarStatus
+        # Update the max SC status for all drivers
+        for obj_to_be_updated in self.m_driver_data.values():
+            obj_to_be_updated.m_driver_info.m_curr_lap_max_sc_status = (
+                packet.m_safetyCarStatus
+                if obj_to_be_updated.m_driver_info.m_curr_lap_max_sc_status is None
+                else max(packet.m_safetyCarStatus, obj_to_be_updated.m_driver_info.m_curr_lap_max_sc_status)
+            )
 
     def processLapDataUpdate(self, packet: PacketLapData) -> None:
         """Process the lap data packet and update the necessary fields
@@ -525,12 +529,11 @@ class DriverData:
                     sum(car_telemetry_data.m_tyresInnerTemperature)/len(car_telemetry_data.m_tyresInnerTemperature)
             obj_to_be_updated.m_tyre_info.tyre_surface_temp = \
                     sum(car_telemetry_data.m_tyresSurfaceTemperature)/len(car_telemetry_data.m_tyresSurfaceTemperature)
-            if obj_to_be_updated.m_lap_info.m_top_speed_kmph_this_lap is None:
-                obj_to_be_updated.m_lap_info.m_top_speed_kmph_this_lap = car_telemetry_data.m_speed
-            else:
-                obj_to_be_updated.m_lap_info.m_top_speed_kmph_this_lap = \
-                    max(car_telemetry_data.m_speed,
-                        obj_to_be_updated.m_lap_info.m_top_speed_kmph_this_lap)
+            obj_to_be_updated.m_lap_info.m_top_speed_kmph_this_lap = (
+                car_telemetry_data.m_speed
+                if obj_to_be_updated.m_lap_info.m_top_speed_kmph_this_lap is None
+                else max(car_telemetry_data.m_speed, obj_to_be_updated.m_lap_info.m_top_speed_kmph_this_lap)
+            )
             obj_to_be_updated.m_packet_copies.m_packet_car_telemetry = car_telemetry_data
 
     def processCarStatusUpdate(self, packet: PacketCarStatusData) -> None:


### PR DESCRIPTION
Handles safety car intervals properly. The max SC status per lap is tracked for each driver and if the status is other than NO_SAFETY_CAR, then it is treated as a non racing lap

## Summary by Sourcery

Enhance fuel calculation to handle safety car intervals more robustly by tracking maximum safety car status per lap and improving fuel rate computation across racing and safety car segments

Bug Fixes:
- Fixed safety car status tracking to use maximum status per lap
- Corrected fuel rate calculations to account for non-consecutive racing laps

Enhancements:
- Improved fuel rate calculation to handle discontinuities caused by safety car periods
- More sophisticated tracking of lap types and fuel consumption
- Enhanced prediction of final fuel levels considering racing and safety car segments

Tests:
- Added comprehensive test case for 20-lap race with multiple safety car intervals
- Verified fuel rate calculations across different lap types