### PR TITLE
Tyre stint hist fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,8 @@
             "module": "apps.backend.pits_n_giggles",
             "console": "integratedTerminal",
             "args": [
-                "--debug"
+                "--debug",
+                "--log-file-name", "png_backend_debug.log"
             ],
             "cwd": "${workspaceFolder}"
         },
@@ -44,7 +45,8 @@
             "console": "integratedTerminal",
             "args": [
                 "--debug",
-                "--replay-server"
+                "--replay-server",
+                "--log-file-name", "png_backend_debug.log"
             ],
             "cwd": "${workspaceFolder}"
         },

--- a/apps/backend/pits_n_giggles.py
+++ b/apps/backend/pits_n_giggles.py
@@ -70,6 +70,7 @@ class PngRunner:
             udp_custom_action_code=self.m_config.Network.udp_custom_action_code,
             udp_tyre_delta_action_code=self.m_config.Network.udp_tyre_delta_action_code,
             forwarding_targets=self.m_config.Forwarding.forwarding_targets,
+            ver_str=self.m_version,
             tasks=self.m_tasks
         )
         self.m_web_server = self._setupUiIntfLayer(

--- a/apps/backend/state_mgmt_layer/data_per_driver/__init__.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/__init__.py
@@ -20,14 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .tyre_info import TyreSetInfo, TyreSetHistoryEntry, TyreSetHistoryManager, TyreInfo
-from .warns_pens_info import WarningPenaltyEntry, WarningPenaltyHistory
-from .per_lap_snapshot import PerLapSnapshotEntry
+from .car_info import CarInfo
+from .data_per_driver import DataPerDriver
 from .driver_info import DriverInfo
 from .lap_info import LapInfo
 from .packet_copies import PacketCopies
-from .car_info import CarInfo
-from .data_per_driver import DataPerDriver
+from .pending_events import DriverPendingEvents
+from .per_lap_snapshot import PerLapSnapshotEntry
+from .tyre_info import (TyreInfo, TyreSetHistoryEntry, TyreSetHistoryManager,
+                        TyreSetInfo)
+from .warns_pens_info import WarningPenaltyEntry, WarningPenaltyHistory
 
 __all__ = [
     'TyreSetInfo',
@@ -49,4 +51,6 @@ __all__ = [
     'CarInfo',
 
     'DataPerDriver',
+
+    'DriverPendingEvents',
 ]

--- a/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
@@ -587,8 +587,8 @@ class DataPerDriver:
             return
 
         # This can happen if tyre sets packets arrives before lap data packet
+        fitted_tyre_set_key = self._getCurrentTyreSetKey()
         if self.m_lap_info.m_current_lap is not None:
-            fitted_tyre_set_key = self._getCurrentTyreSetKey()
             if not self.m_tyre_info.m_tyre_set_history_manager.length:
                 if 0 in self.m_per_lap_snapshots:
                     # Start of race, enter the tyre wear data along with starting value
@@ -668,12 +668,11 @@ class DataPerDriver:
         """
 
         curr_is_pitting = lap_data.m_pitStatus in {LapData.PitStatus.PITTING, LapData.PitStatus.IN_PIT_AREA}
-        if not self.m_lap_info.m_is_pitting and curr_is_pitting:
+        if not self.m_lap_info.m_is_pitting and curr_is_pitting and F1Utils.isFinishLineAfterPitGarage(track):
             # entering pits
-            if F1Utils.isFinishLineAfterPitGarage(track):
-                # note down curr tyre wear for delayed tyre set change handling
-                # take a deepcopy since this obj is volatile
-                self.m_pending_events_data = deepcopy(self.m_tyre_info.tyre_wear)
+            # note down curr tyre wear for delayed tyre set change handling
+            # take a deepcopy since this obj is volatile
+            self.m_pending_events_data = deepcopy(self.m_tyre_info.tyre_wear)
 
         self.m_lap_info.m_is_pitting = lap_data.m_pitStatus in \
                 [LapData.PitStatus.PITTING, LapData.PitStatus.IN_PIT_AREA]

--- a/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
@@ -597,27 +597,37 @@ class DataPerDriver:
                                                 initial_tyre_wear=initial_tyre_wear,
                     ))
             elif fitted_index != self.m_tyre_info.m_tyre_set_history_manager.getLastEntry().m_fitted_index:
-                lap_number = self.m_lap_info.m_current_lap - 1
-                # create a new tyre set entry with initial data.
-                initial_tyre_wear = TyreWearPerLap(
-                    fl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_LEFT],
-                    fr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_RIGHT],
-                    rl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_LEFT],
-                    rr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_RIGHT],
-                    lap_number=lap_number,
-                    is_racing_lap=True,
-                    desc=f"tyre set change detected. key={str(fitted_tyre_set_key)}"
-                )
-                self.m_tyre_info.m_tyre_set_history_manager.add(TyreSetHistoryEntry(
-                                            start_lap=lap_number,
-                                            index=fitted_index,
-                                            tyre_set_key=fitted_tyre_set_key,
-                                            initial_tyre_wear=initial_tyre_wear,
-                ))
+                self.onTyreSetChange(fitted_index, fitted_tyre_set_key, "tyre set change detected")
 
-                # Tyre set change detected. clear the extrapolation data
-                self.m_tyre_info.m_tyre_wear_extrapolator.clear()
-                self.m_tyre_info.m_tyre_wear_extrapolator.add(initial_tyre_wear)
+    def onTyreSetChange(self, fitted_index: int, fitted_tyre_set_key: str, reason: str) -> None:
+        """Update the tyre set history list, if required.
+
+        Args:
+            fitted_index (int): The fitted tyre set index
+            fitted_tyre_set_key (str): The fitted tyre set key
+            reason (str): The reason for the tyre set change
+        """
+        lap_number = self.m_lap_info.m_current_lap - 1
+        # create a new tyre set entry with initial data.
+        initial_tyre_wear = TyreWearPerLap(
+            fl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_LEFT],
+            fr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_RIGHT],
+            rl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_LEFT],
+            rr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_RIGHT],
+            lap_number=lap_number,
+            is_racing_lap=True,
+            desc=f"{reason}. key={str(fitted_tyre_set_key)}"
+        )
+        self.m_tyre_info.m_tyre_set_history_manager.add(TyreSetHistoryEntry(
+                                    start_lap=lap_number,
+                                    index=fitted_index,
+                                    tyre_set_key=fitted_tyre_set_key,
+                                    initial_tyre_wear=initial_tyre_wear,
+        ))
+
+        # Tyre set change detected. clear the extrapolation data
+        self.m_tyre_info.m_tyre_wear_extrapolator.clear()
+        self.m_tyre_info.m_tyre_wear_extrapolator.add(initial_tyre_wear)
 
     def _getCurrentTyreSetKey(self) -> Optional[str]:
         """Get the unique ID key for the currently equipped tyre set

--- a/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
@@ -23,18 +23,21 @@
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from copy import deepcopy
 
 from apps.backend.common.png_logger import getLogger
 from lib.collisions_analyzer import (CollisionAnalyzer, CollisionAnalyzerMode,
                                      CollisionRecord)
-from lib.f1_types import (F1Utils, LapData, SafetyCarType, SessionType23, PacketLapPositionsData, TrackID,
-                          SessionType24, TelemetrySetting)
+from lib.f1_types import (F1Utils, LapData, PacketLapPositionsData,
+                          SafetyCarType, SessionType23, SessionType24,
+                          TelemetrySetting, TrackID)
 from lib.tyre_wear_extrapolator import TyreWearPerLap
 
 from .car_info import CarInfo
 from .driver_info import DriverInfo
 from .lap_info import LapInfo
 from .packet_copies import PacketCopies
+from .pending_events import DriverPendingEvents, PendingEventsManager
 from .per_lap_snapshot import PerLapSnapshotEntry
 from .tyre_info import TyreInfo, TyreSetHistoryEntry, TyreSetInfo
 from .warns_pens_info import WarningPenaltyHistory
@@ -73,7 +76,9 @@ class DataPerDriver:
         "m_per_lap_snapshots",
         "m_latest_snapshot_lap_num",
         "m_position_history",
-        )
+        "m_pending_events_mgr",
+        "m_pending_events_data",
+    )
 
     def __repr__(self) -> str:
         """Get the string representation of this object
@@ -119,6 +124,12 @@ class DataPerDriver:
             self.m_position_history: List[int] = [0] * (total_laps + 1) # +1 for zeroth lap
         else:
             self.m_position_history: List[int] = None
+
+        # Pending events
+        self.m_pending_events_mgr: PendingEventsManager = PendingEventsManager(
+            callback=self._delayedTyreSetsChange
+        )
+        self.m_pending_events_data: Optional[Any] = None
 
     @property
     def is_valid(self) -> bool:
@@ -597,27 +608,46 @@ class DataPerDriver:
                                                 initial_tyre_wear=initial_tyre_wear,
                     ))
             elif fitted_index != self.m_tyre_info.m_tyre_set_history_manager.getLastEntry().m_fitted_index:
-                self.onTyreSetChange(fitted_index, fitted_tyre_set_key, "tyre set change detected")
+                # Tyre set change detected
+                if F1Utils.isFinishLineAfterPitGarage(track):
+                    # In these tracks, the tyre set change happens before lap completion. this causes the prev lap's
+                    # tyre wear data could get lost. Hence, the tyre set change operation is delayed and handled after
+                    #     - lap change
+                    #     - car damage packet (new updated tyre wear for the new tyre set)
+                    if not self.m_pending_events_mgr.areEventsPending():
+                        png_logger.debug("Driver %s - lap %d tyre set change detected. Registering for delayed handling",
+                                        str(self), self.m_lap_info.m_current_lap)
+                        self.m_pending_events_mgr.register(
+                            events={DriverPendingEvents.CAR_DMG_PKT_EVENT, DriverPendingEvents.LAP_CHANGE_EVENT},
+                            initial_tyre_wear=self.m_pending_events_data)
+                        self.m_pending_events_data = None
+                else:
+                    initial_tyre_wear = TyreWearPerLap(
+                        fl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_LEFT],
+                        fr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_RIGHT],
+                        rl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_LEFT],
+                        rr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_RIGHT],
+                        lap_number=self.m_lap_info.m_current_lap-1, # -1 because this is the end of last lap value
+                        is_racing_lap=True,
+                        desc=f"tyre set change detected. key={str(fitted_tyre_set_key)}"
+                    )
+                    self.onTyreSetChange(
+                        fitted_index=fitted_index,
+                        fitted_tyre_set_key=fitted_tyre_set_key,
+                        lap_number=self.m_lap_info.m_current_lap,
+                        initial_tyre_wear=initial_tyre_wear
+                    )
 
-    def onTyreSetChange(self, fitted_index: int, fitted_tyre_set_key: str, reason: str) -> None:
+    def onTyreSetChange(self, fitted_index: int, fitted_tyre_set_key: str, lap_number: int, initial_tyre_wear: TyreWearPerLap) -> None:
         """Update the tyre set history list, if required.
 
         Args:
             fitted_index (int): The fitted tyre set index
             fitted_tyre_set_key (str): The fitted tyre set key
