### PR TITLE
Confetti

### DIFF
--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -912,6 +912,16 @@ class SessionState:
             None,
         )
 
+    def getPlayerDriverInfo(self) -> Optional[DataPerDriver]:
+        """
+        Get the player driver data
+
+        Returns:
+            Optional[DataPerDriver]: The player driver data object
+        """
+        return self._getObjectByIndex(self.m_player_index) if self.m_player_index is not None else None
+
+
     def getEventInfoStr(self) -> Optional[str]:
         """Returns a string with the following format
                 <event-type> _ <circuit> _

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -44,7 +44,9 @@ from lib.f1_types import (F1PacketType, PacketCarDamageData,
                           PacketSessionData, PacketSessionHistoryData,
                           PacketTimeTrialData, PacketTyreSetsData,
                           SessionType23, SessionType24)
-from lib.inter_task_communicator import AsyncInterTaskCommunicator
+from lib.inter_task_communicator import (AsyncInterTaskCommunicator,
+                                         FinalClassificationNotification,
+                                         ITCMessage)
 from lib.telemetry_manager import AsyncF1TelemetryManager
 
 # -------------------------------------- TYPE DEFINITIONS --------------------------------------------------------------
@@ -291,6 +293,17 @@ class F1TelemetryHandler:
                             break
                 if is_event_supported:
                     await self.postGameDumpToFile(final_json)
+
+            # Notify the frontend about the final classification
+            if player_info := self.m_session_state_ref.getPlayerDriverInfo():
+                player_position = player_info.m_driver_info.position
+                await AsyncInterTaskCommunicator().send(
+                    "frontend-update",
+                    ITCMessage(
+                        m_message_type=ITCMessage.MessageType.FINAL_CLASSIFICATION_NOTIFICATION,
+                        m_message=FinalClassificationNotification(player_position)
+                    )
+                )
 
             # Uncomment the below lines for profiling - Kill the process after one session
             # # Cancel all tasks except itself

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -294,16 +294,16 @@ class F1TelemetryHandler:
                 if is_event_supported:
                     await self.postGameDumpToFile(final_json)
 
-            # Notify the frontend about the final classification
-            if player_info := self.m_session_state_ref.getPlayerDriverInfo():
-                player_position = player_info.m_driver_info.position
-                await AsyncInterTaskCommunicator().send(
-                    "frontend-update",
-                    ITCMessage(
-                        m_message_type=ITCMessage.MessageType.FINAL_CLASSIFICATION_NOTIFICATION,
-                        m_message=FinalClassificationNotification(player_position)
-                    )
-                )
+                    # Notify the frontend about the final classification
+                    if player_info := self.m_session_state_ref.getPlayerDriverInfo():
+                        player_position = player_info.m_driver_info.position
+                        await AsyncInterTaskCommunicator().send(
+                            "frontend-update",
+                            ITCMessage(
+                                m_message_type=ITCMessage.MessageType.FINAL_CLASSIFICATION_NOTIFICATION,
+                                m_message=FinalClassificationNotification(player_position)
+                            )
+                        )
 
             # Uncomment the below lines for profiling - Kill the process after one session
             # # Cancel all tasks except itself

--- a/apps/backend/ui_intf_layer/telemetry_ui_tasks.py
+++ b/apps/backend/ui_intf_layer/telemetry_ui_tasks.py
@@ -119,9 +119,8 @@ async def frontEndMessageTask(sio: socketio.AsyncServer) -> None:
     """
 
     while True:
