### PR TITLE
Charts and Tyre wear prediction in driver modal

### DIFF
--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -747,7 +747,7 @@ class SessionState:
         """
 
         return {
-            # "classification-data" : self._getClassificationDataListJSON(), # TODO - remove
+            "classification-data" : self._getClassificationDataListJSON(),
             "collisions" : self.getCollisionStatsJSON(),
             "session-info" : self.m_session_info.m_packet_session.toJSON() \
                 if self.m_session_info.m_packet_session else None,

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -747,7 +747,7 @@ class SessionState:
         """
 
         return {
-            "classification-data" : self._getClassificationDataListJSON(),
+            # "classification-data" : self._getClassificationDataListJSON(), # TODO - remove
             "collisions" : self.getCollisionStatsJSON(),
             "session-info" : self.m_session_info.m_packet_session.toJSON() \
                 if self.m_session_info.m_packet_session else None,
@@ -1004,11 +1004,10 @@ class SessionState:
         """
 
         final_json = self.getRaceInfoJSON()
-        if "records" not in final_json:
-            final_json['records'] = {
-                'fastest' : getFastestTimesJson(final_json),
-                'tyre-stats' : getTyreStintRecordsDict(final_json),
-            }
+        final_json['records'] = {
+            'fastest' : getFastestTimesJson(final_json),
+            'tyre-stats' : getTyreStintRecordsDict(final_json),
+        }
         return final_json
 
     def isPositionHistorySupported(self) -> bool:

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -152,7 +152,7 @@ class OverallRaceStatsRsp:
         self.m_rsp = _session_state_ref.getRaceInfo()
         self._checkUpdateRecords()
         # Remove the classification-data key as it is not used by the frontend
-        del self.m_rsp["classification-data"]
+        self.m_rsp.pop('classification-data', None)
 
     def _checkUpdateRecords(self):
         """

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -151,6 +151,8 @@ class OverallRaceStatsRsp:
 
         self.m_rsp = _session_state_ref.getRaceInfo()
         self._checkUpdateRecords()
+        # Remove the classification-data key as it is not used by the frontend
+        del self.m_rsp["classification-data"]
 
     def _checkUpdateRecords(self):
         """

--- a/apps/frontend/css/lapSectorRecords.css
+++ b/apps/frontend/css/lapSectorRecords.css
@@ -1,0 +1,357 @@
+.f1-lapsec-records {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 100%);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+  color: #ffffff;
+  position: relative;
+  overflow: hidden;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.f1-lapsec-records-header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.f1-lapsec-records-title {
+  font-size: 28px;
+  font-weight: 800;
+  margin: 0;
+  background: linear-gradient(45deg, #e10600, #ff6b00);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+.f1-lapsec-records-subtitle {
+  font-size: 14px;
+  color: #aaaaaa;
+  margin: 8px 0 0 0;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.f1-lapsec-records-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+  max-width: 100%;
+}
+
+@media (min-width: 768px) {
+  .f1-lapsec-records-grid {
+    grid-template-columns: 1.5fr 1fr;
+    gap: 32px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .f1-lapsec-records-grid {
+    grid-template-columns: 1.8fr 1fr;
+    gap: 40px;
+  }
+}
+
+.f1-lapsec-records-fastest-lap {
+  background: linear-gradient(135deg, #2a1810 0%, #3d2518 100%);
+  border: 1px solid #4a2d1a;
+  border-radius: 12px;
+  padding: 24px;
+  position: relative;
+  overflow: hidden;
+  min-height: 200px;
+}
+
+.f1-lapsec-records-fastest-lap::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, #8b5cf6 0%, #a855f7 100%);
+}
+
+.f1-lapsec-records-sectors {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 100%;
+}
+
+.f1-lapsec-records-section-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0 0 16px 0;
+  color: #ffd700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.f1-lapsec-records-section-icon {
+  width: 24px;
+  height: 24px;
+  background: #ffd700;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 800;
+  color: #1a1a1a;
+  flex-shrink: 0;
+}
+
+.f1-lapsec-records-driver-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 16px;
+  gap: 16px;
+}
+
+.f1-lapsec-records-driver-details {
+  flex: 1;
+  min-width: 0;
+}
+
+.f1-lapsec-records-driver-details h3 {
+  font-size: 22px;
+  font-weight: 800;
+  margin: 0 0 4px 0;
+  color: #ffffff;
+  text-transform: uppercase;
+  word-break: break-word;
+}
+
+.f1-lapsec-records-driver-details p {
+  margin: 0;
+  font-size: 14px;
+  color: #aaaaaa;
+  word-break: break-word;
+}
+
+.f1-lapsec-records-lap-info {
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.f1-lapsec-records-time {
+  font-size: 24px;
+  font-weight: 800;
+  margin: 0;
+  color: #ffd700;
+  font-family: 'Courier New', monospace;
+  white-space: nowrap;
+}
+
+.f1-lapsec-records-lap-number {
+  font-size: 12px;
+  color: #aaaaaa;
+  margin: 4px 0 0 0;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.f1-lapsec-records-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #444444;
+}
+
+.f1-lapsec-records-stat {
+  text-align: center;
+  min-width: 0;
+}
+
+.f1-lapsec-records-stat-label {
+  font-size: 10px;
+  color: #aaaaaa;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin: 0;
+}
+
+.f1-lapsec-records-stat-value {
+  font-size: 14px;
+  font-weight: 700;
+  color: #ffffff;
+  margin: 4px 0 0 0;
+  word-break: break-word;
+}
+
+.f1-lapsec-records-sector {
+  background: linear-gradient(135deg, #1a2332 0%, #243447 100%);
+  border: 1px solid #2d4159;
+  border-radius: 8px;
+  padding: 16px;
+  position: relative;
+  overflow: hidden;
+  transition: all 0.3s ease;
+  min-height: 80px;
+}
+
+.f1-lapsec-records-sector:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+}
+
+.f1-lapsec-records-sector-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  gap: 8px;
+}
+
+.f1-lapsec-records-sector-label {
+  font-size: 14px;
+  font-weight: 700;
+  margin: 0;
+  color: #ffffff;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.f1-lapsec-records-sector-time {
+  font-size: 16px;
+  font-weight: 800;
+  color: #00ff41;
+  font-family: 'Courier New', monospace;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.f1-lapsec-records-sector:nth-child(2) .f1-lapsec-records-sector-time {
+  color: #ff6b00;
+}
+
+.f1-lapsec-records-sector:nth-child(3) .f1-lapsec-records-sector-time {
+  color: #e10600;
+}
+
+.f1-lapsec-records-sector-driver {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0 0 4px 0;
+  color: #ffffff;
+  text-transform: uppercase;
+  word-break: break-word;
+}
+
+.f1-lapsec-records-sector-team {
+  font-size: 12px;
+  color: #aaaaaa;
+  margin: 0;
+  word-break: break-word;
+}
+
+.f1-lapsec-records-no-data {
+  text-align: center;
+  color: #666666;
+  font-style: italic;
+  padding: 20px;
+  margin-top: 16px;
+}
+
+.f1-lapsec-records-pulse {
+  animation: f1-lapsec-records-pulse 2s infinite;
+}
+
+@keyframes f1-lapsec-records-pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.f1-lapsec-records-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 200px;
+  color: #aaaaaa;
+  font-size: 16px;
+}
+
+.f1-lapsec-records-error {
+  background: linear-gradient(135deg, #3d1a1a 0%, #4d2222 100%);
+  border: 1px solid #5a2626;
+  border-radius: 8px;
+  padding: 20px;
+  text-align: center;
+  color: #ff6b6b;
+}
+
+@media (max-width: 767px) {
+  .f1-lapsec-records {
+    padding: 16px;
+    margin: 0;
+  }
+
+  .f1-lapsec-records-title {
+    font-size: 24px;
+  }
+
+  .f1-lapsec-records-driver-info {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .f1-lapsec-records-lap-info {
+    text-align: left;
+  }
+
+  .f1-lapsec-records-time {
+    font-size: 20px;
+  }
+
+  .f1-lapsec-records-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .f1-lapsec-records-sector-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  .f1-lapsec-records-sector-time {
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 480px) {
+  .f1-lapsec-records {
+    padding: 12px;
+  }
+
+  .f1-lapsec-records-grid {
+    gap: 16px;
+  }
+
+  .f1-lapsec-records-fastest-lap {
+    padding: 16px;
+  }
+
+  .f1-lapsec-records-sector {
+    padding: 12px;
+  }
+}

--- a/apps/frontend/css/tyreRecords.css
+++ b/apps/frontend/css/tyreRecords.css
@@ -1,0 +1,341 @@
+/* F1 Tyre Records Component Styles */
+
+.f1-tyre-records-wrapper {
+  --f1-primary: #e10600;
+  --f1-primary-light: #ff1e1e;
+  --f1-primary-dark: #b30500;
+  --f1-secondary: #15151e;
+  --f1-secondary-light: #2a2a3a;
+  --f1-accent: #ffd700;
+  --f1-text-primary: #ffffff;
+  --f1-text-secondary: #b0b0b0;
+  --f1-text-muted: #888888;
+  --f1-background: #0d1117;
+  --f1-card-bg: #161b22;
+  --f1-border: #30363d;
+  --f1-shadow: rgba(0, 0, 0, 0.3);
+  --f1-shadow-hover: rgba(225, 6, 0, 0.2);
+
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
+  background: linear-gradient(135deg, var(--f1-background) 0%, var(--f1-secondary) 100%);
+  border-radius: 12px;
+  padding: 24px;
+  color: var(--f1-text-primary);
+  min-height: 400px;
+  position: relative;
+  overflow: hidden;
+}
+
+.f1-tyre-records-wrapper::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--f1-primary) 0%, var(--f1-accent) 50%, var(--f1-primary) 100%);
+  border-radius: 12px 12px 0 0;
+}
+
+.f1-tyre-records-content {
+  position: relative;
+}
+
+.f1-tyre-records-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+  align-items: start;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.f1-tyre-records-card {
+  background: var(--f1-card-bg);
+  border: 1px solid var(--f1-border);
+  border-radius: 12px;
+  overflow: hidden;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  box-shadow: 0 4px 12px var(--f1-shadow);
+  max-width: 350px;
+  margin: 0 auto;
+}
+
+.f1-tyre-records-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px var(--f1-shadow-hover);
+  border-color: var(--f1-primary);
+}
+
+.f1-tyre-records-card-header {
+  padding: 20px;
+  background: linear-gradient(135deg, var(--f1-secondary-light) 0%, var(--f1-secondary) 100%);
+  border-bottom: 1px solid var(--f1-border);
+  position: relative;
+}
+
+.f1-tyre-records-card-header::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 20px;
+  right: 20px;
+  height: 2px;
+  background: linear-gradient(90deg, transparent 0%, var(--f1-primary) 50%, transparent 100%);
+}
+
+.f1-tyre-records-tyre-info {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.f1-tyre-records-tyre-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  flex-shrink: 0;
+  font-size: 32px;
+}
+
+.f1-tyre-records-tyre-icon-fallback {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--f1-text-primary);
+  background: linear-gradient(135deg, var(--f1-primary) 0%, var(--f1-primary-light) 100%);
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(225, 6, 0, 0.3);
+}
+
+.f1-tyre-records-tyre-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.f1-tyre-records-compound-name {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+  color: var(--f1-text-primary);
+  letter-spacing: -0.01em;
+}
+
+.f1-tyre-records-compound-code {
+  font-size: 14px;
+  color: var(--f1-text-secondary);
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 2px 8px;
+  border-radius: 4px;
+  display: inline-block;
+}
+
+.f1-tyre-records-card-body {
+  padding: 20px;
+}
+
+.f1-tyre-records-record-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px;
+  margin-bottom: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.f1-tyre-records-record-item:last-child {
+  margin-bottom: 0;
+}
+
+.f1-tyre-records-record-item:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(225, 6, 0, 0.3);
+  transform: translateX(4px);
+}
+
+.f1-tyre-records-record-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(225, 6, 0, 0.2) 0%, rgba(255, 215, 0, 0.2) 100%);
+  font-size: 16px;
+  flex-shrink: 0;
+  border: 1px solid rgba(225, 6, 0, 0.3);
+  color: var(--f1-text-primary);
+}
+
+.f1-tyre-records-record-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.f1-tyre-records-record-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--f1-text-primary);
+  margin-bottom: 4px;
+  letter-spacing: -0.01em;
+}
+
+.f1-tyre-records-record-driver {
+  font-size: 13px;
+  color: var(--f1-text-secondary);
+  font-weight: 500;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.f1-tyre-records-record-value {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--f1-accent);
+  text-align: right;
+  flex-shrink: 0;
+  min-width: fit-content;
+}
+
+.f1-tyre-records-empty-state {
+  text-align: center;
+  padding: 64px 20px;
+  color: var(--f1-text-muted);
+}
+
+.f1-tyre-records-empty-icon {
+  font-size: 48px;
+  margin-bottom: 16px;
+  opacity: 0.5;
+}
+
+.f1-tyre-records-empty-text {
+  font-size: 16px;
+  margin: 0;
+  font-weight: 500;
+}
+
+/* Bootstrap Icons CDN - Load if not already available */
+@import url('https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css');
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .f1-tyre-records-wrapper {
+    padding: 16px;
+  }
+
+  .f1-tyre-records-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .f1-tyre-records-card-header,
+  .f1-tyre-records-card-body {
+    padding: 16px;
+  }
+
+  .f1-tyre-records-tyre-info {
+    gap: 12px;
+  }
+
+  .f1-tyre-records-tyre-icon {
+    width: 40px;
+    height: 40px;
+    font-size: 28px;
+  }
+
+  .f1-tyre-records-tyre-icon-fallback {
+    width: 40px;
+    height: 40px;
+  }
+
+  .f1-tyre-records-compound-name {
+    font-size: 18px;
+  }
+
+  .f1-tyre-records-record-item {
+    padding: 12px;
+    gap: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .f1-tyre-records-record-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .f1-tyre-records-record-value {
+    align-self: flex-end;
+    margin-top: -24px;
+  }
+
+  .f1-tyre-records-record-content {
+    width: 100%;
+  }
+}
+
+/* Animation for data updates */
+@keyframes f1-tyre-records-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.f1-tyre-records-card {
+  animation: f1-tyre-records-fade-in 0.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+.f1-tyre-records-card:nth-child(1) { animation-delay: 0.1s; }
+.f1-tyre-records-card:nth-child(2) { animation-delay: 0.2s; }
+.f1-tyre-records-card:nth-child(3) { animation-delay: 0.3s; }
+.f1-tyre-records-card:nth-child(4) { animation-delay: 0.4s; }
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  .f1-tyre-records-wrapper {
+    --f1-primary: #ff0000;
+    --f1-background: #000000;
+    --f1-card-bg: #1a1a1a;
+    --f1-text-primary: #ffffff;
+    --f1-border: #666666;
+  }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .f1-tyre-records-card,
+  .f1-tyre-records-record-item {
+    transition: none;
+    animation: none;
+  }
+
+  .f1-tyre-records-card:hover {
+    transform: none;
+  }
+
+  .f1-tyre-records-record-item:hover {
+    transform: none;
+  }
+}

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/speedLimit.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreStintHistoryModal.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreSetsCards.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/lapSectorRecords.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@10"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/4.4.1/socket.io.min.js"></script>
@@ -526,6 +527,7 @@
     <script src="{{ url_for('static', filename='js/driverDataModalPopulator.js') }}"></script>
     <script src="{{ url_for('static', filename='js/raceStatsModalPopulator.js') }}"></script>
     <script src="{{ url_for('static', filename='js/tyreSetsCards.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/lapSectorRecords.js') }}"></script>
     <script src="{{ url_for('static', filename='js/tyreStintHistoryModal.js') }}"></script>
     <script src="{{ url_for('static', filename='js/modals.js') }}"></script>
     <script src="{{ url_for('static', filename='js/raceTableRowPopulator.js') }}"></script>

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreStintHistoryModal.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreSetsCards.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/lapSectorRecords.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreRecords.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@10"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/4.4.1/socket.io.min.js"></script>
@@ -528,6 +529,7 @@
     <script src="{{ url_for('static', filename='js/raceStatsModalPopulator.js') }}"></script>
     <script src="{{ url_for('static', filename='js/tyreSetsCards.js') }}"></script>
     <script src="{{ url_for('static', filename='js/lapSectorRecords.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/tyreRecords.js') }}"></script>
     <script src="{{ url_for('static', filename='js/tyreStintHistoryModal.js') }}"></script>
     <script src="{{ url_for('static', filename='js/modals.js') }}"></script>
     <script src="{{ url_for('static', filename='js/raceTableRowPopulator.js') }}"></script>

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/modals.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreSetsCards.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/lapSectorRecords.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreRecords.css') }}">
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/4.4.1/socket.io.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
@@ -202,6 +203,7 @@
     <script src="{{ url_for('static', filename='js/driverDataModalPopulator.js') }}"></script>
     <script src="{{ url_for('static', filename='js/tyreSetsCards.js') }}"></script>
     <script src="{{ url_for('static', filename='js/lapSectorRecords.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/tyreRecords.js') }}"></script>
     <script src="{{ url_for('static', filename='js/weatherUI.js') }}"></script>
     <script src="{{ url_for('static', filename='js/engView.js') }}"></script>
 </body>

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/engView.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/modals.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreSetsCards.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/lapSectorRecords.css') }}">
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/4.4.1/socket.io.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
@@ -200,6 +201,7 @@
     <script src="{{ url_for('static', filename='js/graph.js') }}"></script>
     <script src="{{ url_for('static', filename='js/driverDataModalPopulator.js') }}"></script>
     <script src="{{ url_for('static', filename='js/tyreSetsCards.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/lapSectorRecords.js') }}"></script>
     <script src="{{ url_for('static', filename='js/weatherUI.js') }}"></script>
     <script src="{{ url_for('static', filename='js/engView.js') }}"></script>
 </body>

--- a/apps/frontend/js/driverDataModalPopulator.js
+++ b/apps/frontend/js/driverDataModalPopulator.js
@@ -634,71 +634,6 @@ class DriverModalPopulator {
             leftDiv.appendChild(table);
         };
 
-        /* Create and populate the table
-        const leftPanePopulator = (leftDiv) => {
-            const table = document.createElement('table');
-            table.className = this.tableClassNames ;
-
-            // Create table header
-            const thead = document.createElement('thead');
-            const headerRow = document.createElement('tr');
-            const headers = [
-                'Lap',
-                'FL',
-                'FR',
-                'RL',
-                'RR',
-                'Average'
-            ];
-
-            headers.forEach(headerText => {
-                const th = document.createElement('th');
-                th.textContent = headerText;
-                headerRow.appendChild(th);
-            });
-
-            thead.appendChild(headerRow);
-            table.appendChild(thead);
-
-            // Create table body
-            const tbody = document.createElement('tbody');
-            if (predictions.length > 0) {
-                predictions.forEach((predictionData) => {
-                    const currentLapNum = predictionData["lap-number"];
-                    const flWear = formatFloatWithTwoDecimals(predictionData["front-left-wear"]) + "%";
-                    const frWear = formatFloatWithTwoDecimals(predictionData["front-right-wear"]) + "%";
-                    const rlWear = formatFloatWithTwoDecimals(predictionData["rear-left-wear"]) + "%";
-                    const rrWear = formatFloatWithTwoDecimals(predictionData["rear-right-wear"]) + "%";
-                    const average = formatFloatWithTwoDecimals(predictionData["average"]) + "%";
-                    const row = tbody.insertRow();
-                    this.populateTableRow(row, [
-                        currentLapNum,
-                        flWear,
-                        frWear,
-                        rlWear,
-                        rrWear,
-                        average
-                    ]);
-
-                    if (currentLapNum == selectedPitStop) {
-                        row.classList.add('border', 'border-white');
-                    }
-
-                    // update the graph data
-                    graphDataFL.push({ x: parseFloat(currentLapNum), y: predictionData["front-left-wear"], desc: predictionData["desc"] });
-                    graphDataFR.push({ x: parseFloat(currentLapNum), y: predictionData["front-right-wear"], desc: predictionData["desc"] });
-                    graphDataRL.push({ x: parseFloat(currentLapNum), y: predictionData["rear-left-wear"], desc: predictionData["desc"] });
-                    graphDataRR.push({ x: parseFloat(currentLapNum), y: predictionData["rear-right-wear"], desc: predictionData["desc"] });
-                });
-            } else {
-                const row = tbody.insertRow();
-                row.innerHTML = '<td colspan="6">Tyre wear prediction data not available</td>';
-            }
-
-            table.appendChild(tbody);
-            divElement.appendChild(table);
-        };
-
         /* Now create and populate the graph */
         const rightPanePopulator = (rightDiv) => {
             const datasets = [
@@ -944,9 +879,6 @@ class DriverModalPopulator {
             tabs.push({ id: 'tyre-wear-prediction', label: 'Tyre Wear Prediction' });
         }
 
-        // Sort tabs alphabetically based on the label
-        tabs.sort((a, b) => a.label.localeCompare(b.label));
-
         tabs.forEach((tab, index) => {
             const navItem = document.createElement('li');
             navItem.className = 'nav-item';
@@ -994,9 +926,6 @@ class DriverModalPopulator {
         if (this.tyreWearPredictionsAvailable) {
             tabs.push({ id: 'tyre-wear-prediction', method: this.populateTyreWearPredictionTab });
         }
-
-        // Sort tabs alphabetically based on the label
-        tabs.sort((a, b) => a.id.localeCompare(b.id));
 
         tabs.forEach((tab, index) => {
             const tabPane = document.createElement('div');

--- a/apps/frontend/js/driverDataModalPopulator.js
+++ b/apps/frontend/js/driverDataModalPopulator.js
@@ -4,6 +4,7 @@ class DriverModalPopulator {
         this.tableClassNames = 'table table-bordered table-striped table-dark table-sm align-middle';
         this.iconCache = iconCache;
         this.telemetryEnabled = (this.data?.["participant-data"]?.["telemetry-setting"] === "Public");
+        this.tyreWearPredictionsAvailable = this.data?.["tyre-wear-predictions"]?.["status"];
     }
 
     populateLapTimesTab(tabPane) {
@@ -832,7 +833,6 @@ class DriverModalPopulator {
             { id: 'tyre-stint-history', label: 'Tyre Stint History' },
             { id: 'ers-history', label: 'ERS Usage History' },
             { id: 'car-damage', label: 'Car Damage' },
-            { id: 'tyre-wear-prediction', label: 'Tyre Wear Prediction' },
             { id: 'warns-pens-info', label: 'Warns/Pens' },
             { id: 'collisions-info', label: 'Collisions' },
             { id: 'tyre-sets', label: 'Tyre Sets' },
@@ -840,6 +840,10 @@ class DriverModalPopulator {
 
         if ('car-setup' in this.data) {
             tabs.push({ id: 'car-setup', label: 'Car Setup' });
+        }
+
+        if (this.tyreWearPredictionsAvailable) {
+            tabs.push({ id: 'tyre-wear-prediction', label: 'Tyre Wear Prediction' });
         }
 
         // Sort tabs alphabetically based on the label
@@ -880,7 +884,6 @@ class DriverModalPopulator {
             { id: 'tyre-stint-history', method: this.populateTyreStintHistoryTab },
             { id: 'ers-history', method: this.populateERSHistoryTab },
             { id: 'car-damage', method: this.populateCarDamageTab },
-            { id: 'tyre-wear-prediction', method: this.populateTyreWearPredictionTab },
             { id: 'warns-pens-info', method: this.populateWarnsPensInfoTab },
             { id: 'collisions-info', method: this.populateCollisionsInfoTab },
             { id: 'tyre-sets', method: this.populateTyreSetsInfoTab },
@@ -890,6 +893,9 @@ class DriverModalPopulator {
           tabs.push({ id: 'car-setup', method: this.populateCarSetupTab });
         }
 
+        if (this.tyreWearPredictionsAvailable) {
+            tabs.push({ id: 'tyre-wear-prediction', method: this.populateTyreWearPredictionTab });
+        }
 
         // Sort tabs alphabetically based on the label
         tabs.sort((a, b) => a.id.localeCompare(b.id));

--- a/apps/frontend/js/driverDataModalPopulator.js
+++ b/apps/frontend/js/driverDataModalPopulator.js
@@ -879,6 +879,9 @@ class DriverModalPopulator {
             tabs.push({ id: 'tyre-wear-prediction', label: 'Tyre Wear Prediction' });
         }
 
+        // Sort tabs alphabetically based on the label
+        tabs.sort((a, b) => a.id.localeCompare(b.id));
+
         tabs.forEach((tab, index) => {
             const navItem = document.createElement('li');
             navItem.className = 'nav-item';
@@ -926,6 +929,9 @@ class DriverModalPopulator {
         if (this.tyreWearPredictionsAvailable) {
             tabs.push({ id: 'tyre-wear-prediction', method: this.populateTyreWearPredictionTab });
         }
+
+        // Sort tabs alphabetically based on the label
+        tabs.sort((a, b) => a.id.localeCompare(b.id));
 
         tabs.forEach((tab, index) => {
             const tabPane = document.createElement('div');

--- a/apps/frontend/js/lapSectorRecords.js
+++ b/apps/frontend/js/lapSectorRecords.js
@@ -26,8 +26,12 @@ class F1LapSectorRecords {
 
   createElement(tag, className = '', textContent = '') {
     const element = document.createElement(tag);
-    if (className) element.className = className;
-    if (textContent) element.textContent = textContent;
+    if (className) {
+      element.className = className;
+    }
+    if (textContent) {
+      element.textContent = textContent;
+    }
     return element;
   }
 

--- a/apps/frontend/js/lapSectorRecords.js
+++ b/apps/frontend/js/lapSectorRecords.js
@@ -1,0 +1,226 @@
+class F1LapSectorRecords {
+  constructor(containerDiv) {
+    this.container = containerDiv;
+    this.data = null;
+    this.init();
+  }
+
+  init() {
+    this.container.className = 'f1-lapsec-records';
+    this.showLoading();
+  }
+
+  showLoading() {
+    this.container.innerHTML = '';
+    const loadingDiv = this.createElement('div', 'f1-lapsec-records-loading');
+    loadingDiv.textContent = 'Loading records...';
+    this.container.appendChild(loadingDiv);
+  }
+
+  showError(message = 'Error loading records') {
+    this.container.innerHTML = '';
+    const errorDiv = this.createElement('div', 'f1-lapsec-records-error');
+    errorDiv.textContent = message;
+    this.container.appendChild(errorDiv);
+  }
+
+  createElement(tag, className = '', textContent = '') {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    if (textContent) element.textContent = textContent;
+    return element;
+  }
+
+  formatTime(timeStr) {
+    return timeStr || '--:--.---';
+  }
+
+  createHeader() {
+    const header = this.createElement('div', 'f1-lapsec-records-header');
+
+    const title = this.createElement('h1', 'f1-lapsec-records-title', 'Track Records');
+    const subtitle = this.createElement('p', 'f1-lapsec-records-subtitle', 'Fastest Lap & Sector Times');
+
+    header.appendChild(title);
+    header.appendChild(subtitle);
+
+    return header;
+  }
+
+  createFastestLapSection() {
+    const section = this.createElement('div', 'f1-lapsec-records-fastest-lap');
+
+    const sectionTitle = this.createElement('div', 'f1-lapsec-records-section-title');
+    const icon = this.createElement('div', 'f1-lapsec-records-section-icon', '🏆');
+    const titleText = this.createElement('span', '', 'Fastest Lap');
+    sectionTitle.appendChild(icon);
+    sectionTitle.appendChild(titleText);
+
+    if (!this.data.lap) {
+      const noData = this.createElement('div', 'f1-lapsec-records-no-data', 'No fastest lap data available');
+      section.appendChild(sectionTitle);
+      section.appendChild(noData);
+      return section;
+    }
+
+    const driverInfo = this.createElement('div', 'f1-lapsec-records-driver-info');
+
+    const driverDetails = this.createElement('div', 'f1-lapsec-records-driver-details');
+    const driverName = this.createElement('h3', '', this.data.lap['driver-name'] || 'Unknown Driver');
+    const teamName = this.createElement('p', '', this.data.lap['team-id'] || 'Unknown Team');
+    driverDetails.appendChild(driverName);
+    driverDetails.appendChild(teamName);
+
+    const lapInfo = this.createElement('div', 'f1-lapsec-records-lap-info');
+    const time = this.createElement('p', 'f1-lapsec-records-time', this.formatTime(this.data.lap['time-str']));
+    const lapNumber = this.createElement('p', 'f1-lapsec-records-lap-number',
+      this.data.lap['lap-number'] ? `Lap ${this.data.lap['lap-number']}` : 'Lap --');
+    lapInfo.appendChild(time);
+    lapInfo.appendChild(lapNumber);
+
+    driverInfo.appendChild(driverDetails);
+    driverInfo.appendChild(lapInfo);
+
+    const stats = this.createElement('div', 'f1-lapsec-records-stats');
+
+    const teamStat = this.createElement('div', 'f1-lapsec-records-stat');
+    const teamLabel = this.createElement('p', 'f1-lapsec-records-stat-label', 'Team');
+    const teamValue = this.createElement('p', 'f1-lapsec-records-stat-value', this.data.lap['team-id'] || 'Unknown');
+    teamStat.appendChild(teamLabel);
+    teamStat.appendChild(teamValue);
+
+    const lapStat = this.createElement('div', 'f1-lapsec-records-stat');
+    const lapLabel = this.createElement('p', 'f1-lapsec-records-stat-label', 'Lap');
+    const lapValue = this.createElement('p', 'f1-lapsec-records-stat-value',
+      this.data.lap['lap-number'] ? this.data.lap['lap-number'].toString() : '--');
+    lapStat.appendChild(lapLabel);
+    lapStat.appendChild(lapValue);
+
+    const timeStat = this.createElement('div', 'f1-lapsec-records-stat');
+    const timeLabel = this.createElement('p', 'f1-lapsec-records-stat-label', 'Time');
+    const timeValue = this.createElement('p', 'f1-lapsec-records-stat-value', this.formatTime(this.data.lap['time-str']));
+    timeStat.appendChild(timeLabel);
+    timeStat.appendChild(timeValue);
+
+    stats.appendChild(teamStat);
+    stats.appendChild(lapStat);
+    stats.appendChild(timeStat);
+
+    section.appendChild(sectionTitle);
+    section.appendChild(driverInfo);
+    section.appendChild(stats);
+
+    return section;
+  }
+
+  createSectorRecord(sectorData, sectorName) {
+    const sector = this.createElement('div', 'f1-lapsec-records-sector');
+
+    const header = this.createElement('div', 'f1-lapsec-records-sector-header');
+    const label = this.createElement('h4', 'f1-lapsec-records-sector-label', sectorName);
+
+    if (!sectorData) {
+      const time = this.createElement('p', 'f1-lapsec-records-sector-time', '--:--.---');
+      header.appendChild(label);
+      header.appendChild(time);
+
+      const driver = this.createElement('p', 'f1-lapsec-records-sector-driver', 'No Data');
+      const team = this.createElement('p', 'f1-lapsec-records-sector-team', '--');
+
+      sector.appendChild(header);
+      sector.appendChild(driver);
+      sector.appendChild(team);
+
+      return sector;
+    }
+
+    const time = this.createElement('p', 'f1-lapsec-records-sector-time', this.formatTime(sectorData['time-str']));
+    header.appendChild(label);
+    header.appendChild(time);
+
+    const driver = this.createElement('p', 'f1-lapsec-records-sector-driver',
+      sectorData['driver-name'] || 'Unknown Driver');
+    const team = this.createElement('p', 'f1-lapsec-records-sector-team',
+      sectorData['team-id'] || 'Unknown Team');
+
+    sector.appendChild(header);
+    sector.appendChild(driver);
+    sector.appendChild(team);
+
+    return sector;
+  }
+
+  createSectorsSection() {
+    const sectorsContainer = this.createElement('div', 'f1-lapsec-records-sectors');
+
+    const s1 = this.createSectorRecord(this.data.s1, 'Sector 1');
+    sectorsContainer.appendChild(s1);
+
+    const s2 = this.createSectorRecord(this.data.s2, 'Sector 2');
+    sectorsContainer.appendChild(s2);
+
+    const s3 = this.createSectorRecord(this.data.s3, 'Sector 3');
+    sectorsContainer.appendChild(s3);
+
+    return sectorsContainer;
+  }
+
+  render() {
+    this.container.innerHTML = '';
+
+    const header = this.createHeader();
+    this.container.appendChild(header);
+
+    const grid = this.createElement('div', 'f1-lapsec-records-grid');
+
+    const fastestLap = this.createFastestLapSection();
+    grid.appendChild(fastestLap);
+
+    const sectors = this.createSectorsSection();
+    grid.appendChild(sectors);
+
+    this.container.appendChild(grid);
+  }
+
+  updateData(newData) {
+    try {
+      if (!newData || typeof newData !== 'object') {
+        throw new Error('Invalid data format');
+      }
+
+      // Ensure all required keys exist, even if null
+      this.data = {
+        lap: newData.lap || null,
+        s1: newData.s1 || null,
+        s2: newData.s2 || null,
+        s3: newData.s3 || null
+      };
+
+      this.render();
+    } catch (error) {
+      console.error('Error updating F1 records:', error);
+      this.showError('Error updating records');
+    }
+  }
+
+  // Public method to update with new data
+  update(data) {
+    this.updateData(data);
+  }
+
+  // Method to get current data
+  getData() {
+    return this.data;
+  }
+
+  // Method to clear the display
+  clear() {
+    this.container.innerHTML = '';
+    this.data = null;
+  }
+
+  // Static method to create instance
+  static create(containerDiv) {
+    return new F1LapSectorRecords(containerDiv);
+  }
+}

--- a/apps/frontend/js/raceStatsModalPopulator.js
+++ b/apps/frontend/js/raceStatsModalPopulator.js
@@ -82,56 +82,8 @@ class RaceStatsModalPopulator {
     populateLapTimeRecordsTab(tabPane) {
 
         const containerDiv = document.createElement('div');
-        containerDiv.className = 'd-flex table-responsive';
-
-        const table = document.createElement('table');
-        table.className = this.tableClassNames;
-
-        // Create table header
-        const thead = document.createElement('thead');
-        const headerRow = document.createElement('tr');
-        const headers = [
-            'Category',
-            'Driver',
-            'Team',
-            'Lap',
-            'Time',
-        ];
-
-        headers.forEach(headerText => {
-            const th = document.createElement('th');
-            th.textContent = headerText;
-            th.setAttribute('scope', 'col');  // Adds semantic meaning
-            th.className = 'text-nowrap';     // Prevents text wrapping
-            headerRow.appendChild(th);
-        });
-
-        thead.appendChild(headerRow);
-        table.appendChild(thead);
-
-        // Create table body
-        const timesRecordsTableBody = document.createElement('tbody');
-
-        if (this.isFastestRecordAvailable(this.data)) {
-            if ('lap' in this.data["records"]["fastest"]) {
-                this.insertFastestRow(this.data, timesRecordsTableBody, "Lap", "lap");
-            }
-            if ('s1' in this.data["records"]["fastest"]) {
-                this.insertFastestRow(this.data, timesRecordsTableBody, "Sector 1", "s1");
-            }
-            if ('s2' in this.data["records"]["fastest"]) {
-                this.insertFastestRow(this.data, timesRecordsTableBody, "Sector 2", "s2");
-            }
-            if ('s3' in this.data["records"]["fastest"]) {
-                this.insertFastestRow(this.data, timesRecordsTableBody, "Sector 3", "s3");
-            }
-        } else {
-            const row = timesRecordsTableBody.insertRow();
-            row.innerHTML = '<td colspan="5">Fastest Times Records data not available</td>';
-        }
-
-        table.appendChild(timesRecordsTableBody);
-        containerDiv.appendChild(table);
+        const records = new F1LapSectorRecords(containerDiv);
+        records.update(this.data["records"]["fastest"]);
         tabPane.appendChild(containerDiv);
     }
 

--- a/apps/frontend/js/raceStatsModalPopulator.js
+++ b/apps/frontend/js/raceStatsModalPopulator.js
@@ -147,48 +147,8 @@ class RaceStatsModalPopulator {
     populateTyreStintRecordsTab(tabPane) {
 
         const containerDiv = document.createElement('div');
-        containerDiv.className = 'd-flex table-responsive';
-
-        const table = document.createElement('table');
-        table.className = this.tableClassNames;
-
-        // Create table header
-        const thead = document.createElement('thead');
-        const headerRow = document.createElement('tr');
-        const headers = [
-            'Compound',
-            'Category',
-            'Driver',
-            'Record',
-        ];
-
-        headers.forEach(headerText => {
-            const th = document.createElement('th');
-            th.textContent = headerText;
-            headerRow.appendChild(th);
-        });
-
-        thead.appendChild(headerRow);
-        table.appendChild(thead);
-
-        // Create table body
-        const tyreStintRecordsTableBody = document.createElement('tbody');
-        if ("records" in this.data && 'tyre-stats' in this.data["records"] && this.data["records"]["tyre-stats"] != null &&
-            !this.isObjectEmpty(this.data["records"]["tyre-stats"])) {
-
-            const tyreStats = this.data["records"]["tyre-stats"];
-            for (let compound in tyreStats) {
-                const compoundRecords = tyreStats[compound];
-                this.insertTyreStintRecordRow(tyreStintRecordsTableBody, compound, compoundRecords);
-            }
-
-        } else {
-            const row = tyreStintRecordsTableBody.insertRow();
-            row.innerHTML = '<td colspan="4">Tyre Stint Records data not available</td>';
-        }
-
-        table.appendChild(tyreStintRecordsTableBody);
-        containerDiv.appendChild(table);
+        const records = new F1TyreRecords(containerDiv, this.iconCache);
+        records.update(this.data["records"]["tyre-stats"]);
         tabPane.appendChild(containerDiv);
     }
 

--- a/apps/frontend/js/tyreRecords.js
+++ b/apps/frontend/js/tyreRecords.js
@@ -1,0 +1,202 @@
+class F1TyreRecords {
+  constructor(container, iconCache) {
+    this.container = container;
+    this.iconCache = iconCache;
+    this.data = null;
+    this.init();
+  }
+
+  init() {
+    // Clear the container completely
+    this.container.innerHTML = '';
+
+    // Create main wrapper
+    this.wrapper = document.createElement('div');
+    this.wrapper.className = 'f1-tyre-records-wrapper';
+    this.container.appendChild(this.wrapper);
+
+    // Create content container (no header)
+    this.contentContainer = document.createElement('div');
+    this.contentContainer.className = 'f1-tyre-records-content';
+    this.wrapper.appendChild(this.contentContainer);
+  }
+
+  update(data) {
+    console.log('F1TyreRecords.update called with data:', data);
+    this.data = data;
+    this.render();
+  }
+
+  render() {
+    console.log('F1TyreRecords.render called, data:', this.data);
+
+    // Clear content
+    this.contentContainer.innerHTML = '';
+
+    if (!this.data || Object.keys(this.data).length === 0) {
+      console.log('No data available, showing empty state');
+      this.showEmptyState();
+      return;
+    }
+
+    // Create grid container
+    const grid = document.createElement('div');
+    grid.className = 'f1-tyre-records-grid';
+    this.contentContainer.appendChild(grid);
+
+    // Sort tyre compounds by actual compound (C1, C2, C3, etc.)
+    const sortedEntries = Object.entries(this.data).sort(([a], [b]) => {
+      const aCompound = a.split(' - ')[0];
+      const bCompound = b.split(' - ')[0];
+      return aCompound.localeCompare(bCompound);
+    });
+
+    // Process each tyre compound in sorted order
+    sortedEntries.forEach(([tyreType, records]) => {
+      console.log('Processing tyre type:', tyreType, 'with records:', records);
+      const card = this.createTyreCard(tyreType, records);
+      grid.appendChild(card);
+    });
+  }
+
+  createTyreCard(tyreType, records) {
+    const [actualCompound, visualCompound] = tyreType.split(' - ');
+    console.log('Creating card for:', { actualCompound, visualCompound, records });
+
+    const card = document.createElement('div');
+    card.className = 'f1-tyre-records-card';
+
+    // Card header with tyre info
+    const cardHeader = document.createElement('div');
+    cardHeader.className = 'f1-tyre-records-card-header';
+
+    const tyreInfo = document.createElement('div');
+    tyreInfo.className = 'f1-tyre-records-tyre-info';
+
+    // Try to get icon from cache
+    let iconElement = null;
+    if (this.iconCache && typeof this.iconCache.getIcon === 'function') {
+      try {
+        const icon = this.iconCache.getIcon(visualCompound);
+        if (icon) {
+          iconElement = document.createElement('div');
+          iconElement.className = 'f1-tyre-records-tyre-icon';
+          iconElement.appendChild(icon);
+        }
+      } catch (e) {
+        console.log('Icon not found for', visualCompound, 'using fallback');
+      }
+    }
+
+    // Fallback if no icon
+    if (!iconElement) {
+      iconElement = document.createElement('div');
+      iconElement.className = 'f1-tyre-records-tyre-icon';
+      iconElement.innerHTML = `<span class="f1-tyre-records-tyre-icon-fallback">${visualCompound.charAt(0)}</span>`;
+    }
+
+    const tyreText = document.createElement('div');
+    tyreText.className = 'f1-tyre-records-tyre-text';
+
+    const compoundName = document.createElement('h3');
+    compoundName.className = 'f1-tyre-records-compound-name';
+    compoundName.textContent = visualCompound.toUpperCase(); // Make uppercase
+
+    const compoundCode = document.createElement('span');
+    compoundCode.className = 'f1-tyre-records-compound-code';
+    compoundCode.textContent = actualCompound;
+
+    tyreText.appendChild(compoundName);
+    tyreText.appendChild(compoundCode);
+
+    tyreInfo.appendChild(iconElement);
+    tyreInfo.appendChild(tyreText);
+    cardHeader.appendChild(tyreInfo);
+    card.appendChild(cardHeader);
+
+    // Card body with records
+    const cardBody = document.createElement('div');
+    cardBody.className = 'f1-tyre-records-card-body';
+
+    // Process each record type with Bootstrap icons
+    const recordTypes = [
+      { key: 'highest-tyre-wear', label: 'Highest Wear', unit: '%', icon: 'bi-arrow-up-circle' },
+      { key: 'longest-tyre-stint', label: 'Longest Stint', unit: ' laps', icon: 'bi-stopwatch' },
+      { key: 'lowest-tyre-wear-per-lap', label: 'Lowest Wear/Lap', unit: '%', icon: 'bi-arrow-down-circle' }
+    ];
+
+    recordTypes.forEach(recordType => {
+      if (records[recordType.key]) {
+        const recordItem = this.createRecordItem(recordType, records[recordType.key]);
+        cardBody.appendChild(recordItem);
+      }
+    });
+
+    card.appendChild(cardBody);
+    return card;
+  }
+
+  createRecordItem(recordType, recordData) {
+    const item = document.createElement('div');
+    item.className = 'f1-tyre-records-record-item';
+
+    const iconContainer = document.createElement('div');
+    iconContainer.className = 'f1-tyre-records-record-icon';
+
+    // Use Bootstrap icon
+    const icon = document.createElement('i');
+    icon.className = recordType.icon;
+    iconContainer.appendChild(icon);
+
+    const content = document.createElement('div');
+    content.className = 'f1-tyre-records-record-content';
+
+    const label = document.createElement('div');
+    label.className = 'f1-tyre-records-record-label';
+    label.textContent = recordType.label;
+
+    const driver = document.createElement('div');
+    driver.className = 'f1-tyre-records-record-driver';
+    driver.textContent = recordData['driver-name'];
+
+    const value = document.createElement('div');
+    value.className = 'f1-tyre-records-record-value';
+
+    // Format value based on type - integers for stint length, decimals for others
+    let formattedValue;
+    if (recordType.key === 'longest-tyre-stint') {
+      formattedValue = Math.round(recordData.value);
+    } else {
+      formattedValue = typeof recordData.value === 'number'
+        ? recordData.value.toFixed(2)
+        : recordData.value;
+    }
+    value.textContent = formattedValue + recordType.unit;
+
+    content.appendChild(label);
+    content.appendChild(driver);
+
+    item.appendChild(iconContainer);
+    item.appendChild(content);
+    item.appendChild(value);
+
+    return item;
+  }
+
+  showEmptyState() {
+    const emptyState = document.createElement('div');
+    emptyState.className = 'f1-tyre-records-empty-state';
+
+    const emptyIcon = document.createElement('div');
+    emptyIcon.className = 'f1-tyre-records-empty-icon';
+    emptyIcon.textContent = '🏎️';
+
+    const emptyText = document.createElement('p');
+    emptyText.className = 'f1-tyre-records-empty-text';
+    emptyText.textContent = 'No tyre records available';
+
+    emptyState.appendChild(emptyIcon);
+    emptyState.appendChild(emptyText);
+    this.contentContainer.appendChild(emptyState);
+  }
+}

--- a/apps/frontend/js/tyreRecords.js
+++ b/apps/frontend/js/tyreRecords.js
@@ -92,7 +92,11 @@ class F1TyreRecords {
     if (!iconElement) {
       iconElement = document.createElement('div');
       iconElement.className = 'f1-tyre-records-tyre-icon';
-      iconElement.innerHTML = `<span class="f1-tyre-records-tyre-icon-fallback">${visualCompound.charAt(0)}</span>`;
+
+      const fallbackIcon = document.createElement('span');
+      fallbackIcon.className = 'f1-tyre-records-tyre-icon-fallback';
+      fallbackIcon.textContent = visualCompound.charAt(0);
+      iconElement.appendChild(fallbackIcon);
     }
 
     const tyreText = document.createElement('div');

--- a/apps/save_viewer/telemetry_post_race_data_viewer.py
+++ b/apps/save_viewer/telemetry_post_race_data_viewer.py
@@ -640,7 +640,7 @@ def handleRaceInfoRequest() -> Tuple[Dict[str, Any], HTTPStatus]:
         ret = {
             "session-info" : g_json_data["session-info"],
             "records" : g_json_data.get("records", None),
-            "classification-data" : g_json_data.get("classification-data", None),
+            # "classification-data" : g_json_data.get("classification-data", None), # TODO - remove
             "overtakes" : g_json_data.get("overtakes", None),
             "custom-markers" : g_json_data.get("custom-markers", []),
             "position-history" : g_json_data.get("position-history", []),


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Added improved charts in race info stats for lap/sector records and tyre stint records
![image](https://github.com/user-attachments/assets/60ad22eb-d535-4792-8a2a-2e4cfd473bfb)
![image](https://github.com/user-attachments/assets/e822e8eb-dbd8-48ce-9497-201abcdd23b8)

Made the tyre wear prediction tab show up only when data is available and added a chart
![image](https://github.com/user-attachments/assets/b6f66672-078f-43cd-b832-eadd0a5a1b41)

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Unit Tests

- [x] All unit tests pass
- Attach test command/output (e.g., `poetry run python tests/unit_tests.py`):

```
----------------------------------------------------------------------
Ran 240 tests in 9.486s

OK
```

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output (e.g., `poetry run python tests/integration_test/runner.py `):

```
===== TEST RESULTS =====
Passed: 13/13
PASS: f1_23_sp_austria.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
```

### ✅ Pylint

* [x] Code passes `pylint`
* Paste summary report:

```
$ pylint --rcfile scripts/.pylintrc lib apps

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

To run pylint
```
pylint --rcfile scripts/.pylintrc lib apps
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
<details>
<summary>Click to expand</summary>

Explain what was added/updated, or write "N/A" if not applicable.

</details>
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Enhance the frontend to display rich charts for lap/sector records, tyre-stint records, and tyre wear predictions, refactor modal populator logic to use reusable components, and streamline backend responses by standardizing record data and removing unused fields.

New Features:
- Add F1LapSectorRecords and F1TyreRecords components with dedicated CSS/JS for enhanced lap, sector, and tyre-stint record visualizations
- Introduce dynamic tyre wear prediction chart in driver modal and display its tab conditionally based on data availability

Bug Fixes:
- Remove unused 'classification-data' key from telemetry API and post‐race data viewer

Enhancements:
- Refactor race stats modal to use new record components instead of manual table construction
- Simplify backend getRaceInfo to always supply records and remove obsolete classification-data from responses

Chores:
- Update HTML templates to include new CSS and JS assets for lap/sector and tyre record components