-            reason (str): The reason for the tyre set change
+            lap_number (int): The lap number
+            initial_tyre_wear (TyreWearPerLap): The initial tyre wear
         """
-        lap_number = self.m_lap_info.m_current_lap - 1
-        # create a new tyre set entry with initial data.
-        initial_tyre_wear = TyreWearPerLap(
-            fl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_LEFT],
-            fr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_RIGHT],
-            rl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_LEFT],
-            rr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_RIGHT],
-            lap_number=lap_number,
-            is_racing_lap=True,
-            desc=f"{reason}. key={str(fitted_tyre_set_key)}"
-        )
+
         self.m_tyre_info.m_tyre_set_history_manager.add(TyreSetHistoryEntry(
                                     start_lap=lap_number,
                                     index=fitted_index,
@@ -628,6 +658,57 @@ class DataPerDriver:
         # Tyre set change detected. clear the extrapolation data
         self.m_tyre_info.m_tyre_wear_extrapolator.clear()
         self.m_tyre_info.m_tyre_wear_extrapolator.add(initial_tyre_wear)
+
+    def processPittingStatus(self, lap_data: LapData, track: TrackID) -> None:
+        """Process the pit status data
+
+        Args:
+            lap_data (LapData): The lap data
+            track (TrackID): The track ID enum
+        """
+
+        curr_is_pitting = lap_data.m_pitStatus in {LapData.PitStatus.PITTING, LapData.PitStatus.IN_PIT_AREA}
+        if not self.m_lap_info.m_is_pitting and curr_is_pitting:
+            # entering pits
+            if F1Utils.isFinishLineAfterPitGarage(track):
+                # note down curr tyre wear for delayed tyre set change handling
+                # take a deepcopy since this obj is volatile
+                self.m_pending_events_data = deepcopy(self.m_tyre_info.tyre_wear)
+
+        self.m_lap_info.m_is_pitting = lap_data.m_pitStatus in \
+                [LapData.PitStatus.PITTING, LapData.PitStatus.IN_PIT_AREA]
+        self.m_driver_info.m_num_pitstops = lap_data.m_numPitStops
+
+    def _delayedTyreSetsChange(self, initial_tyre_wear: TyreWearPerLap) -> None:
+        """Process the delayed tyre set change
+
+        Args:
+            initial_tyre_wear (TyreWearPerLap): The initial tyre wear data
+        """
+
+        png_logger.debug("Driver %s - processing delayed tyre set change", str(self))
+        initial_tyre_wear.lap_number = self.m_lap_info.m_current_lap - 1
+        tyre_set_key = self.m_packet_copies.m_packet_tyre_sets.getFittedTyreSetKey()
+        initial_tyre_wear.desc = f"Delayed tyre set change. old tyre val. key={tyre_set_key}"
+
+        # First, overwrite the end of lap-1 snapshot's tyre wear
+        self.m_tyre_info.m_tyre_set_history_manager.overwriteLatestTyreWear(initial_tyre_wear)
+
+        initial_tyre_wear = TyreWearPerLap(
+            fl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_LEFT],
+            fr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_RIGHT],
+            rl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_LEFT],
+            rr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_RIGHT],
+            lap_number=self.m_lap_info.m_current_lap-1, # -1 because this is the end of last lap value
+            is_racing_lap=True,
+            desc=f"Delayed tyre set change. new tyre val. key={str(self.m_packet_copies.m_packet_tyre_sets.getFittedTyreSetKey())}"
+        )
+        self.onTyreSetChange(
+            fitted_index=self.m_packet_copies.m_packet_tyre_sets.m_fittedIdx,
+            fitted_tyre_set_key=tyre_set_key,
+            lap_number=self.m_lap_info.m_current_lap,
+            initial_tyre_wear=initial_tyre_wear
+        )
 
     def _getCurrentTyreSetKey(self) -> Optional[str]:
         """Get the unique ID key for the currently equipped tyre set