-        message = await AsyncInterTaskCommunicator().receive("frontend-update")
-        if message:
-            await sio.emit('frontend-update', message.toJSON())
+        if message := await AsyncInterTaskCommunicator().receive("frontend-update"):
+            await sio.emit('frontend-update', message.toJSON(), room="race-table")
 
 def _isRoomEmpty(sio: socketio.AsyncServer, room_name: str, namespace: Optional[str] = '/') -> bool:
     """Check if a room is empty

--- a/apps/frontend/html/index.html
+++ b/apps/frontend/html/index.html
@@ -21,6 +21,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/4.4.1/socket.io.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tsparticles/confetti@3.0.3/tsparticles.confetti.bundle.min.js"></script>
   </head>
   <body>
     <div class="dashboard-container">

--- a/apps/frontend/js/app.js
+++ b/apps/frontend/js/app.js
@@ -74,6 +74,9 @@ socketio.on('frontend-update', function (data) {
         case 'tyre-delta':
             processTyreDeltaMessage(data['message']);
             break;
+        case 'final-classification-notification':
+            processFinalClassificationNotification(data['message']);
+            break
         default:
             console.error("received unsupported message type in frontend-update");
     }

--- a/apps/frontend/js/frontendUpdate.js
+++ b/apps/frontend/js/frontendUpdate.js
@@ -48,7 +48,7 @@ function processFinalClassificationNotification(data) {
     const playerPosition = data['player-position'];
     if (playerPosition && playerPosition >= 1 && playerPosition <= 3) {
         console.log("Podium finish! Player position:", playerPosition);
-        const confettDurationMs = 10000;
-        shootConfetti(confettDurationMs);
+        const confettiDurationMs = 10000;
+        shootConfetti(confettiDurationMs);
     }
 }

--- a/apps/frontend/js/frontendUpdate.js
+++ b/apps/frontend/js/frontendUpdate.js
@@ -45,4 +45,10 @@ function processCustomMarkerMessage(data) {
 
 function processFinalClassificationNotification(data) {
     console.log("processFinalClassificationNotification", data);
+    const playerPosition = data['player-position'];
+    if (playerPosition && playerPosition >= 1 && playerPosition <= 3) {
+        console.log("Podium finish! Player position:", playerPosition);
+        const confettDurationMs = 10000;
+        shootConfetti(confettDurationMs);
+    }
 }

--- a/apps/frontend/js/frontendUpdate.js
+++ b/apps/frontend/js/frontendUpdate.js
@@ -42,3 +42,7 @@ function processTyreDeltaMessage(data) {
 function processCustomMarkerMessage(data) {
     console.log("processCustomMarkerMessage", data);
 }
+
+function processFinalClassificationNotification(data) {
+    console.log("processFinalClassificationNotification", data);
+}

--- a/apps/frontend/js/utils.js
+++ b/apps/frontend/js/utils.js
@@ -277,8 +277,8 @@ function randomInRange(min, max) {
 }
 
 function shootConfetti(durationMs) {
-    animationEnd = Date.now() + durationMs,
-    defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 0 };
+    const animationEnd = Date.now() + durationMs;
+    const defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 0 };
 
     const interval = setInterval(function() {
         const timeLeft = animationEnd - Date.now();

--- a/apps/frontend/js/utils.js
+++ b/apps/frontend/js/utils.js
@@ -271,3 +271,35 @@ function truncateName(name) {
       return name;
     }
 }
+
+function randomInRange(min, max) {
+    return Math.random() * (max - min) + min;
+}
+
+function shootConfetti(durationMs) {
+    animationEnd = Date.now() + durationMs,
+    defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 0 };
+
+    const interval = setInterval(function() {
+        const timeLeft = animationEnd - Date.now();
+
+        if (timeLeft <= 0) {
+            return clearInterval(interval);
+        }
+
+        const particleCount = 50 * (timeLeft / durationMs);
+
+        // since particles fall down, start a bit higher than random
+        confetti(
+            Object.assign({}, defaults, {
+            particleCount,
+            origin: { x: randomInRange(0.1, 0.3), y: Math.random() - 0.2 },
+            })
+        );
+        confetti(
+            Object.assign({}, defaults, {
+                particleCount,
+                origin: { x: randomInRange(0.7, 0.9), y: Math.random() - 0.2 },
+            }));
+    }, 250);
+}

--- a/lib/inter_task_communicator.py
+++ b/lib/inter_task_communicator.py
@@ -126,26 +126,17 @@ class FinalClassificationNotification:
 
 @dataclass(frozen=True)
 class ITCMessage:
-    class MessageType(Enum):
-        CUSTOM_MARKER = 1
-        TYRE_DELTA_NOTIFICATION = 2
-        UDP_PACKET_FORWARD = 3
-        FINAL_CLASSIFICATION_NOTIFICATION = 4
-        # Add more message types as needed
-
-        def __repr__(self) -> str:
-            """Return a string representation of the ITCMessage object."""
-            return {
-                ITCMessage.MessageType.CUSTOM_MARKER: "custom-marker",
-                ITCMessage.MessageType.TYRE_DELTA_NOTIFICATION: "tyre-delta",
-                ITCMessage.MessageType.UDP_PACKET_FORWARD: "udp-packet-forward",
-                ITCMessage.MessageType.FINAL_CLASSIFICATION_NOTIFICATION: "final-classification-notification",
-            }[self]
+    class MessageType(str, Enum):
+        CUSTOM_MARKER                      = "custom-marker"
+        TYRE_DELTA_NOTIFICATION            = "tyre-delta"
+        UDP_PACKET_FORWARD                 = "udp-packet-forward"
+        FINAL_CLASSIFICATION_NOTIFICATION  = "final-classification-notification"
 
         def __str__(self) -> str:
-            """Return a string representation of the ITCMessage object."""
-            return self.__repr__()
+            return self.value
 
+        def __repr__(self) -> str:
+            return self.value
     m_message_type: "ITCMessage.MessageType"
     m_message: Any
 

--- a/lib/inter_task_communicator.py
+++ b/lib/inter_task_communicator.py
@@ -97,12 +97,40 @@ class TyreDeltaMessage:
             "tyre-delta": self.m_delta
         }
 
+class FinalClassificationNotification:
+    def __init__(self, player_position: int) -> None:
+        """Initialize the FinalClassificationNotification object.
+
+        Args:
+            player_position (int): The player's position in the final classification
+        """
+        self.m_player_position = player_position
+
+    def __repr__(self) -> str:
+        """Return a string representation of the FinalClassificationNotification object."""
+        return f"FinalClassificationNotification(player_position={self.m_player_position})"
+
+    def __str__(self) -> str:
+        """Return a string representation of the FinalClassificationNotification object."""
+        return self.__repr__()
+
+    def toJSON(self) -> Dict[str, Any]:
+        """Get the JSON representation of this object.
+
+        Returns:
+            Dict[str, Any]: The JSON representation of this object.
+        """
+        return {
+            "player-position": self.m_player_position
+        }
+
 @dataclass(frozen=True)
 class ITCMessage:
     class MessageType(Enum):
         CUSTOM_MARKER = 1
         TYRE_DELTA_NOTIFICATION = 2
         UDP_PACKET_FORWARD = 3
+        FINAL_CLASSIFICATION_NOTIFICATION = 4
         # Add more message types as needed
 
         def __repr__(self) -> str:
@@ -110,6 +138,8 @@ class ITCMessage:
             return {
                 ITCMessage.MessageType.CUSTOM_MARKER: "custom-marker",
                 ITCMessage.MessageType.TYRE_DELTA_NOTIFICATION: "tyre-delta",
+                ITCMessage.MessageType.UDP_PACKET_FORWARD: "udp-packet-forward",
+                ITCMessage.MessageType.FINAL_CLASSIFICATION_NOTIFICATION: "final-classification-notification",
             }[self]
 
         def __str__(self) -> str:


### PR DESCRIPTION
Now driver view fires confetti if player finishes in podium

## Summary by Sourcery

Send a new final-classification notification from the backend when the player finishes a session and celebrate podium finishes with a confetti animation in the frontend.

New Features:
- Add FinalClassificationNotification to send the player’s finishing position via inter-task communicator
- Trigger a 10-second confetti animation on the frontend for 1st to 3rd place finishes

Enhancements:
- Add getPlayerDriverInfo helper to session state for fetching player data
- Refactor frontend message loop to use assignment expression when receiving updates