### PR TITLE
Migration of all checks from game year to packet format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/*
 png-venv/
 .vercel
 *yappi*
+*.part

--- a/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
@@ -413,7 +413,7 @@ class DataPerDriver:
         self.m_tyre_info.m_tyre_set_history_manager.remove(outdated_laps)
         self.m_car_info.m_fuel_rate_recommender.remove(outdated_laps)
 
-        png_logger.debug(f'Driver {self} - detected flashback. outdated_laps: {outdated_laps}')
+        png_logger.debug("Driver %s - detected flashback. outdated_laps: %s", str(self), outdated_laps)
 
     def onLapChange(self,
         old_lap_number: int,
@@ -467,7 +467,8 @@ class DataPerDriver:
 
         # Check if the old lap number is already present in the snapshots (lap already processed)
         if old_lap_number in self.m_per_lap_snapshots:
-            png_logger.debug(f'Driver {self} - lap {old_lap_number} already in per_lap_snapshots. Possible flashback')
+            png_logger.debug("Driver %s - lap %d already in per_lap_snapshots. Possible flashback",
+                             str(self), old_lap_number)
             return
 
         # Store the snapshot data for the old lap
@@ -517,7 +518,7 @@ class DataPerDriver:
         # Now clear the per lap max stuff
         self.m_lap_info.m_top_speed_kmph_this_lap = None
         self.m_driver_info.m_curr_lap_max_sc_status = None
-        png_logger.debug(f'Driver {self} - inserted snapshot for lap {old_lap_number}')
+        png_logger.debug("Driver %s - lap %d added to per_lap_snapshots", str(self), old_lap_number)
 
     def shouldCaptureZerothLapSnapshot(self) -> bool:
         """
@@ -750,15 +751,12 @@ class DataPerDriver:
             ],
         }
 
-    def _positionHistoryHelper(self, packet_format: int, session_ended: bool) -> Iterator[Tuple[int, int]]:
+    def _positionHistoryHelper(self, _packet_format: int, _session_ended: bool) -> Iterator[Tuple[int, int]]:
         """Helper function to get the position history
 
         Args:
-            packet_format (int): The packet format
-            session_ended (bool): Whether the session has ended
-
-        Returns:
-            Iterator[Tuple[int, int]]: The position history
+            _packet_format (int): The packet format
+            _session_ended (bool): Whether the session has ended
         """
 
         # if packet_format >= 2025:
@@ -906,7 +904,7 @@ class DataPerDriver:
 
         # Defer this update if the position history is not yet initialized
         if not self.m_position_history:
-            png_logger.debug(f"Position history not yet initialized. {self.__str__()}")
+            png_logger.debug("Position history: %s", str(self.m_position_history))
             return
 
         assert len(position_history) == packet.m_numLaps

--- a/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
@@ -730,8 +730,12 @@ class DataPerDriver:
             "surplus-laps-game" : 0.0,
         }
 
-    def getPositionHistoryJSON(self, game_year: int, session_ended: bool) -> Dict[str, Any]:
+    def getPositionHistoryJSON(self, packet_format: int, session_ended: bool) -> Dict[str, Any]:
         """Get the position history JSON.
+
+        Args:
+            packet_format (int): The packet format
+            session_ended (bool): Whether the session has ended
 
         Returns:
             Dict[str, Any]: Position history JSON
@@ -742,22 +746,22 @@ class DataPerDriver:
             "driver-number": self.m_driver_info.driver_number,
             "driver-position-history": [
                 {"lap-number": lap, "position": pos}
-                for lap, pos in self._positionHistoryHelper(game_year, session_ended)
+                for lap, pos in self._positionHistoryHelper(packet_format, session_ended)
             ],
         }
 
-    def _positionHistoryHelper(self, game_year: int, session_ended: bool) -> Iterator[Tuple[int, int]]:
+    def _positionHistoryHelper(self, packet_format: int, session_ended: bool) -> Iterator[Tuple[int, int]]:
         """Helper function to get the position history
 
         Args:
-            game_year (int): The game year
+            packet_format (int): The packet format
             session_ended (bool): Whether the session has ended
 
         Returns:
             Iterator[Tuple[int, int]]: The position history
         """
 
-        # if game_year >= 25:
+        # if packet_format >= 2025:
         #     max_lap = (
         #         len(self.m_position_history) - 1
         #         if session_ended

--- a/apps/backend/state_mgmt_layer/data_per_driver/tyre_info.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/tyre_info.py
@@ -251,8 +251,8 @@ class TyreSetHistoryManager:
         # If the first stint has garbage data, remove it (this happens if the user customizes the strat before race)
         if self.m_history[0].m_end_lap < self.m_history[0].m_start_lap:
             garbage_obj = self.m_history.pop(0)
-            png_logger.debug(f"Removed garbage tyre stint history record.\n"
-                                f"{json.dumps(garbage_obj.toJSON(include_tyre_wear_history=False), indent=4)}")
+            png_logger.debug("Removed garbage tyre stint history record.\n %s",
+                             json.dumps(garbage_obj.toJSON(include_tyre_wear_history=False), indent=4))
 
     def getEntries(self) -> List[TyreSetHistoryEntry]:
         """Get all entries in the tyre set history collection

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -488,7 +488,7 @@ class SessionState:
             final_json["classification-data"][index] = obj_to_be_updated.toJSON(index)
             if is_position_history_supported:
                 final_json["position-history"].append(
-                    obj_to_be_updated.getPositionHistoryJSON(packet.m_header.m_packetFormat, session_ended=True))
+                    obj_to_be_updated.getPositionHistoryJSON())
                 final_json["tyre-stint-history"].append(obj_to_be_updated.getTyreStintHistoryJSON())
         final_json['classification-data'] = sorted(final_json['classification-data'], key=lambda x: x['track-position'])
         final_json['game-year'] = self.m_session_info.m_game_year

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -70,6 +70,7 @@ class SessionInfo:
          - m_packet_session (Optional[PacketSessionData]): Copy of the last saved session packet
          - m_packet_final_classification (Optional[PacketFinalClassificationData]): The final classification packet
          - m_game_year (Optional[int]): The current game year
+         - m_packet_format (Optional[int]): The current packet format
     """
 
     def __init__(self):
@@ -91,6 +92,7 @@ class SessionInfo:
         self.m_packet_session: Optional[PacketSessionData] = None
         self.m_packet_final_classification : Optional[PacketFinalClassificationData] = None
         self.m_game_year : Optional[int] = None
+        self.m_packet_format : Optional[int] = None
 
     def __str__(self) -> str:
         """Dump the SessionInfo object to a readable string
@@ -132,6 +134,7 @@ class SessionInfo:
         self.m_packet_final_classification = None
         self.m_packet_session = None
         self.m_game_year = None
+        self.m_packet_format = None
 
     @property
     def is_valid(self) -> bool:
@@ -171,6 +174,7 @@ class SessionInfo:
         self.m_is_spectating = packet.m_isSpectating
         self.m_spectator_car_index = packet.m_spectatorCarIndex if packet.m_spectatorCarIndex != 255 else None
         self.m_game_year = packet.m_header.m_gameYear
+        self.m_packet_format = packet.m_header.m_packetFormat
         self.m_safety_car_status = packet.m_safetyCarStatus
         return ret_status
 
@@ -484,10 +488,11 @@ class SessionState:
             final_json["classification-data"][index] = obj_to_be_updated.toJSON(index)
             if is_position_history_supported:
                 final_json["position-history"].append(
-                    obj_to_be_updated.getPositionHistoryJSON(packet.m_header.m_gameYear, session_ended=True))
+                    obj_to_be_updated.getPositionHistoryJSON(packet.m_header.m_packetFormat, session_ended=True))
                 final_json["tyre-stint-history"].append(obj_to_be_updated.getTyreStintHistoryJSON())
         final_json['classification-data'] = sorted(final_json['classification-data'], key=lambda x: x['track-position'])
         final_json['game-year'] = self.m_session_info.m_game_year
+        final_json['packet-format'] = self.m_session_info.m_packet_format
 
         final_json["session-info"] = self.m_session_info.m_packet_session.toJSON() \
             if self.m_session_info.m_packet_session else None

--- a/apps/backend/state_mgmt_layer/telemetry_state.py
+++ b/apps/backend/state_mgmt_layer/telemetry_state.py
@@ -22,7 +22,6 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
-import asyncio
 import logging
 from typing import Optional
 

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -591,9 +591,7 @@ class DriversListRsp:
             return []
 
         # Use original list since this request comes only once in a bluemoon
-        packet_format = _session_state_ref.m_session_info.m_packet_format
-        session_ended = _session_state_ref.m_session_info.session_ended
-        return [data_per_driver.getPositionHistoryJSON(packet_format, session_ended) \
+        return [data_per_driver.getPositionHistoryJSON() \
                 for data_per_driver in _session_state_ref.m_driver_data \
                     if data_per_driver and data_per_driver.is_valid]
 

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -92,6 +92,7 @@ class RaceInfoUpdate:
             # First, global fields
             "live-data" : True,
             "f1-game-year" : _getValueOrDefaultValue(self.m_session_info.m_game_year, None),
+            "packet-format" : _getValueOrDefaultValue(self.m_session_info.m_packet_format, None),
             "circuit": str(self.m_session_info.m_track) if self.m_session_info.m_track is not None else "---",
             "track-temperature": _getValueOrDefaultValue(self.m_session_info.m_track_temp, default_value=0),
             "air-temperature": _getValueOrDefaultValue(self.m_session_info.m_air_temp, default_value=0),
@@ -250,6 +251,7 @@ class PlayerTelemetryOverlayUpdate:
         self.m_circuit                  = _session_state_ref.m_session_info.m_track
         self.m_total_laps               = _session_state_ref.m_session_info.m_total_laps
         self.m_game_year                = _session_state_ref.m_session_info.m_game_year
+        self.m_packet_format            = _session_state_ref.m_session_info.m_packet_format
         self.m_session_type               = _session_state_ref.m_session_info.m_session_type
         self.m_pit_speed_limit          = _session_state_ref.m_session_info.m_pit_speed_limit
 
@@ -589,9 +591,9 @@ class DriversListRsp:
             return []
 
         # Use original list since this request comes only once in a bluemoon
-        game_year = _session_state_ref.m_session_info.m_game_year
+        packet_format = _session_state_ref.m_session_info.m_packet_format
         session_ended = _session_state_ref.m_session_info.session_ended
-        return [data_per_driver.getPositionHistoryJSON(game_year, session_ended) \
+        return [data_per_driver.getPositionHistoryJSON(packet_format, session_ended) \
                 for data_per_driver in _session_state_ref.m_driver_data \
                     if data_per_driver and data_per_driver.is_valid]
 

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -386,15 +386,17 @@ class F1TelemetryHandler:
 
             self.m_session_state_ref.processTimeTrialUpdate(packet)
 
-        @self.m_manager.on_packet(F1PacketType.LAP_POSITIONS)
-        async def processLapPositionsUpdate(packet: PacketLapPositionsData) -> None:
-            """Update the data structures with lap positions information
+        # We're not using this data, no need to waste CPU cycles processing it.
+        # Commenting it out for now
+        # @self.m_manager.on_packet(F1PacketType.LAP_POSITIONS)
+        # async def processLapPositionsUpdate(packet: PacketLapPositionsData) -> None:
+        #     """Update the data structures with lap positions information
 
-            Args:
-                packet (PacketLapPositionsData): The lap positions update packet
-            """
+        #     Args:
+        #         packet (PacketLapPositionsData): The lap positions update packet
+        #     """
 
-            self.m_session_state_ref.processLapPositionsUpdate(packet)
+        #     self.m_session_state_ref.processLapPositionsUpdate(packet)
 
         async def handeSessionStartEvent(packet: PacketEventData) -> None:
             """

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -265,7 +265,7 @@ class F1TelemetryHandler:
             # Perform the auto save stuff only for races
             if event_type_str := str(self.m_session_state_ref.m_session_info.m_session_type):
                 is_event_supported = True
-                if packet.m_header.m_gameYear == 23:
+                if packet.m_header.m_packetFormat == 2023:
                     unsupported_event_types_f1_23 = [
                         SessionType23.PRACTICE_1,
                         SessionType23.PRACTICE_2,

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -40,10 +40,10 @@ from lib.f1_types import (F1PacketType, PacketCarDamageData,
                           PacketCarSetupData, PacketCarStatusData,
                           PacketCarTelemetryData, PacketEventData,
                           PacketFinalClassificationData, PacketLapData,
-                          PacketLapPositionsData, PacketMotionData,
-                          PacketParticipantsData, PacketSessionData,
-                          PacketSessionHistoryData, PacketTimeTrialData,
-                          PacketTyreSetsData, SessionType23, SessionType24)
+                          PacketMotionData, PacketParticipantsData,
+                          PacketSessionData, PacketSessionHistoryData,
+                          PacketTimeTrialData, PacketTyreSetsData,
+                          SessionType23, SessionType24)
 from lib.inter_task_communicator import (AsyncInterTaskCommunicator,
                                          FinalClassificationNotification,
                                          ITCMessage)

--- a/apps/frontend/html/player-stream-overlay.html
+++ b/apps/frontend/html/player-stream-overlay.html
@@ -338,11 +338,11 @@
         });
 
         socket.on('player-overlay-update', function (data) {
-            if (!firstDataReceived && data["f1-game-year"] !== null) {
+            if (!firstDataReceived && data["f1-packet-format"] !== null) {
                 firstDataReceived = true;
             }
             if (!firstDataReceived && data['show-sample-data-at-start']) {
-                if (data["f1-game-year"] === null) {
+                if (data["f1-packet-format"] === null) {
                     data = sampleStreamOverlayJSON;
                 } else {
                     firstDataReceived = true;
@@ -351,7 +351,7 @@
 
             // Update the widgets with the actual data
             carTelemetryWidget.update(data["car-telemetry"]);
-            pensStatsWidget.update(data["penalties-and-stats"], data["f1-game-year"]);
+            pensStatsWidget.update(data["penalties-and-stats"], data["f1-packet-format"]);
             lapTimesWidget.update(data["lap-time-history"]);
             weatherWidget.update(data["weather-forecast-samples"].slice(0, maxWeatherSamples + 1));
             gForceDisplayWidget.update(data["g-force"]);

--- a/apps/frontend/js/constants.js
+++ b/apps/frontend/js/constants.js
@@ -7,6 +7,7 @@ function getDefaultOverlayData() {
         },
         "event-type": "Race",
         "f1-game-year": 24,
+        "f1-packet-format" : 2024,
         "g-force": {
             "lat": 0.36567622423171997,
             "long": 0.37355566024780273,

--- a/apps/frontend/js/penaltiesStatsOverlay.js
+++ b/apps/frontend/js/penaltiesStatsOverlay.js
@@ -10,13 +10,13 @@ class PenaltiesStatsWidget {
   }
 
   // Method to update the UI with the penalties stats
-  update(penaltiesStats, gameYear) {
+  update(penaltiesStats, packetFormat) {
     // Update the individual penalty stats
-    this.updatePenaltiesStats(penaltiesStats, gameYear);
+    this.updatePenaltiesStats(penaltiesStats, packetFormat);
   }
 
   // Method to update the penalties stats in the UI
-  updatePenaltiesStats(pensStats, gameYear) {
+  updatePenaltiesStats(pensStats, packetFormat) {
     const airTemp = pensStats['air-temperature'];
     const trackTemp = pensStats['track-temperature'];
     const trackLimits = pensStats['corner-cutting-warnings'];
@@ -35,7 +35,7 @@ class PenaltiesStatsWidget {
     this.pitLaneSpeedLimitSpan.style.display = (pitLaneSpeedLimit !== null && pitLaneSpeedLimit !== undefined) ? "inline-flex" : "none";
 
     // speed trap support from F1 24 onwards
-    if (gameYear >= 24) {
+    if (packetFormat >= 2024) {
       this.speedTrapDiv.style.display = "";
       if (speedTrap !== null && speedTrap !== undefined && speedTrap !== 0.0) {
         this.speedTrapSpan.textContent = formatFloatWithTwoDecimals(speedTrap);

--- a/apps/frontend/js/raceTableRowPopulator.js
+++ b/apps/frontend/js/raceTableRowPopulator.js
@@ -1,8 +1,8 @@
 class RaceTableRowPopulator {
-    constructor(row, rowData, gameYear, isLiveDataMode, iconCache, raceEnded, spectatorIndex) {
+    constructor(row, rowData, packetFormat, isLiveDataMode, iconCache, raceEnded, spectatorIndex) {
         this.row = row;
         this.rowData = rowData;
-        this.gameYear = gameYear;
+        this.packetFormat = packetFormat;
         this.isLiveDataMode = isLiveDataMode;
         this.iconCache = iconCache;
         this.raceEnded = raceEnded;
@@ -100,7 +100,7 @@ class RaceTableRowPopulator {
         // Game-specific layout:
         // - In F1 23, use a single-line cell with just the lap content
         // - in F1 24+, use a multi-line cell with lap content and speed trap info
-        if (this.gameYear == 23) {
+        if (this.packetFormat == 2023) {
             cell = this.row.insertCell();
             cell.textContent = lapContent;
         } else {
@@ -121,7 +121,7 @@ class RaceTableRowPopulator {
         const index = this.rowData["driver-info"]["index"];
         const lapInfo = this.rowData["lap-info"]["last-lap"];
         const cellContent = [];
-        if (this.gameYear > 23) {
+        if (this.packetFormat > 2023) {
             // one line to pad against speed trap record
             cellContent.push(null);
         }

--- a/apps/frontend/js/telemetryRenderer.js
+++ b/apps/frontend/js/telemetryRenderer.js
@@ -18,12 +18,12 @@ class TelemetryRenderer {
     this.uiMode = 'Splash';
   }
 
-  renderTelemetryRow(data, gameYear, isLiveDataMode, raceEnded, spectatorIndex) {
+  renderTelemetryRow(data, packetFormat, isLiveDataMode, raceEnded, spectatorIndex) {
     const { 'driver-info': driverInfo } = data;
     const row = document.createElement('tr');
 
     // Populate row with data
-    new RaceTableRowPopulator(row, data, gameYear, isLiveDataMode, this.iconCache, raceEnded, spectatorIndex).populate();
+    new RaceTableRowPopulator(row, data, packetFormat, isLiveDataMode, this.iconCache, raceEnded, spectatorIndex).populate();
 
     // Apply CSS classes based on row state
     const cssClasses = this.determineRowClasses(driverInfo, isLiveDataMode, spectatorIndex);
@@ -75,7 +75,7 @@ class TelemetryRenderer {
 
     // enable the time trial UI and set the data
     this.setUIMode('Time Trial');
-    this.timeTrialDataPopulator.populate(incomingData["tt-data"], incomingData["f1-game-year"]);
+    this.timeTrialDataPopulator.populate(incomingData["tt-data"], incomingData["f1-packet-format"]);
   }
 
   // Extract existing driver rows and remove them from the DOM
@@ -99,8 +99,8 @@ class TelemetryRenderer {
   }
 
   // Update or create row based on existing data
-  updateOrCreateRow(row, data, gameYear, isLiveDataMode, driverIndex, raceEnded, spectatorIndex) {
-    const newRow = this.renderTelemetryRow(data, gameYear, isLiveDataMode, raceEnded, spectatorIndex);
+  updateOrCreateRow(row, data, packetFormat, isLiveDataMode, driverIndex, raceEnded, spectatorIndex) {
+    const newRow = this.renderTelemetryRow(data, packetFormat, isLiveDataMode, raceEnded, spectatorIndex);
     if (row) {
       row.innerHTML = newRow.innerHTML;
     } else {
@@ -125,7 +125,7 @@ class TelemetryRenderer {
       ((entry) => entry["driver-info"]?.["index"] == spectatorCarIndex) :
       ((entry) => entry["driver-info"]?.["is-player"])
     );
-    const gameYear = incomingData["f1-game-year"];
+    const packetFormat = incomingData["f1-packet-format"];
     this.indexByPosition = incomingData["table-entries"].map(entry => entry["driver-info"]["index"]);
 
     // Extract and remove existing driver rows
@@ -136,7 +136,7 @@ class TelemetryRenderer {
     tableEntries.forEach(data => {
       const driverIndex = data["driver-info"]["index"];
       let row = driverRowMap.get(driverIndex);
-      row = this.updateOrCreateRow(row, data, gameYear, isLiveDataMode, driverIndex, raceEnded, spectatorCarIndex);
+      row = this.updateOrCreateRow(row, data, packetFormat, isLiveDataMode, driverIndex, raceEnded, spectatorCarIndex);
       this.telemetryTable.appendChild(row);
     });
     // Rows not referenced in tableEntries will be left out

--- a/apps/frontend/js/timeTrialDataPopulator.js
+++ b/apps/frontend/js/timeTrialDataPopulator.js
@@ -96,12 +96,12 @@ class TimeTrialDataPopulator {
         this.rivalSessionBestPopulator      = new TimeTrialTtDataPopulator('ttRivalSessionBest');
     }
 
-    populate(incomingData, gameYear) {
-        this.populateTimeTrialTable(incomingData["session-history"], gameYear);
-        this.populateTimeTrialTtData(incomingData["tt-data"], gameYear);
+    populate(incomingData, packetFormat) {
+        this.populateTimeTrialTable(incomingData["session-history"], packetFormat);
+        this.populateTimeTrialTtData(incomingData["tt-data"], packetFormat);
     }
 
-    populateTimeTrialTable(incomingData, gameYear) {
+    populateTimeTrialTable(incomingData, packetFormat) {
         if (!incomingData || !incomingData["lap-history-data"]) {
             return;
         }
@@ -160,15 +160,15 @@ class TimeTrialDataPopulator {
         });
     }
 
-    populateTimeTrialTtData(ttData, gameYear) {
+    populateTimeTrialTtData(ttData, packetFormat) {
 
         const playerPersonalBestPacket = (ttData) ? (ttData["personal-best-data-set"]) : (null);
         const playerSessionBestPacket = (ttData) ? (ttData["player-session-best-data-set"]) : (null);
         const rivalSessionBestPacket = (ttData) ? (ttData["rival-session-best-data-set"]) : (null);
 
-        this.playerPersonalBestPopulator.populate(playerPersonalBestPacket, gameYear);
-        this.playerSessionBestPopulator.populate(playerSessionBestPacket, gameYear);
-        this.rivalSessionBestPopulator.populate(rivalSessionBestPacket, gameYear);
+        this.playerPersonalBestPopulator.populate(playerPersonalBestPacket, packetFormat);
+        this.playerSessionBestPopulator.populate(playerSessionBestPacket, packetFormat);
+        this.rivalSessionBestPopulator.populate(rivalSessionBestPacket, packetFormat);
     }
 
     applyColourToCell(cell, lapNum, pbLapNum, isValid) {

--- a/apps/frontend/js/timeTrialDataPopulator.js
+++ b/apps/frontend/js/timeTrialDataPopulator.js
@@ -22,9 +22,9 @@ class TimeTrialTtDataPopulator {
         this.custSetupCell  = document.getElementById(`${sectionPrefix}CustomSetup`);
     }
 
-    populate(ttPacket, gameYear) {
+    populate(ttPacket, packetFormat) {
 
-        if (gameYear < 24) {
+        if (packetFormat < 2024) {
             this.clearCells();
             this.showUnsupportedDiv();
             return;

--- a/apps/save_viewer/telemetry_post_race_data_viewer.py
+++ b/apps/save_viewer/telemetry_post_race_data_viewer.py
@@ -281,6 +281,7 @@ def getTelemetryInfo():
                 "air-temperature" : 0,
                 "weather-forecast-samples": [],
                 "f1-game-year" : None,
+                "f1-packet-format" : None,
                 "is-spectating" : False,
             }
         if "records" in g_json_data:
@@ -310,6 +311,7 @@ def getTelemetryInfo():
             "weather-forecast-samples": [],
             "race-ended" : True,
             "f1-game-year" : g_json_data["game-year"],
+            "f1-packet-format" : g_json_data.get("packet-format", None),
             "is-spectating" : False,
         }
         for sample in g_json_data["session-info"]["weather-forecast-samples"]:

--- a/lib/f1_types/packet_12_tyre_sets_packet.py
+++ b/lib/f1_types/packet_12_tyre_sets_packet.py
@@ -65,16 +65,16 @@ class TyreSetData:
     )
     PACKET_LEN = struct.calcsize(PACKET_FORMAT)
 
-    def __init__(self, data: bytes, game_year: int) -> None:
+    def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initializes TyreSetData with raw data.
 
         Args:
             data (bytes): Raw data representing information about a tyre set.
-            game_year (int): The current game year.
+            packet_format (int): The packet format version.
         """
 
-        self.m_gameYear = game_year
+        self.m_packetFormat = packet_format
         (
             self.m_actualTyreCompound,
             self.m_visualTyreCompound,
@@ -91,9 +91,9 @@ class TyreSetData:
             self.m_actualTyreCompound = ActualTyreCompound(self.m_actualTyreCompound)
         if VisualTyreCompound.isValid(self.m_visualTyreCompound):
             self.m_visualTyreCompound = VisualTyreCompound(self.m_visualTyreCompound)
-        if self.m_gameYear == 23 and SessionType23.isValid(self.m_recommendedSession):
+        if self.m_packetFormat == 2023 and SessionType23.isValid(self.m_recommendedSession):
             self.m_recommendedSession = SessionType23(self.m_recommendedSession)
-        elif self.m_gameYear in {24, 25} and SessionType24.isValid(self.m_recommendedSession):
+        elif self.m_packetFormat in {2024, 2025} and SessionType24.isValid(self.m_recommendedSession):
             self.m_recommendedSession = SessionType24(self.m_recommendedSession)
         self.m_fitted = bool(self.m_fitted)
 
@@ -190,7 +190,7 @@ class TyreSetData:
 
     @classmethod
     def from_values(cls,
-                game_year: int,
+                packet_format: int,
                 actual_tyre_compound: ActualTyreCompound,
                 visual_tyre_compound: VisualTyreCompound,
                 wear: int,
@@ -204,7 +204,7 @@ class TyreSetData:
         Creates a new TyreSetData object from the given values
 
         Args:
-            game_year (int): Game year
+            packet_format (int): Packet format
             actual_tyre_compound (ActualTyreCompound): Actual tyre compound
             visual_tyre_compound (VisualTyreCompound): Visual tyre compound
             wear (int): Wear percentage
@@ -227,7 +227,7 @@ class TyreSetData:
             life_span,
             usable_life,
             lap_delta_time,
-            fitted), game_year)
+            fitted), packet_format)
 
 class PacketTyreSetsData:
     """
@@ -261,7 +261,7 @@ class PacketTyreSetsData:
         full_tyre_set_data_raw = data[1:1 + tyre_set_data_full_len]
 
         self.m_tyreSetData = [
-            TyreSetData(full_tyre_set_data_raw[i:i + TyreSetData.PACKET_LEN], header.m_gameYear)
+            TyreSetData(full_tyre_set_data_raw[i:i + TyreSetData.PACKET_LEN], header.m_packetFormat)
             for i in range(0, tyre_set_data_full_len, TyreSetData.PACKET_LEN)
         ]
         self.m_fittedIdx: int = struct.unpack("<B", data[(1 + tyre_set_data_full_len):])[0]

--- a/lib/f1_types/packet_13_motion_ex_data.py
+++ b/lib/f1_types/packet_13_motion_ex_data.py
@@ -186,9 +186,9 @@ class PacketMotionExData:
 
         ) = struct.unpack(self.PACKET_FORMAT_23, data[0:self.PACKET_LEN_23])
 
-        if header.m_gameYear > 23:
+        if header.m_packetFormat > 2023:
             curr_offset = self.PACKET_LEN_23
-            if header.m_gameYear >= 24:
+            if header.m_packetFormat >= 2024:
                 (
                     self.m_frontAeroHeight,             # float
                     self.m_rearAeroHeight,              # float
@@ -198,7 +198,7 @@ class PacketMotionExData:
                 ) = struct.unpack(self.PACKET_FORMAT_24_EXTRA,
                                     data[curr_offset:curr_offset + self.PACKET_LEN_EXTRA_24])
                 curr_offset += self.PACKET_LEN_EXTRA_24
-            if header.m_gameYear >= 25:
+            if header.m_packetFormat >= 2025:
                 (
                     self.m_chassisPitch,                # float
                     self.m_wheelCamber[0],             # array of floats

--- a/lib/f1_types/packet_14_time_trial_data.py
+++ b/lib/f1_types/packet_14_time_trial_data.py
@@ -62,13 +62,13 @@ class TimeTrialDataSet:
     )
     PACKET_LEN = struct.calcsize(PACKET_FORMAT)
 
-    def __init__(self, data: bytes, game_year: int) -> None:
+    def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initializes a TimeTrialDataSet object by unpacking the provided binary data.
 
         Parameters:
             data (bytes): Binary data to be unpacked.
-            game_year (int): The game year.
+            packet_format (int): Packet format version
 
         Raises:
             struct.error: If the binary data does not match the expected format.
@@ -91,7 +91,7 @@ class TimeTrialDataSet:
         ) = unpacked_data
 
         # No ned to check game year, since this packet type is not available in F1 23
-        if game_year < 25 and TeamID24.isValid(self.m_teamId):
+        if packet_format < 2025 and TeamID24.isValid(self.m_teamId):
                 self.m_teamId = TeamID24(self.m_teamId)
         elif TeamID25.isValid(self.m_teamId):
             self.m_teamId = TeamID25(self.m_teamId)
@@ -271,17 +271,17 @@ class PacketTimeTrialData:
         bytes_so_far = 0
         raw_data = data[:bytes_so_far + TimeTrialDataSet.PACKET_LEN]
         bytes_so_far += TimeTrialDataSet.PACKET_LEN
-        self.m_playerSessionBestDataSet = TimeTrialDataSet(raw_data, header.m_gameYear)
+        self.m_playerSessionBestDataSet = TimeTrialDataSet(raw_data, header.m_packetFormat)
 
         # Next, the personal best data set
         raw_data = data[bytes_so_far:bytes_so_far + TimeTrialDataSet.PACKET_LEN]
         bytes_so_far += TimeTrialDataSet.PACKET_LEN
-        self.m_personalBestDataSet = TimeTrialDataSet(raw_data, header.m_gameYear)
+        self.m_personalBestDataSet = TimeTrialDataSet(raw_data, header.m_packetFormat)
 
         # Finally, the rival data set
         raw_data = data[bytes_so_far:bytes_so_far + TimeTrialDataSet.PACKET_LEN]
         bytes_so_far += TimeTrialDataSet.PACKET_LEN
-        self.m_rivalSessionBestDataSet = TimeTrialDataSet(raw_data, header.m_gameYear)
+        self.m_rivalSessionBestDataSet = TimeTrialDataSet(raw_data, header.m_packetFormat)
 
     def toJSON(self, include_header: bool=False) -> Dict[str, Any]:
         """Get the JSON dump of this object

--- a/lib/f1_types/packet_1_session_data.py
+++ b/lib/f1_types/packet_1_session_data.py
@@ -345,12 +345,12 @@ class WeatherForecastSample:
                 WeatherForecastSample.AirTemperatureChange.NO_CHANGE: "No Temperature Change",
             }[self]
 
-    def __init__(self, data: bytes, game_year: int) -> None:
+    def __init__(self, data: bytes, packet_format: int) -> None:
         """Unpack the given raw bytes into this object
 
         Args:
             data (bytes): List of raw bytes received as part of this
-            game_year (int): The year of the game
+            packet_format (int): The format of the packet
         """
 
         # Declare the type hints
@@ -382,7 +382,7 @@ class WeatherForecastSample:
             self.m_airTemperatureChange = WeatherForecastSample.AirTemperatureChange(self.m_airTemperatureChange)
         if WeatherForecastSample.TrackTemperatureChange.isValid(self.m_trackTemperatureChange):
             self.m_trackTemperatureChange = WeatherForecastSample.TrackTemperatureChange(self.m_trackTemperatureChange)
-        if game_year == 23 and SessionType23.isValid(self.m_sessionType):
+        if packet_format == 2023 and SessionType23.isValid(self.m_sessionType):
             self.m_sessionType = SessionType23(self.m_sessionType)
         elif SessionType24.isValid(self.m_sessionType):
             self.m_sessionType = SessionType24(self.m_sessionType)
@@ -1298,7 +1298,7 @@ class PacketSessionData:
         self.m_sector3LapDistanceStart: float    # // Distance in m around track where sector 3
 
         self.m_maxMarshalZones = self.F1_23_MAX_NUM_MARSHAL_ZONES
-        if header.m_gameYear == 23:
+        if header.m_packetFormat == 2023:
             self.m_maxWeatherForecastSamples = self.F1_23_MAX_NUM_WEATHER_FORECAST_SAMPLES
         else:
             self.m_maxWeatherForecastSamples = self.F1_24_MAX_NUM_WEATHER_FORECAST_SAMPLES
@@ -1330,7 +1330,7 @@ class PacketSessionData:
         if TrackID.isValid(self.m_trackId):
             self.m_trackId = TrackID(self.m_trackId)
 
-        if header.m_gameYear <= 23 and SessionType23.isValid(self.m_sessionType):
+        if header.m_packetFormat == 2023 and SessionType23.isValid(self.m_sessionType):
             self.m_sessionType = SessionType23(self.m_sessionType)
         elif SessionType24.isValid(self.m_sessionType):
             self.m_sessionType = SessionType24(self.m_sessionType)
@@ -1369,7 +1369,7 @@ class PacketSessionData:
             item_len=WeatherForecastSample.PACKET_LEN,
             count=self.m_numWeatherForecastSamples,
             max_count=self.m_maxWeatherForecastSamples,
-            game_year=header.m_gameYear
+            packet_format=header.m_packetFormat
         )
 
 
@@ -1419,7 +1419,7 @@ class PacketSessionData:
 
         self.m_weekendStructure = [0] * 12
         # Section 5 - F1 24 specific stuff
-        if header.m_gameYear == 24:
+        if header.m_packetFormat == 2024:
             section_5_raw_data = data[byte_index_so_far:byte_index_so_far + self.PACKET_LEN_SECTION_5]
             unpacked_data = struct.unpack(self.PACKET_FORMAT_SECTION_5, section_5_raw_data)
             (
@@ -1709,7 +1709,7 @@ class PacketSessionData:
         if not self.__eq_f1_23(other):
             return False
 
-        if self.m_header.m_gameYear == 24:
+        if self.m_header.m_packetFormat == 2024:
             return self.__eq_f1_24(other)
 
         return NotImplemented

--- a/lib/f1_types/packet_2_lap_data.py
+++ b/lib/f1_types/packet_2_lap_data.py
@@ -144,7 +144,7 @@ class LapData:
     PACKET_LEN_24:int = struct.calcsize(PACKET_FORMAT_24)
 
     # Type hints declaration for fields
-    m_gameYear: int
+    m_packetFormat: int
     m_lastLapTimeInMS: int
     m_currentLapTimeInMS: int
     m_sector1TimeInMS: int
@@ -295,21 +295,21 @@ class LapData:
             }
             return sector_mapping.get(self.value, "---")
 
-    def __init__(self, data: bytes, game_year: int) -> None:
+    def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initialize LapData instance by unpacking binary data.
 
         Args:
         - data (bytes): Binary data containing lap information.
-        - game_year (int): The year of the game.
+        - packet_format (int): The format version of the packet.
 
         Raises:
         - struct.error: If the binary data does not match the expected format.
         """
 
         # Assign the members from unpacked_data
-        self.m_gameYear = game_year
-        if game_year == 23:
+        self.m_packetFormat = packet_format
+        if packet_format == 2023:
             raw_data = data[:self.PACKET_LEN_23]
             (
                 self.m_lastLapTimeInMS,
@@ -495,7 +495,7 @@ class LapData:
             return False
 
         return (
-            self.m_gameYear == other.m_gameYear and
+            self.m_packetFormat == other.m_packetFormat and
             self.m_lastLapTimeInMS == other.m_lastLapTimeInMS and
             self.m_currentLapTimeInMS == other.m_currentLapTimeInMS and
             self.m_sector1TimeInMS == other.m_sector1TimeInMS and
@@ -568,7 +568,7 @@ class PacketLapData:
         # Determine LapData size based on game year
         # F1 game data structures can vary between game versions
         lap_data_obj_size = LapData.PACKET_LEN_24  # Default to 2024 format
-        if header.m_gameYear == 23:
+        if header.m_packetFormat == 2023:
             lap_data_obj_size = LapData.PACKET_LEN_23  # Use 2023 format if needed
 
         # Calculate expected packet length:
@@ -594,7 +594,7 @@ class PacketLapData:
 
             # Extract this car's binary data and create a LapData object
             car_data = packet[start_idx:end_idx]
-            self.m_lapData.append(LapData(car_data, header.m_gameYear))
+            self.m_lapData.append(LapData(car_data, header.m_packetFormat))
 
         # Extract time trial indices from the last 2 bytes
         # These identify personal best and rival cars in time trial mode

--- a/lib/f1_types/packet_3_event_data.py
+++ b/lib/f1_types/packet_3_event_data.py
@@ -141,13 +141,13 @@ class PacketEventData:
             lapTime (float): Lap time in seconds.
         """
 
-        def __init__(self, data: bytes, _game_year: int) -> None:
+        def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes a FastestLap object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
@@ -235,18 +235,18 @@ class PacketEventData:
                 return PacketEventData.Retirement.Reason.INVALID.value <= value <= \
                             PacketEventData.Retirement.Reason.SESSION_SIMULATED.value
 
-        def __init__(self, data: bytes, game_year: int):
+        def __init__(self, data: bytes, packet_format: int):
             """
             Initializes a Retirement object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                game_year (int): The game year.
+                packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
             """
-            if game_year >= 25:
+            if packet_format >= 2025:
                 format_str = "<BB"
                 self.vehicleIdx, self.m_reason = struct.unpack(format_str, data[: struct.calcsize(format_str)])
                 if PacketEventData.Retirement.Reason.isValid(self.m_reason):
@@ -321,18 +321,18 @@ class PacketEventData:
                 return PacketEventData.DrsDisabled.Reason.WET_TRACK.value <= value <= \
                             PacketEventData.DrsDisabled.Reason.MIN_LAP_NOT_REACHED.value
 
-        def __init__(self, data: bytes, game_year: int):
+        def __init__(self, data: bytes, packet_format: int):
             """
             Initializes a DrsDisabled object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                game_year (int): The game year.
+                packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
             """
-            if game_year < 25:
+            if packet_format <= 2025:
                 self.m_reason = None
                 return
             format_str = "<B"
@@ -356,13 +356,13 @@ class PacketEventData:
         Attributes:
             vehicleIdx(int) - The index of the vehicle that pitted (the teammates index)
         """
-        def __init__(self, data: bytes, _game_year: int):
+        def __init__(self, data: bytes, _packet_format: int):
             """
             Initializes a TeamMateInPits object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
@@ -416,13 +416,13 @@ class PacketEventData:
         Attributes:
             vehicleIdx(int) - The index of the vehicle that pitted (the teammates index)
         """
-        def __init__(self, data: bytes, _game_year: int):
+        def __init__(self, data: bytes, _packet_format: int):
             """
             Initializes a RaceWinner object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
@@ -600,12 +600,12 @@ class PacketEventData:
                     return True  # It's already an instance of SafetyCarStatus
                 return any(infringement_type == member.value for member in  PacketEventData.Penalty.InfringementType)
 
-        def __init__(self, data: bytes, _game_year: int):
+        def __init__(self, data: bytes, _packet_format: int):
             """Parse the penalty event packet into this object
 
             Args:
                 data (bytes): The packet containing the event data.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
             """
 
             format_str = "<BBBBBBB"
@@ -691,13 +691,13 @@ class PacketEventData:
             fastestSpeedInSession (float): The speed of the fastest vehicle in the session.
         """
 
-        def __init__(self, data: bytes, _game_year: int) -> None:
+        def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes a SpeedTrap object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
@@ -788,13 +788,13 @@ class PacketEventData:
             numLights (int): The number of lights in the start lights sequence.
         """
 
-        def __init__(self, data: bytes, _game_year: int) -> None:
+        def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes a StartLights object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
@@ -845,13 +845,13 @@ class PacketEventData:
             vehicleIdx (int): The index of the vehicle serving the drive-through penalty.
         """
 
-        def __init__(self, data: bytes, _game_year: int) -> None:
+        def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes a DriveThroughPenaltyServed object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
@@ -915,19 +915,19 @@ class PacketEventData:
             vehicleIdx (int): The index of the vehicle serving the stop-go penalty.
         """
 
-        def __init__(self, data: bytes, game_year: int) -> None:
+        def __init__(self, data: bytes, packet_format: int) -> None:
             """
             Initializes a StopGoPenaltyServed object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                game_year (int): The game year.
+                packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
             """
 
-            if game_year < 25:
+            if packet_format <= 2025:
                 format_str = "<B"
                 self.vehicleIdx = struct.unpack(format_str, data[:struct.calcsize(format_str)])
                 self.stopTime = 0.0
@@ -991,13 +991,13 @@ class PacketEventData:
             flashbackSessionTime (float): Session time when the flashback was initiated, in seconds.
         """
 
-        def __init__(self, data: bytes, _game_year: int) -> None:
+        def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes a Flashback object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
@@ -1098,13 +1098,13 @@ class PacketEventData:
         UDP_ACTION_11 = 0x40000000
         UDP_ACTION_12 = 0x80000000
 
-        def __init__(self, data: bytes, _game_year: int) -> None:
+        def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes a Buttons object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
@@ -1211,13 +1211,13 @@ class PacketEventData:
             beingOvertakenVehicleIdx (int): The index of the vehicle being overtaken.
         """
 
-        def __init__(self, data: bytes, _game_year: int) -> None:
+        def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes an Overtake object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
@@ -1285,13 +1285,13 @@ class PacketEventData:
             m_event_type (SafetyCarEventType): Refer SafetyCarEventType enumeration
         """
 
-        def __init__(self, data: bytes, _game_year: int) -> None:
+        def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes an Overtake object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
@@ -1362,13 +1362,13 @@ class PacketEventData:
             m_vehicle_2_index (int): The index of the vehicle being overtaken.
         """
 
-        def __init__(self, data: bytes, _game_year: int) -> None:
+        def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes a Collision object by unpacking the provided binary data.
 
             Parameters:
                 data (bytes): Binary data to be unpacked.
-                _game_year (int): The game year.
+                _packet_format (int): The packet format
 
             Raises:
                 struct.error: If the binary data does not match the expected format.
@@ -1478,7 +1478,7 @@ class PacketEventData:
 
         # Parse the optional data, if any
         if PacketEventData.event_type_map.get(self.m_eventCode):
-            self.mEventDetails = PacketEventData.event_type_map[self.m_eventCode](packet[4:], header.m_gameYear)
+            self.mEventDetails = PacketEventData.event_type_map[self.m_eventCode](packet[4:], header.m_packetFormat)
         else:
             self.mEventDetails = None
 

--- a/lib/f1_types/packet_8_final_classification_data.py
+++ b/lib/f1_types/packet_8_final_classification_data.py
@@ -97,21 +97,21 @@ class FinalClassificationData:
     )
     PACKET_LEN_25 = struct.calcsize(PACKET_FORMAT_25)
 
-    def __init__(self, data: bytes, game_year: int) -> None:
+    def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initializes FinalClassificationData with raw data.
 
         Args:
             data (bytes): Raw data representing final classification for a car in a race.
-            game_year (int): The year of the game.
+            packet_format (int): Packet format version.
         """
 
         self.m_tyreStintsActual: List[int] = [0] * 8
         self.m_tyreStintsVisual: List[int] = [0] * 8
         self.m_tyreStintsEndLaps: List[int] = [0] * 8
         self.m_resultReason: ResultReason = ResultReason.INVALID
-        self.m_gameYear = game_year
-        if game_year <= 24:
+        self.m_packetFormat = packet_format
+        if packet_format <= 2024:
             (
                 self.m_position,
                 self.m_numLaps,
@@ -267,7 +267,7 @@ class FinalClassificationData:
             "tyre-stints-end-laps": self.m_tyreStintsEndLaps,
         }
 
-        if self.m_gameYear >= 25:
+        if self.m_packetFormat >= 2025:
             res["result-reason"] = str(self.m_resultReason)
 
         return res
@@ -345,7 +345,7 @@ class FinalClassificationData:
         tyre_stints_actual: List[ActualTyreCompound] = pad_array(self.m_tyreStintsActual)
         tyre_stints_end_laps = pad_array(self.m_tyreStintsEndLaps)
 
-        if self.m_gameYear < 25:
+        if self.m_packetFormat < 2025:
             return struct.pack(self.PACKET_FORMAT,
                 self.m_position,
                 self.m_numLaps,
@@ -425,7 +425,7 @@ class FinalClassificationData:
 
     @classmethod
     def from_values(cls,
-            game_year: int,
+            packet_format: int,
             position: int,
             num_laps: int,
             grid_position: int,
@@ -475,7 +475,7 @@ class FinalClassificationData:
             FinalClassificationData: A new FinalClassificationData object initialized with the provided values.
         """
 
-        if game_year < 25:
+        if packet_format < 2025:
             return cls(struct.pack(cls.PACKET_FORMAT,
                 position,
                 num_laps,
@@ -515,7 +515,7 @@ class FinalClassificationData:
                 tyre_stints_end_laps_5,
                 tyre_stints_end_laps_6,
                 tyre_stints_end_laps_7
-            ), game_year=game_year)
+            ), packet_format=packet_format)
 
         return cls(struct.pack(cls.PACKET_FORMAT_25,
             position,
@@ -557,7 +557,7 @@ class FinalClassificationData:
             tyre_stints_end_laps_5,
             tyre_stints_end_laps_6,
             tyre_stints_end_laps_7
-        ), game_year=game_year)
+        ), packet_format=packet_format)
 
 class PacketFinalClassificationData:
     """
@@ -586,7 +586,7 @@ class PacketFinalClassificationData:
         self.m_header: PacketHeader = header
         self.m_numCars: int = struct.unpack("<B", packet[:1])[0]
 
-        if header.m_gameYear <= 24:
+        if header.m_packetFormat <= 2024:
             packet_len = FinalClassificationData.PACKET_LEN
         else:
             packet_len = FinalClassificationData.PACKET_LEN_25
@@ -594,7 +594,7 @@ class PacketFinalClassificationData:
         # Iterate over packet[1:] in steps of packet_len,
         # creating FinalClassificationData objects for each segment.
         self.m_classificationData: List[FinalClassificationData] = [
-            FinalClassificationData(packet[i:i + packet_len], header.m_gameYear)
+            FinalClassificationData(packet[i:i + packet_len], header.m_packetFormat)
             for i in range(1, len(packet), packet_len)
         ]
         # strip the non-applicable data

--- a/lib/f1_types/packet_8_final_classification_data.py
+++ b/lib/f1_types/packet_8_final_classification_data.py
@@ -25,7 +25,8 @@ import struct
 from typing import Any, Dict, List
 
 from .common import (ActualTyreCompound, F1Utils, PacketHeader, ResultReason,
-                     ResultStatus, VisualTyreCompound)
+                     ResultStatus, VisualTyreCompound,
+                     _validate_parse_fixed_segments)
 
 # --------------------- CLASS DEFINITIONS --------------------------------------
 
@@ -572,7 +573,7 @@ class PacketFinalClassificationData:
         The class is designed to parse and represent the final classification data packet.
     """
 
-    max_cars = 22
+    MAX_CARS = 22
 
     def __init__(self, header: PacketHeader, packet: bytes) -> None:
         """
@@ -593,12 +594,16 @@ class PacketFinalClassificationData:
 
         # Iterate over packet[1:] in steps of packet_len,
         # creating FinalClassificationData objects for each segment.
-        self.m_classificationData: List[FinalClassificationData] = [
-            FinalClassificationData(packet[i:i + packet_len], header.m_packetFormat)
-            for i in range(1, len(packet), packet_len)
-        ]
-        # strip the non-applicable data
-        self.m_classificationData = self.m_classificationData[:self.m_numCars]
+        self.m_classificationData: List[FinalClassificationData]
+        self.m_classificationData, _ = _validate_parse_fixed_segments(
+            data=packet,
+            offset=1,
+            item_cls=FinalClassificationData,
+            item_len=packet_len,
+            count=self.m_numCars,
+            max_count=self.MAX_CARS,
+            packet_format=header.m_packetFormat
+        )
 
     def __str__(self) -> str:
         """

--- a/lib/f1_types/packet_9_lobby_info_data.py
+++ b/lib/f1_types/packet_9_lobby_info_data.py
@@ -119,17 +119,17 @@ class LobbyInfoData:
                 return self.name
             return f'Marshal Zone Flag type {str(self.value)}'
 
-    def __init__(self, data: bytes, game_year: int) -> None:
+    def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initializes LobbyInfoData with raw data.
 
         Args:
             data (bytes): Raw data representing lobby information for a player.
-            game_year (int): Game year
+            packet_format (int): The packet format version.
         """
 
-        self.game_year = game_year
-        if game_year == 23:
+        self.packet_format = packet_format
+        if packet_format == 2023:
             (
                 self.m_aiControlled,
                 self.m_teamId,
@@ -143,7 +143,7 @@ class LobbyInfoData:
             self.m_showOnlineNames = True
             self.m_techLevel = 0
         else:
-            if game_year == 24:
+            if packet_format == 2024:
                 packet_format = self.PACKET_FORMAT_24
             else:
                 packet_format = self.PACKET_FORMAT_25
@@ -165,11 +165,11 @@ class LobbyInfoData:
 
         self.m_name = self.m_name.decode('utf-8', errors='replace').rstrip('\x00')
 
-        if self.game_year == 23 and TeamID23.isValid(self.m_teamId):
+        if self.packet_format == 2023 and TeamID23.isValid(self.m_teamId):
             self.m_teamId = TeamID23(self.m_teamId)
-        elif self.game_year == 24 and TeamID24.isValid(self.m_teamId):
+        elif self.packet_format == 2024 and TeamID24.isValid(self.m_teamId):
             self.m_teamId = TeamID24(self.m_teamId)
-        elif self.game_year == 25 and TeamID25.isValid(self.m_teamId):
+        elif self.packet_format == 2025 and TeamID25.isValid(self.m_teamId):
             self.m_teamId = TeamID25(self.m_teamId)
 
         if Nationality.isValid(self.m_nationality):
@@ -212,7 +212,7 @@ class LobbyInfoData:
         """
 
         return (
-            self.game_year == other.game_year and
+            self.packet_format == other.packet_format and
             self.m_aiControlled == other.m_aiControlled and
             self.m_teamId == other.m_teamId and
             self.m_nationality == other.m_nationality and
@@ -245,7 +245,7 @@ class LobbyInfoData:
             bytes: Raw data representing the LobbyInfoData instance.
         """
 
-        if self.game_year == 23:
+        if self.packet_format == 2023:
             return struct.pack(self.PACKET_FORMAT_23,
                 self.m_aiControlled,
                 self.m_teamId.value,
@@ -255,7 +255,7 @@ class LobbyInfoData:
                 self.m_carNumber,
                 self.m_readyStatus.value,
             )
-        if self.game_year == 24:
+        if self.packet_format == 2024:
             return struct.pack(self.PACKET_FORMAT_24,
                 self.m_aiControlled,
                 self.m_teamId.value,
@@ -268,7 +268,7 @@ class LobbyInfoData:
                 self.m_techLevel,
                 self.m_readyStatus.value,
             )
-        if self.game_year == 25:
+        if self.packet_format == 2025:
             return struct.pack(self.PACKET_FORMAT_25,
                 self.m_aiControlled,
                 self.m_teamId.value,
@@ -282,7 +282,7 @@ class LobbyInfoData:
                 self.m_readyStatus.value,
             )
 
-        raise NotImplementedError(f"Unsupported game year: {self.game_year}")
+        raise NotImplementedError(f"Unsupported packet format: {self.packet_format}")
 
     @classmethod
     def from_values(cls,
@@ -317,7 +317,7 @@ class LobbyInfoData:
             LobbyInfoData: A new LobbyInfoData object.
         """
 
-        if header.m_gameYear == 23:
+        if header.m_packetFormat == 2023:
             return cls(struct.pack(cls.PACKET_FORMAT_23,
                 ai_controlled,
                 team_id.value,
@@ -326,8 +326,8 @@ class LobbyInfoData:
                 name.encode('utf-8'),
                 car_number,
                 ready_status.value,
-            ), header.m_gameYear)
-        if header.m_gameYear == 24:
+            ), header.m_packetFormat)
+        if header.m_packetFormat == 2024:
             return cls(struct.pack(cls.PACKET_FORMAT_24,
                 ai_controlled,
                 team_id.value,
@@ -339,8 +339,8 @@ class LobbyInfoData:
                 show_online_names,
                 tech_level,
                 ready_status.value,
-            ), header.m_gameYear)
-        if header.m_gameYear == 25:
+            ), header.m_packetFormat)
+        if header.m_packetFormat == 2025:
             return cls(struct.pack(cls.PACKET_FORMAT_25,
                 ai_controlled,
                 team_id.value,
@@ -352,9 +352,9 @@ class LobbyInfoData:
                 show_online_names,
                 tech_level,
                 ready_status.value,
-            ), header.m_gameYear)
+            ), header.m_packetFormat)
 
-        raise NotImplementedError(f"Unsupported game year: {header.m_gameYear}")
+        raise NotImplementedError(f"Unsupported packet format: {header.m_packetFormat}")
 
 class PacketLobbyInfoData:
     """
@@ -381,9 +381,9 @@ class PacketLobbyInfoData:
 
         self.m_header: PacketHeader = header
         self.m_numPlayers: int = struct.unpack("<B", packet[:1])[0]
-        if header.m_gameYear == 23:
+        if header.m_packetFormat == 2023:
             packet_len = LobbyInfoData.PACKET_LEN_23
-        elif header.m_gameYear == 24:
+        elif header.m_packetFormat == 2024:
             packet_len = LobbyInfoData.PACKET_LEN_24
         else:
             packet_len = LobbyInfoData.PACKET_LEN_25
@@ -396,7 +396,7 @@ class PacketLobbyInfoData:
             item_len=packet_len,
             count=self.m_numPlayers,
             max_count=self.MAX_PLAYERS,
-            game_year=header.m_gameYear
+            packet_format=header.m_packetFormat
         )
 
     def toJSON(self, include_header: bool=False) -> Dict[str, Any]:

--- a/lib/telemetry_manager.py
+++ b/lib/telemetry_manager.py
@@ -41,7 +41,7 @@ from lib.socket_receiver import (AsyncTCPListener, AsyncUDPListener,
 
 # ------------------------- CLASSES ------------------------------------------------------------------------------------
 
-class UnsupportedGameYear(Exception):
+class UnsupportedPacketFormat(Exception):
     """Raised when packet data is malformed or insufficient"""
     def __init__(self, game_year):
         super().__init__(f"Unsupported game year. {game_year}")
@@ -74,7 +74,7 @@ class AsyncF1TelemetryManager:
         F1PacketType.LAP_POSITIONS: PacketLapPositionsData,
     }
 
-    MIN_GAME_YEAR = 23
+    MIN_PACKET_FORMAT = 2023
 
     def __init__(self, port_number: int, logger: Logger = None, replay_server: bool = False):
         """Init the telemetry manager app and all its sub components
@@ -158,7 +158,7 @@ class AsyncF1TelemetryManager:
             raw_packet = await self.m_server.getNextMessage()
             try:
                 await self._processPacket(should_parse_packet, raw_packet)
-            except UnsupportedGameYear as e:
+            except UnsupportedPacketFormat as e:
                 self.m_logger.error(e, exc_info=True)
             except Exception as e:
                 self.m_logger.error("Error processing packet: %s", e, exc_info=True)
@@ -188,8 +188,8 @@ class AsyncF1TelemetryManager:
             # Unsupported packet type, skip
             return
 
-        if header.m_gameYear < self.MIN_GAME_YEAR:
-            raise UnsupportedGameYear(header.m_gameYear)
+        if header.m_packetFormat < self.MIN_PACKET_FORMAT:
+            raise UnsupportedPacketFormat(header.m_packetFormat)
 
         # Parse the payload and call the registered callback
         payload_raw = raw_packet[PacketHeader.PACKET_LEN:]

--- a/tests/f1_types/tests_packet_10_car_damage_data.py
+++ b/tests/f1_types/tests_packet_10_car_damage_data.py
@@ -44,7 +44,7 @@ class TestPacketCarDamageData(F1TypesTest):
 
         generated_test_obj = PacketCarDamageData.from_values(
             self.m_header_25,
-            [self._generateRandomCarDamageData(game_year=25) for _ in range(self.m_num_players)]
+            [self._generateRandomCarDamageData(packet_format=2025) for _ in range(self.m_num_players)]
         )
         serialised_test_obj = generated_test_obj.to_bytes()
         header_bytes = serialised_test_obj[:PacketHeader.PACKET_LEN]
@@ -62,7 +62,7 @@ class TestPacketCarDamageData(F1TypesTest):
 
         generated_test_obj = PacketCarDamageData.from_values(
             self.m_header_24,
-            [self._generateRandomCarDamageData(game_year=24) for _ in range(self.m_num_players)]
+            [self._generateRandomCarDamageData(packet_format=2024) for _ in range(self.m_num_players)]
         )
         serialised_test_obj = generated_test_obj.to_bytes()
         header_bytes = serialised_test_obj[:PacketHeader.PACKET_LEN]
@@ -80,7 +80,7 @@ class TestPacketCarDamageData(F1TypesTest):
 
         generated_test_obj = PacketCarDamageData.from_values(
             self.m_header_23,
-            [self._generateRandomCarDamageData(game_year=23) for _ in range(self.m_num_players)]
+            [self._generateRandomCarDamageData(packet_format=2023) for _ in range(self.m_num_players)]
         )
         serialised_test_obj = generated_test_obj.to_bytes()
         header_bytes = serialised_test_obj[:PacketHeader.PACKET_LEN]
@@ -1802,19 +1802,19 @@ class TestPacketCarDamageData(F1TypesTest):
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
 
-    def _generateRandomCarDamageData(self, game_year: int) -> CarDamageData:
+    def _generateRandomCarDamageData(self, packet_format: int) -> CarDamageData:
         """
         Generate a random car damage data object
 
         Args:
-            game_year (int): The game year
+            packet_format (int): The packet format
 
         Returns:
             LobbyInfoData: A random car damage data object
         """
 
         return CarDamageData.from_values(
-            game_year=game_year,
+            packet_format=packet_format,
             tyres_wear=[random.uniform(0.0, 100.0) for _ in range(4)],
             tyres_damage=[random.randrange(0, 100) for _ in range(4)],
             brakes_damage=[random.randrange(0, 100) for _ in range(4)],

--- a/tests/f1_types/tests_packet_12_tyre_sets_data.py
+++ b/tests/f1_types/tests_packet_12_tyre_sets_data.py
@@ -562,9 +562,9 @@ class TestPacketTyreSetsData(F1TypesTest):
             TyreSetData: Random tyre set data
         """
 
-        session_obj_type = SessionType23 if header.m_gameYear == 23 else SessionType24
+        session_obj_type = SessionType23 if header.m_packetFormat == 2023 else SessionType24
         return TyreSetData.from_values(
-            game_year=header.m_gameYear,
+            packet_format=header.m_packetFormat,
             actual_tyre_compound=random.choice(list(ActualTyreCompound)),
             visual_tyre_compound=random.choice(list(VisualTyreCompound)),
             wear=random.randint(0, 100),

--- a/tests/f1_types/tests_packet_14_time_trial_data.py
+++ b/tests/f1_types/tests_packet_14_time_trial_data.py
@@ -147,28 +147,28 @@ class TestPacketTimeTrialData(F1TypesTest):
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
 
-    def _generateRandomTimeTrialDataSet(self, index: int, game_year: int) -> TimeTrialDataSet:
+    def _generateRandomTimeTrialDataSet(self, index: int, packet_format: int) -> TimeTrialDataSet:
         """
         Generates a random TimeTrialDataSet
 
         Args:
             index (int): The index of the car
-            game_year (int): The game year
+            packet_format (int): The packet format
 
         Returns:
             TimeTrialDataSet: A random TimeTrialDataSet
         """
 
-        if game_year == 24:
+        if packet_format == 2024:
             team_id_type = TeamID24
-        elif game_year == 25:
+        elif packet_format == 2025:
             team_id_type = TeamID25
 
         s1_time_ms = random.randrange(0, 60000)
         s2_time_ms = random.randrange(0, 60000)
         s3_time_ms = random.randrange(0, 60000)
         return TimeTrialDataSet.from_values(
-            game_year=game_year,
+            game_year=packet_format,
             car_index=index,
             team_id=random.choice(list(team_id_type)),
             lap_time_in_ms=(s1_time_ms + s2_time_ms + s3_time_ms),
@@ -196,7 +196,7 @@ class TestPacketTimeTrialData(F1TypesTest):
 
         return PacketTimeTrialData.from_values(
             header=header,
-            player_session_best_data_set=self._generateRandomTimeTrialDataSet(0, header.m_gameYear),
-            personal_best_data_set=self._generateRandomTimeTrialDataSet(1, header.m_gameYear),
-            rival_session_best_data_set=self._generateRandomTimeTrialDataSet(2, header.m_gameYear),
+            player_session_best_data_set=self._generateRandomTimeTrialDataSet(0, header.m_packetFormat),
+            personal_best_data_set=self._generateRandomTimeTrialDataSet(1, header.m_packetFormat),
+            rival_session_best_data_set=self._generateRandomTimeTrialDataSet(2, header.m_packetFormat),
         )

--- a/tests/f1_types/tests_packet_4_participants_data.py
+++ b/tests/f1_types/tests_packet_4_participants_data.py
@@ -723,11 +723,11 @@ class TestPacketParticipantsData(F1TypesTest):
             for _ in range(num_colours)
         ]
 
-        if header.m_gameYear == 23:
+        if header.m_packetFormat == 2023:
             team_id = random.choice(list(TeamID23))
-        elif header.m_gameYear == 24:
+        elif header.m_packetFormat == 2024:
             team_id = random.choice(list(TeamID24))
-        elif header.m_gameYear == 25:
+        elif header.m_packetFormat == 2025:
             team_id = random.choice(list(TeamID25))
         return ParticipantData.from_values(
             header,

--- a/tests/f1_types/tests_packet_5_car_setups_data.py
+++ b/tests/f1_types/tests_packet_5_car_setups_data.py
@@ -1269,12 +1269,12 @@ class TestPacketCarSetupData(F1TypesTest):
             CarSetupData: The random car setup data object
         """
 
-        if header.m_gameYear == 23:
+        if header.m_packetFormat == 2023:
             engine_braking = 0
         else:
             engine_braking = random.getrandbits(8)
         return CarSetupData.from_values(
-            header.m_gameYear,
+            header.m_packetFormat,
             front_wing=random.getrandbits(8),
             rear_wing=random.getrandbits(8),
             on_throttle=random.getrandbits(8),

--- a/tests/f1_types/tests_packet_8_final_classification.py
+++ b/tests/f1_types/tests_packet_8_final_classification.py
@@ -51,7 +51,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         generated_test_obj = PacketFinalClassificationData.from_values(
             self.m_header_25,
             self.m_num_players,
-            [self._generateRandomFinalClassificationData(game_year=25) for _ in range(self.m_num_players)]
+            [self._generateRandomFinalClassificationData(packet_format=2025) for _ in range(self.m_num_players)]
         )
         serialised_test_obj = generated_test_obj.to_bytes()
         header_bytes = serialised_test_obj[:PacketHeader.PACKET_LEN]
@@ -70,7 +70,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         generated_test_obj = PacketFinalClassificationData.from_values(
             self.m_header_24,
             self.m_num_players,
-            [self._generateRandomFinalClassificationData(game_year=24) for _ in range(self.m_num_players)]
+            [self._generateRandomFinalClassificationData(packet_format=2024) for _ in range(self.m_num_players)]
         )
         serialised_test_obj = generated_test_obj.to_bytes()
         header_bytes = serialised_test_obj[:PacketHeader.PACKET_LEN]
@@ -89,7 +89,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         generated_test_obj = PacketFinalClassificationData.from_values(
             self.m_header_23,
             self.m_num_players,
-            [self._generateRandomFinalClassificationData(game_year=23) for _ in range(self.m_num_players)]
+            [self._generateRandomFinalClassificationData(packet_format=2023) for _ in range(self.m_num_players)]
         )
         serialised_test_obj = generated_test_obj.to_bytes()
         header_bytes = serialised_test_obj[:PacketHeader.PACKET_LEN]
@@ -608,20 +608,20 @@ class TestPacketFinalClassificationData(F1TypesTest):
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
 
-    def _generateRandomFinalClassificationData(self, game_year: int) -> FinalClassificationData:
+    def _generateRandomFinalClassificationData(self, packet_format: int) -> FinalClassificationData:
         """
         Generate a random car status data object
 
         Args:
-            game_year (int): Game year
+            packet_format (int): Packet format
 
         Returns:
             FinalClassificationData: A random car status data object
         """
 
-        if game_year in {23, 24}:
+        if packet_format in {2023, 2024}:
             return FinalClassificationData.from_values(
-                game_year=game_year,
+                packet_format=packet_format,
                 position=random.randrange(1,22),
                 num_laps=random.randrange(0,70),
                 grid_position=random.randrange(1,22),
@@ -662,9 +662,9 @@ class TestPacketFinalClassificationData(F1TypesTest):
                 tyre_stints_end_laps_6=random.randrange(0,22),
                 tyre_stints_end_laps_7=random.randrange(0,22)
             )
-        if game_year == 25:
+        if packet_format == 2025:
             return FinalClassificationData.from_values(
-                game_year=game_year,
+                packet_format=packet_format,
                 position=random.randrange(1,22),
                 num_laps=random.randrange(0,70),
                 grid_position=random.randrange(1,22),
@@ -706,4 +706,4 @@ class TestPacketFinalClassificationData(F1TypesTest):
                 tyre_stints_end_laps_7=random.randrange(0,22)
             )
 
-        raise NotImplementedError(f"Unsupported game year: {game_year}")
+        raise NotImplementedError(f"Unsupported game year: {packet_format}")

--- a/tests/f1_types/tests_packet_9_lobby_info_data.py
+++ b/tests/f1_types/tests_packet_9_lobby_info_data.py
@@ -493,7 +493,7 @@ class TestPacketLobbyInfoData(F1TypesTest):
             LobbyInfoData: A random lobby info data object
         """
 
-        if header.m_gameYear == 23:
+        if header.m_packetFormat == 2023:
             return LobbyInfoData.from_values(
                 header=header,
                 ai_controlled=F1TypesTest.getRandomBool(),
@@ -503,7 +503,7 @@ class TestPacketLobbyInfoData(F1TypesTest):
                 name=F1TypesTest.getRandomUserName(),
                 car_number=random.randint(1, 99),
             )
-        if header.m_gameYear == 24:
+        if header.m_packetFormat == 2024:
             return LobbyInfoData.from_values(
                 header=header,
                 ai_controlled=F1TypesTest.getRandomBool(),
@@ -517,7 +517,7 @@ class TestPacketLobbyInfoData(F1TypesTest):
                 tech_level=random.randrange(0,5000),
                 ready_status=random.choice(list(LobbyInfoData.ReadyStatus))
             )
-        if header.m_gameYear == 25:
+        if header.m_packetFormat == 2025:
             return LobbyInfoData.from_values(
                 header=header,
                 ai_controlled=F1TypesTest.getRandomBool(),
@@ -532,4 +532,4 @@ class TestPacketLobbyInfoData(F1TypesTest):
                 ready_status=random.choice(list(LobbyInfoData.ReadyStatus))
             )
 
-        raise NotImplementedError(f"Test not implemented for game year {header.m_gameYear}")
+        raise NotImplementedError(f"Test not implemented for packet format {header.m_packetFormat}")

--- a/tests/integration_test/runner.py
+++ b/tests/integration_test/runner.py
@@ -17,7 +17,7 @@ import gdown
 DRIVE_FOLDER_URL = "https://drive.google.com/drive/folders/13tIadKMvi3kuItkovT6GUTTHOL3YM6n_?usp=drive_link"
 CACHE_DIR = Path("test_data")
 
-def main():
+def main(port):
     # Create test data directory if it doesn't exist
     CACHE_DIR.mkdir(exist_ok=True)
 
@@ -67,7 +67,7 @@ def main():
 
             # Run telemetry replayer and show output in real-time
             replayer_cmd = ["poetry", "run", "python", "-m", "apps.dev_tools.telemetry_replayer",
-                          "--file-name", file_path]
+                          "--file-name", file_path, "--port", str(port)]
 
             try:
                 result = subprocess.run(replayer_cmd, timeout=120)
@@ -105,5 +105,5 @@ def main():
 
 if __name__ == "__main__":
     port = 20777
-    success = main()
+    success = main(port)
     sys.exit(0 if success else 1)

--- a/tests/integration_test/runner.py
+++ b/tests/integration_test/runner.py
@@ -104,5 +104,6 @@ def main():
     return success_count == len(results)
 
 if __name__ == "__main__":
+    port = 20777
     success = main()
     sys.exit(0 if success else 1)


### PR DESCRIPTION
## 📝 Description

Issues are arising when user players newer games with older packet formats. 
This is because the code only checks the game year and assumes the format. 
With this change, game year field is not used for taking decisions, packet format field is

Fixes #57

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ X] Bug fix 🐞
- [ ] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Unit Tests

- [X] All unit tests pass
- Attach test command/output (e.g., `poetry run python tests/unit_tests.py`):

```
----------------------------------------------------------------------
Ran 185 tests in 7.674s

OK
```

### ✅ Integration Tests

* [X] All integration tests pass
* Attach test command/output (e.g., `poetry run python tests/integration_test/runner.py `):

```
===== TEST RESULTS =====
Passed: 13/13
PASS: f1_23_sp_austria.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
```

### ✅ Pylint

* [X] Code passes `pylint`
* Paste summary report:

```
$ pylint --rcfile scripts/.pylintrc lib apps

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

To run pylint
```
pylint --rcfile scripts/.pylintrc lib apps
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
<details>
<summary>Click to expand</summary>

Explain what was added/updated, or write "N/A" if not applicable.

</details>
```

---

## 📋 General Checklist

* [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [X] My code follows project style conventions
* [X] All new and existing tests pass
* [X] I have added relevant documentation/comments
* [X] I have reviewed my changes and believe they are ready to merge

---