--- a/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
@@ -597,21 +597,19 @@ class DataPerDriver:
                                                 initial_tyre_wear=initial_tyre_wear,
                     ))
             elif fitted_index != self.m_tyre_info.m_tyre_set_history_manager.getLastEntry().m_fitted_index:
-
-                tyre_change_lap_num = self.m_lap_info.m_current_lap if F1Utils.isFinishLineAfterPitGarage(track) \
-                                        else self.m_lap_info.m_current_lap - 1
+                lap_number = self.m_lap_info.m_current_lap - 1
                 # create a new tyre set entry with initial data.
                 initial_tyre_wear = TyreWearPerLap(
                     fl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_LEFT],
                     fr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_FRONT_RIGHT],
                     rl_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_LEFT],
                     rr_tyre_wear=self.m_packet_copies.m_packet_car_damage.m_tyresWear[F1Utils.INDEX_REAR_RIGHT],
-                    lap_number=tyre_change_lap_num,
+                    lap_number=lap_number,
                     is_racing_lap=True,
                     desc=f"tyre set change detected. key={str(fitted_tyre_set_key)}"
                 )
                 self.m_tyre_info.m_tyre_set_history_manager.add(TyreSetHistoryEntry(
-                                            start_lap=self.m_lap_info.m_current_lap, # new
+                                            start_lap=lap_number,
                                             index=fitted_index,
                                             tyre_set_key=fitted_tyre_set_key,
                                             initial_tyre_wear=initial_tyre_wear,

--- a/apps/backend/state_mgmt_layer/data_per_driver/pending_events.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/pending_events.py
@@ -23,7 +23,7 @@
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
 from enum import Enum, auto
-from typing import Any, Callable, Set, Tuple, Dict
+from typing import Any, Callable, Set, Dict
 
 # -------------------------------------- CLASS DEFINITIONS -------------------------------------------------------------
 
@@ -70,9 +70,6 @@ class PendingEventsManager:
         Args:
             events (Set[DriverPendingEvents]): Events that must occur before the callback is triggered.
             **kwargs (Any): Keyword arguments to pass to the callback.
-
-        Returns:
-            None
         """
         self._pending_events = set(events)
         self._callback_kwargs = kwargs
@@ -85,9 +82,6 @@ class PendingEventsManager:
 
         Args:
             event (DriverPendingEvents): The event that occurred.
-
-        Returns:
-            None
         """
         if event not in self._pending_events:
             return

--- a/apps/backend/state_mgmt_layer/data_per_driver/pending_events.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/pending_events.py
@@ -1,0 +1,107 @@
+# MIT License
+#
+# Copyright (c) [2025] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------- IMPORTS -----------------------------------------------------------------------
+
+from enum import Enum, auto
+from typing import Any, Callable, Set, Tuple, Dict
+
+# -------------------------------------- CLASS DEFINITIONS -------------------------------------------------------------
+
+class DriverPendingEvents(Enum):
+    """
+    Enum class representing possible pending events for a driver.
+    """
+    LAP_CHANGE_EVENT = auto()
+    CAR_DMG_PKT_EVENT = auto()
+
+    def __str__(self) -> str:
+        """
+        Returns the name of the enum member as a string.
+
+        Returns:
+            str: Name of the enum member.
+        """
+        return self.name
+
+class PendingEventsManager:
+    """
+    Manages a set of pending events. When all registered events have occurred at least once,
+    the callback is triggered with optional keyword arguments provided during registration.
+    """
+
+    def __init__(self, callback: Callable[..., None]):
+        """
+        Initializes the PendingEventsManager.
+
+        Args:
+            callback (Callable[..., None]): Function to call once all registered events have occurred.
+                                            Can accept keyword arguments.
+        """
+        self._pending_events: Set[DriverPendingEvents] = set()
+        self._callback: Callable[..., None] = callback
+        self._callback_kwargs: Dict[str, Any] = {}
+
+    def register(self,
+                 events: Set[DriverPendingEvents],
+                 **kwargs: Any) -> None:
+        """
+        Registers the set of events to wait for and optional keyword arguments for the callback.
+
+        Args:
+            events (Set[DriverPendingEvents]): Events that must occur before the callback is triggered.
+            **kwargs (Any): Keyword arguments to pass to the callback.
+
+        Returns:
+            None
+        """
+        self._pending_events = set(events)
+        self._callback_kwargs = kwargs
+
+    def onEvent(self, event: DriverPendingEvents) -> None:
+        """
+        Called when an event occurs. If the event is one of the registered pending events,
+        it is removed. If all pending events have occurred, the callback is triggered
+        with the previously registered keyword arguments.
+
+        Args:
+            event (DriverPendingEvents): The event that occurred.
+
+        Returns:
+            None
+        """
+        if event not in self._pending_events:
+            return
+
+        self._pending_events.remove(event)
+
+        if not self._pending_events:
+            self._callback(**self._callback_kwargs)
+
+    def areEventsPending(self) -> bool:
+        """
+        Returns whether there are any pending events.
+
+        Returns:
+            bool: True if there are pending events, False otherwise.
+        """
+        return bool(self._pending_events)

--- a/apps/backend/state_mgmt_layer/data_per_driver/tyre_info.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/tyre_info.py
@@ -208,6 +208,16 @@ class TyreSetHistoryManager:
             raise IndexError("Tyre history is empty, cannot add tyre wear info")
         self.m_history[-1].m_tyre_wear_history.append(tyre_wear_info)
 
+    def overwriteLatestTyreWear(self, tyre_wear_info: TyreWearPerLap) -> None:
+        """Overwrite tyre wear info for the specified tyre wear history item at the given index
+
+        Args:
+            tyre_wear_info (TyreWearPerLap): Tyre wear of latest lap
+        """
+        if not self.m_history:
+            raise IndexError("Tyre history is empty, cannot overwrite tyre wear info")
+        self.m_history[-1].m_tyre_wear_history[-1] = tyre_wear_info
+
     def remove(self, laps: List[int]) -> None:
         """Remove the specified laps from the tyre set history
 
@@ -331,9 +341,9 @@ class TyreInfo:
     total_laps: InitVar[int]
 
     tyre_age: Optional[int] = None
-    tyre_vis_compound: Optional["VisualTyreCompound"] = None
-    tyre_act_compound: Optional["ActualTyreCompound"] = None
-    tyre_wear: Optional["TyreWearPerLap"] = None
+    tyre_vis_compound: Optional[VisualTyreCompound] = None
+    tyre_act_compound: Optional[ActualTyreCompound] = None
+    tyre_wear: Optional[TyreWearPerLap] = None
     tyre_surface_temp: Optional[float] = None
     tyre_inner_temp: Optional[float] = None
     tyre_life_remaining_laps: Optional[int] = None

--- a/apps/backend/state_mgmt_layer/data_per_driver/tyre_info.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/tyre_info.py
@@ -243,7 +243,7 @@ class TyreSetHistoryManager:
         for i in range(len(self.m_history) - 1):
             current_stint = self.m_history[i]
             next_stint = self.m_history[i + 1]
-            current_stint.m_end_lap = next_stint.m_start_lap
+            current_stint.m_end_lap = next_stint.m_start_lap - 1
 
         # For the last tyre stint, get end lap num from session history
         self.m_history[-1].m_end_lap = final_lap_num

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -612,7 +612,7 @@ class SessionState:
         obj_to_be_updated.m_tyre_info.tyre_life_remaining_laps = packet.m_tyreSetData[packet.m_fittedIdx].m_lifeSpan
 
         # Update the tyre set history
-        obj_to_be_updated.updateTyreSetData(fitted_index=packet.m_fittedIdx)
+        obj_to_be_updated.updateTyreSetData(fitted_index=packet.m_fittedIdx, track=self.m_session_info.m_track)
 
     def processMotionUpdate(self, packet: PacketMotionData) -> None:
         """Process the motion update packet and update the necessary fields

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -32,7 +32,7 @@ from apps.backend.state_mgmt_layer.overtakes import (GetOvertakesStatus,
 from lib.collisions_analyzer import (CollisionAnalyzer, CollisionAnalyzerMode,
                                      CollisionRecord)
 from lib.custom_marker_tracker import CustomMarkerEntry, CustomMarkersHistory
-from lib.f1_types import (ActualTyreCompound, CarStatusData, F1Utils, LapData,
+from lib.f1_types import (ActualTyreCompound, CarStatusData, F1Utils,
                           PacketCarDamageData, PacketCarSetupData,
                           PacketCarStatusData, PacketCarTelemetryData,
                           PacketEventData, PacketFinalClassificationData,

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -33,7 +33,7 @@ from lib.collisions_analyzer import (CollisionAnalyzer, CollisionAnalyzerMode,
                                      CollisionRecord)
 from lib.custom_marker_tracker import CustomMarkerEntry, CustomMarkersHistory
 from lib.f1_types import (ActualTyreCompound, CarStatusData, F1Utils,
-                          PacketCarDamageData, PacketCarSetupData,
+                          PacketCarDamageData, PacketCarSetupData, LapData,
                           PacketCarStatusData, PacketCarTelemetryData,
                           PacketEventData, PacketFinalClassificationData,
                           PacketLapData, PacketLapPositionsData,
@@ -352,7 +352,7 @@ class SessionState:
         if should_recompute_fastest_lap:
             self._recomputeFastestLap()
 
-    def _updateDriverPositionData(self, driver_obj: object, lap_data: object) -> None:
+    def _updateDriverPositionData(self, driver_obj: DataPerDriver, lap_data: LapData) -> None:
         """Update driver position and timing information
 
         Args:
@@ -367,7 +367,7 @@ class SessionState:
             (lap_data.m_deltaToRaceLeaderMinutes * 60000)
         )
 
-    def _handleLapChangeLogic(self, driver_obj: object, lap_data: object) -> None:
+    def _handleLapChangeLogic(self, driver_obj: DataPerDriver, lap_data: LapData) -> None:
         """Handle lap change detection and snapshot capture
 
         Args:
@@ -403,7 +403,7 @@ class SessionState:
             driver_obj.m_pending_events_mgr.onEvent(DriverPendingEvents.LAP_CHANGE_EVENT)
 
 
-    def _updateDriverStatus(self, driver_obj: object, lap_data: object, driver_index: int) -> None:
+    def _updateDriverStatus(self, driver_obj: DataPerDriver, lap_data: LapData, driver_index: int) -> None:
         """Update driver's current status including DNF status
 
         Args:

--- a/apps/backend/telemetry_layer/telemetry_layer_init.py
+++ b/apps/backend/telemetry_layer/telemetry_layer_init.py
@@ -39,6 +39,7 @@ def initTelemetryLayer(
         udp_custom_action_code: Optional[int],
         udp_tyre_delta_action_code: Optional[int],
         forwarding_targets: List[Tuple[str, int]],
+        ver_str: str,
         tasks: List[asyncio.Task]) -> None:
     """Initialize the telemetry layer
 
@@ -50,6 +51,7 @@ def initTelemetryLayer(
         udp_custom_action_code (Optional[int]): UDP custom action code.
         udp_tyre_delta_action_code (Optional[int]): UDP tyre delta action code.
         forwarding_targets (List[Tuple[str, int]]): List of IP addr port pairs to forward packets to
+        ver_str (str): Version string
         tasks (List[asyncio.Task]): List of tasks to be executed
     """
 
@@ -61,6 +63,7 @@ def initTelemetryLayer(
         udp_custom_action_code=udp_custom_action_code,
         udp_tyre_delta_action_code=udp_tyre_delta_action_code,
         forwarding_targets=forwarding_targets,
+        ver_str=ver_str,
         tasks=tasks
     )
     setupForwarder(


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Fixes tyre stint start lap for stints after pits stops (thereby fixing stint length issue in #68 )
Fixed tyre long term tyre stint history bug in tracks where start/finish line is after pit garages. (this fixes issue #35)
    this is done by performing onTyreChange only after the lap is completed
    added a pending events infra for this
General code cleanup in processLapData update.

Fixes #68 #35 

---

## 📂 Type of change

<!-- Check all that apply: -->

- [x] Bug fix 🐞
- [ ] New feature 🚀
- [x] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Unit Tests

- [x] All unit tests pass
- Attach test command/output (e.g., `poetry run python tests/unit_tests.py`):

```
----------------------------------------------------------------------
Ran 253 tests in 6.748s

OK
```

### ✅ Integration Tests

* [x] All integration tests pass
* Attach test command/output (e.g., `poetry run python tests/integration_test/runner.py `):

```
===== TEST RESULTS =====
Passed: 16/16
PASS: f1_23_sp_austria.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_sp_aus_5lap_1stop_flashback.f1pcap
PASS: f1_25_sp_aus_5lap_1stop.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_sp_imola_5lap_1stop.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
```

### ✅ Pylint

* [x] Code passes `pylint`
* Paste summary report:

```
$ pylint --rcfile scripts/.pylintrc lib apps

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

To run pylint
```
pylint --rcfile scripts/.pylintrc lib apps
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
N/A
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Refactor lap data processing and tyre stint history handling to improve clarity and correctness, introduce event-driven mechanism for delayed tyre set changes, and propagate version metadata through telemetry outputs.

New Features:
- Introduce PendingEventsManager and DriverPendingEvents enum to coordinate delayed tyre set change handling across lap and damage events
- Add version string parameter to telemetry handler and include it in post-race JSON dumps

Bug Fixes:
- Correct off-by-one calculation for tyre stint end lap in TyreInfo
- Include track context in updateTyreSetData to ensure accurate tyre set history updates

Enhancements:
- Refactor processLapDataUpdate into modular helper methods for position, status, and lap-change logic
- Support delayed tyre set change on circuits where pit exit crosses the finish line
- Emit pending events on car damage updates and reorganize data_per_driver imports