### PR TITLE
Configure session autosave and improve launcher errors

### DIFF
--- a/apps/backend/pits_n_giggles.py
+++ b/apps/backend/pits_n_giggles.py
@@ -66,7 +66,7 @@ class PngRunner:
             port_number=self.m_config.Network.telemetry_port,
             replay_server=replay_server,
             logger=self.m_logger,
-            post_race_data_autosave=self.m_config.Capture.post_race_data_autosave,
+            capture_settings=self.m_config.Capture,
             udp_custom_action_code=self.m_config.Network.udp_custom_action_code,
             udp_tyre_delta_action_code=self.m_config.Network.udp_tyre_delta_action_code,
             forwarding_targets=self.m_config.Forwarding.forwarding_targets,

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -43,8 +43,7 @@ from lib.f1_types import (F1PacketType, PacketCarDamageData,
                           PacketFinalClassificationData, PacketLapData,
                           PacketMotionData, PacketParticipantsData,
                           PacketSessionData, PacketSessionHistoryData,
-                          PacketTimeTrialData, PacketTyreSetsData,
-                          SessionType23, SessionType24)
+                          PacketTimeTrialData, PacketTyreSetsData)
 from lib.inter_task_communicator import (AsyncInterTaskCommunicator,
                                          FinalClassificationNotification,
                                          ITCMessage)
@@ -567,9 +566,8 @@ class F1TelemetryHandler:
 
         if curr_session_type.isFpTypeSession() and self.m_capture_settings.post_fp_data_autosave:
             return True
-        elif curr_session_type.isQualiTypeSession() and self.m_capture_settings.post_quali_data_autosave:
+        if curr_session_type.isQualiTypeSession() and self.m_capture_settings.post_quali_data_autosave:
             return True
-        elif curr_session_type.isRaceTypeSession() and self.m_capture_settings.post_race_data_autosave:
+        if curr_session_type.isRaceTypeSession() and self.m_capture_settings.post_race_data_autosave:
             return True
-        else:
-            return False
+        return False

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -36,6 +36,7 @@ import aiofiles
 import apps.backend.state_mgmt_layer.telemetry_state as TelState
 import lib.race_analyzer as RaceAnalyzer
 from lib.button_debouncer import ButtonDebouncer
+from lib.config import CaptureSettings
 from lib.f1_types import (F1PacketType, PacketCarDamageData,
                           PacketCarSetupData, PacketCarStatusData,
                           PacketCarTelemetryData, PacketEventData,
@@ -57,7 +58,7 @@ def setupTelemetryTask(
         port_number: int,
         replay_server: bool,
         logger: logging.Logger,
-        post_race_data_autosave: bool,
+        capture_settings: CaptureSettings,
         udp_custom_action_code: Optional[int],
         udp_tyre_delta_action_code: Optional[int],
         forwarding_targets: List[Tuple[str, int]],
@@ -69,7 +70,7 @@ def setupTelemetryTask(
         port_number (int): Port number for the telemetry client.
         replay_server (bool): Whether to enable the TCP replay debug server.
         logger (logging.Logger): Logger instance
-        post_race_data_autosave (bool): Whether to autosave race data at the end of the race.
+        capture_settings (CaptureSettings): Capture settings
         udp_custom_action_code (Optional[int]): UDP custom action code.
         udp_tyre_delta_action_code (Optional[int]): UDP tyre delta action code.
         forwarding_targets (List[Tuple[str, int]]): List of IP addr port pairs to forward packets to
@@ -81,9 +82,9 @@ def setupTelemetryTask(
         port=port_number,
         forwarding_targets=forwarding_targets,
         logger=logger,
+        capture_settings=capture_settings,
         udp_custom_action_code=udp_custom_action_code,
         udp_tyre_delta_action_code=udp_tyre_delta_action_code,
-        post_race_data_autosave=post_race_data_autosave,
         replay_server=replay_server,
         ver_str=ver_str
     )
@@ -103,9 +104,9 @@ class F1TelemetryHandler:
         port: int,
         forwarding_targets: List[Tuple[str, int]],
         logger: logging.Logger,
+        capture_settings: CaptureSettings,
         udp_custom_action_code: Optional[int] = None,
         udp_tyre_delta_action_code: Optional[int] = None,
-        post_race_data_autosave: bool = False,
         replay_server: bool = False,
         ver_str: str = "dev") -> None:
         """
@@ -115,9 +116,9 @@ class F1TelemetryHandler:
             - port (int): The port number for telemetry.
             - forwarding_targets (List[Tuple[str, int]]): List of IP addr port pairs to forward packets to
             - logger (logging.Logger): Logger
+            - capture_settings (CaptureSettings): Capture settings
             - udp_custom_action_code (Optional[int]): UDP custom action code.
             - udp_tyre_delta_action_code (Optional[int]): UDP tyre delta action code
-            - post_race_data_autosave (bool): Save JSON file after race
             - replay_server: bool: If true, init in replay mode (TCP). Else init in live mode (UDP)
             - ver_str (str): Version string
         """
@@ -135,7 +136,8 @@ class F1TelemetryHandler:
         self.g_udp_custom_action_code: Optional[int] = udp_custom_action_code
         self.g_udp_tyre_delta_action_code: Optional[int] = udp_tyre_delta_action_code
         self.g_final_classification_processed: bool = False
-        self.g_post_race_data_autosave: bool = post_race_data_autosave
+        self.g_post_race_data_autosave: bool = capture_settings.post_race_data_autosave
+        self.m_capture_settings: CaptureSettings = capture_settings
         self.g_button_debouncer: ButtonDebouncer = ButtonDebouncer()
 
         self.m_should_forward: bool = bool(forwarding_targets)

--- a/apps/backend/telemetry_layer/telemetry_layer_init.py
+++ b/apps/backend/telemetry_layer/telemetry_layer_init.py
@@ -26,6 +26,8 @@ import asyncio
 import logging
 from typing import List, Optional, Tuple
 
+from lib.config import CaptureSettings
+
 from .telemetry_forwarder import setupForwarder
 from .telemetry_handler import setupTelemetryTask
 
@@ -35,7 +37,7 @@ def initTelemetryLayer(
         port_number: int,
         replay_server: bool,
         logger: logging.Logger,
-        post_race_data_autosave: bool,
+        capture_settings: CaptureSettings,
         udp_custom_action_code: Optional[int],
         udp_tyre_delta_action_code: Optional[int],
         forwarding_targets: List[Tuple[str, int]],
@@ -47,7 +49,7 @@ def initTelemetryLayer(
         port_number (int): Port number for the telemetry client.
         replay_server (bool): Whether to enable the TCP replay debug server.
         logger (logging.Logger): Logger instance
-        post_race_data_autosave (bool): Whether to autosave race data at the end of the race.
+        capture_settings (CaptureSettings): Capture settings
         udp_custom_action_code (Optional[int]): UDP custom action code.
         udp_tyre_delta_action_code (Optional[int]): UDP tyre delta action code.
         forwarding_targets (List[Tuple[str, int]]): List of IP addr port pairs to forward packets to
@@ -59,7 +61,7 @@ def initTelemetryLayer(
         port_number=port_number,
         replay_server=replay_server,
         logger=logger,
-        post_race_data_autosave=post_race_data_autosave,
+        capture_settings=capture_settings,
         udp_custom_action_code=udp_custom_action_code,
         udp_tyre_delta_action_code=udp_tyre_delta_action_code,
         forwarding_targets=forwarding_targets,

--- a/apps/launcher/app_managers/base_mgr.py
+++ b/apps/launcher/app_managers/base_mgr.py
@@ -28,13 +28,14 @@ import sys
 import threading
 import tkinter as tk
 from abc import ABC, abstractmethod
-from tkinter import ttk
+from tkinter import ttk, messagebox
 from typing import Callable, Optional
 
 import psutil
 
 from lib.config import PngSettings
 from lib.pid_report import extract_pid_from_line
+from lib.error_codes import PNG_ERROR_CODE_PORT_IN_USE, PNG_ERROR_CODE_UNKNOWN
 
 from ..console_interface import ConsoleInterface
 
@@ -141,6 +142,7 @@ class PngAppMgrBase(ABC):
             self.child_pid = self.process.pid
             self.status_var.set("Running")
             threading.Thread(target=self._capture_output, daemon=True).start()
+            threading.Thread(target=self._monitor_process_exit, daemon=True).start()
 
             self.console_app.log(f"{self.display_name} started successfully. PID = {self.child_pid}")
 
@@ -235,3 +237,45 @@ class PngAppMgrBase(ABC):
                     self.child_pid = pid
                 else:
                     self.console_app.log(line, is_child_message=True)
+
+    def _monitor_process_exit(self):
+        try:
+            if not self.process:
+                return
+            ret_code = self.process.wait()
+
+            if self.is_running:
+                self.console_app.log(f"{self.display_name} exited unexpectedly with code {ret_code}")
+                self.is_running = False
+                self.child_pid = None
+                self.process = None
+
+                if ret_code == PNG_ERROR_CODE_PORT_IN_USE:
+                    messagebox.showerror(
+                        title=f"{self.display_name} - Port In Use",
+                        message=f"{self.display_name} failed to start because the required port is already in use.\n"
+                                f"Please close the conflicting app or change the port in settings."
+                    )
+                    self.status_var.set("Port Conflict")
+                elif ret_code == PNG_ERROR_CODE_UNKNOWN:
+                    messagebox.showerror(
+                        title=f"{self.display_name} - Unknown Error",
+                        message=f"{self.display_name} failed to start due to an unknown error.\n"
+                                f"Please check the logs for more details."
+                    )
+                    self.status_var.set("Crashed")
+                else:
+                    messagebox.showerror(
+                        title=f"{self.display_name} - Unknown Error",
+                        message=f"{self.display_name} failed to start due to an unknown error.\n"
+                                f"Please check the logs for more details."
+                    )
+                    self.status_var.set("Crashed")
+
+                if self._post_stop_hook:
+                    try:
+                        self._post_stop_hook()
+                    except Exception as e:
+                        self.console_app.log(f"{self.display_name}: Error in post-stop hook after crash: {e}")
+        finally:
+            self.process = None

--- a/apps/launcher/app_managers/base_mgr.py
+++ b/apps/launcher/app_managers/base_mgr.py
@@ -275,7 +275,7 @@ class PngAppMgrBase(ABC):
                 if self._post_stop_hook:
                     try:
                         self._post_stop_hook()
-                    except Exception as e:
+                    except Exception as e: # pylint: disable=broad-exception-caught
                         self.console_app.log(f"{self.display_name}: Error in post-stop hook after crash: {e}")
         finally:
             self.process = None

--- a/apps/launcher/app_managers/base_mgr.py
+++ b/apps/launcher/app_managers/base_mgr.py
@@ -244,8 +244,7 @@ class PngAppMgrBase(ABC):
         """Restart the sub-application process"""
         if self.is_running:
             self.stop()
-            self.start()
-        # No Op if not running
+        self.start()
 
     def _capture_output(self):
         """Capture and log the subprocess output line by line"""

--- a/apps/launcher/png_launcher.py
+++ b/apps/launcher/png_launcher.py
@@ -81,7 +81,8 @@ class PngLauncher(ConsoleInterface):
         self.header_frame = ttk.Frame(root, padding="10", style="Racing.TFrame")
         self.header_frame.pack(fill=tk.X)
 
-        self.subapps_frame = ttk.LabelFrame(root, text="Race Components", padding="10", style="Racing.TLabelframe")
+        self.subapps_frame = ttk.LabelFrame(root, text="Pits n' Giggles subsystems",
+                                            padding="10", style="Racing.TLabelframe")
         self.subapps_frame.pack(fill=tk.X, padx=10, pady=5)
 
         self.console_frame = ttk.Frame(root, padding="10", style="Racing.TFrame")

--- a/apps/save_viewer/telemetry_post_race_data_viewer.py
+++ b/apps/save_viewer/telemetry_post_race_data_viewer.py
@@ -961,15 +961,12 @@ class TelemetryWebServer:
         logging.getLogger('gevent').setLevel(logging.ERROR)
         logging.getLogger('websocket').setLevel(logging.ERROR)
 
-        try:
-            self.m_socketio.run(
-                app=self.m_app,
-                debug=False,
-                host="0.0.0.0",
-                port=self.m_port,
-                use_reloader=False)
-        except OSError as e:
-            raise
+        self.m_socketio.run(
+            app=self.m_app,
+            debug=False,
+            host="0.0.0.0",
+            port=self.m_port,
+            use_reloader=False)
 
 def checkRecomputeJSON(json_data : Dict[str, Any]) -> bool:
 

--- a/apps/save_viewer/telemetry_post_race_data_viewer.py
+++ b/apps/save_viewer/telemetry_post_race_data_viewer.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 # pylint: skip-file
 
+import errno
 import argparse
 import json
 import logging
@@ -51,6 +52,7 @@ from lib.f1_types import F1Utils, LapHistoryData, ResultStatus
 from lib.pid_report import report_pid_from_child
 from lib.tyre_wear_extrapolator import TyreWearPerLap
 from lib.version import get_version
+from lib.error_codes import PNG_ERROR_CODE_PORT_IN_USE, PNG_ERROR_CODE_UNKNOWN
 
 
 def find_free_port():
@@ -959,12 +961,15 @@ class TelemetryWebServer:
         logging.getLogger('gevent').setLevel(logging.ERROR)
         logging.getLogger('websocket').setLevel(logging.ERROR)
 
-        self.m_socketio.run(
-            app=self.m_app,
-            debug=False,
-            host="0.0.0.0",
-            port=self.m_port,
-            use_reloader=False)
+        try:
+            self.m_socketio.run(
+                app=self.m_app,
+                debug=False,
+                host="0.0.0.0",
+                port=self.m_port,
+                use_reloader=False)
+        except OSError as e:
+            raise
 
 def checkRecomputeJSON(json_data : Dict[str, Any]) -> bool:
 
@@ -1202,7 +1207,14 @@ def main():
     _server = TelemetryWebServer(
         port=g_port_number,
         ver_str=version)
-    _server.run()
+    try:
+        _server.run()
+    except OSError as e:
+        png_logger.error(e)
+        if e.errno == errno.EADDRINUSE:
+            sys.exit(PNG_ERROR_CODE_PORT_IN_USE)
+        else:
+            sys.exit(PNG_ERROR_CODE_UNKNOWN)
 
 if __name__ == "__main__":
     report_pid_from_child()

--- a/lib/config/config_schema.py
+++ b/lib/config/config_schema.py
@@ -37,7 +37,11 @@ class NetworkSettings(BaseModel):
     udp_custom_action_code: int = Field(12, ge=1, le=12, description="Custom Marker: UDP Action Code")
 
 class CaptureSettings(BaseModel):
-    post_race_data_autosave: bool = Field(False, description="Whether to autosave race data at the end of the race")
+    post_race_data_autosave: bool = Field(True, description="Autosave race data at the end of races")
+    post_quali_data_autosave: bool = Field(True,
+                                           description="Autosave qualifying data at the end of qualifying sessions")
+    post_fp_data_autosave: bool = Field(False,
+                                        description="Autosave free practice data at the end of free practice sessions")
 
 class DisplaySettings(BaseModel):
     refresh_interval: int = Field(200, gt=0, description="Pits n' Giggles client update interval (ms)")

--- a/lib/error_codes.py
+++ b/lib/error_codes.py
@@ -1,0 +1,27 @@
+# MIT License
+#
+# Copyright (c) [2025] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+# -------------------------------------- CONSTANTS -----------------------------------------------------------------------
+
+PNG_ERROR_CODE_PORT_IN_USE = 100
+PNG_ERROR_CODE_UNKNOWN = 999

--- a/lib/f1_types/common.py
+++ b/lib/f1_types/common.py
@@ -224,6 +224,48 @@ class SessionType23(Enum):
         """
         return self.name.replace('_', ' ').title()
 
+    def isFpTypeSession(self) -> bool:
+        """
+        Check if the session type is a free practice session.
+
+        Returns:
+            bool: True if the session type is a free practice session, False otherwise.
+        """
+        return self in {
+            SessionType23.PRACTICE_1,
+            SessionType23.PRACTICE_2,
+            SessionType23.PRACTICE_3,
+            SessionType23.SHORT_PRACTICE,
+        }
+
+    def isQualiTypeSession(self) -> bool:
+        """
+        Check if the session type is a qualifying session.
+
+        Returns:
+            bool: True if the session type is a qualifying session, False otherwise.
+        """
+        return self in {
+            SessionType23.QUALIFYING_1,
+            SessionType23.QUALIFYING_2,
+            SessionType23.QUALIFYING_3,
+            SessionType23.SHORT_QUALIFYING,
+            SessionType23.ONE_SHOT_QUALIFYING,
+        }
+
+    def isRaceTypeSession(self) -> bool:
+        """
+        Check if the session type is a race session.
+
+        Returns:
+            bool: True if the session type is a race session, False otherwise.
+        """
+        return self in {
+            SessionType23.RACE,
+            SessionType23.RACE_2,
+            SessionType23.RACE_3,
+        }
+
 class SessionType24(Enum):
     UNKNOWN = 0
     PRACTICE_1 = 1
@@ -268,6 +310,54 @@ class SessionType24(Enum):
             str: String representation of the SessionType24.
         """
         return self.name.replace('_', ' ').title()
+
+    def isFpTypeSession(self) -> bool:
+        """
+        Check if the session type is a free practice session.
+
+        Returns:
+            bool: True if the session type is a free practice session, False otherwise.
+        """
+        return self in {
+            SessionType24.PRACTICE_1,
+            SessionType24.PRACTICE_2,
+            SessionType24.PRACTICE_3,
+            SessionType24.SHORT_PRACTICE,
+        }
+
+    def isQualiTypeSession(self) -> bool:
+        """
+        Check if the session type is a qualifying session.
+
+        Returns:
+            bool: True if the session type is a qualifying session, False otherwise.
+        """
+        return self in {
+            SessionType24.QUALIFYING_1,
+            SessionType24.QUALIFYING_2,
+            SessionType24.QUALIFYING_3,
+            SessionType24.SHORT_QUALIFYING,
+            SessionType24.ONE_SHOT_QUALIFYING,
+            SessionType24.SPRINT_SHOOTOUT_1,
+            SessionType24.SPRINT_SHOOTOUT_2,
+            SessionType24.SPRINT_SHOOTOUT_3,
+            SessionType24.SHORT_SPRINT_SHOOTOUT,
+            SessionType24.ONE_SHOT_SPRINT_SHOOTOUT,
+        }
+
+    def isRaceTypeSession(self) -> bool:
+        """
+        Check if the session type is a race session.
+
+        Returns:
+            bool: True if the session type is a race session, False otherwise.
+        """
+        return self in {
+            SessionType24.RACE,
+            SessionType24.RACE_2,
+            SessionType24.RACE_3,
+            SessionType24.TIME_TRIAL,
+        }
 
 class SessionLength(Enum):
     """

--- a/scripts/png.spec
+++ b/scripts/png.spec
@@ -18,7 +18,7 @@ from typing import List, Tuple, Any, Optional
 
 # Core application info
 APP_NAME = "pits_n_giggles"
-APP_VERSION = "2.7.0"
+APP_VERSION = "2.7.1"
 ICON_PATH = "../assets/favicon.ico"
 
 # Define all applications to be built

--- a/tests/f1_types/__init__.py
+++ b/tests/f1_types/__init__.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from .tests_common import TestSessionType23, TestSessionType24
 from .tests_packet_0_car_motion_data import TestPacketCarMotionData
 from .tests_packet_1_session_data import TestPacketSessionData
 from .tests_packet_2_lap_data import TestPacketLapData
@@ -28,7 +29,8 @@ from .tests_packet_4_participants_data import TestPacketParticipantsData
 from .tests_packet_5_car_setups_data import TestPacketCarSetupData
 from .tests_packet_6_car_telemetry_data import TestPacketCarTelemetryData
 from .tests_packet_7_status_data import TestPacketCarStatusData
-from .tests_packet_8_final_classification import TestPacketFinalClassificationData
+from .tests_packet_8_final_classification import \
+    TestPacketFinalClassificationData
 from .tests_packet_9_lobby_info_data import TestPacketLobbyInfoData
 from .tests_packet_10_car_damage_data import TestPacketCarDamageData
 from .tests_packet_11_session_history_data import TestPacketSessionHistoryData
@@ -38,6 +40,8 @@ from .tests_packet_14_time_trial_data import TestPacketTimeTrialData
 from .tests_packet_15_lap_positions_data import TestPacketLapPositionsData
 
 __all__ = [
+    'TestSessionType23',
+    'TestSessionType24',
     'TestPacketCarMotionData',
     'TestPacketSessionData',
     'TestPacketLapData',

--- a/tests/f1_types/tests_common.py
+++ b/tests/f1_types/tests_common.py
@@ -1,0 +1,157 @@
+# MIT License
+#
+# Copyright (c) [2025] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from lib.f1_types import SessionType23, SessionType24
+from .tests_parser_base import F1TypesTest
+
+
+class TestSessionType23(F1TypesTest):
+
+    def test_is_fp_type_session(self):
+        fp_sessions = [
+            SessionType23.PRACTICE_1,
+            SessionType23.PRACTICE_2,
+            SessionType23.PRACTICE_3,
+            SessionType23.SHORT_PRACTICE
+        ]
+        for session in fp_sessions:
+            with self.subTest(session=session):
+                self.assertTrue(session.isFpTypeSession())
+
+        non_fp_sessions = [
+            SessionType23.QUALIFYING_1,
+            SessionType23.RACE,
+            SessionType23.TIME_TRIAL
+        ]
+        for session in non_fp_sessions:
+            with self.subTest(session=session):
+                self.assertFalse(session.isFpTypeSession())
+
+    def test_is_quali_type_session(self):
+        quali_sessions = [
+            SessionType23.QUALIFYING_1,
+            SessionType23.QUALIFYING_2,
+            SessionType23.QUALIFYING_3,
+            SessionType23.SHORT_QUALIFYING,
+            SessionType23.ONE_SHOT_QUALIFYING
+        ]
+        for session in quali_sessions:
+            with self.subTest(session=session):
+                self.assertTrue(session.isQualiTypeSession())
+
+        non_quali_sessions = [
+            SessionType23.PRACTICE_1,
+            SessionType23.RACE,
+            SessionType23.TIME_TRIAL
+        ]
+        for session in non_quali_sessions:
+            with self.subTest(session=session):
+                self.assertFalse(session.isQualiTypeSession())
+
+    def test_is_race_type_session(self):
+        race_sessions = [
+            SessionType23.RACE,
+            SessionType23.RACE_2,
+            SessionType23.RACE_3
+        ]
+        for session in race_sessions:
+            with self.subTest(session=session):
+                self.assertTrue(session.isRaceTypeSession())
+
+        non_race_sessions = [
+            SessionType23.QUALIFYING_1,
+            SessionType23.PRACTICE_1,
+            SessionType23.TIME_TRIAL
+        ]
+        for session in non_race_sessions:
+            with self.subTest(session=session):
+                self.assertFalse(session.isRaceTypeSession())
+
+class TestSessionType24(F1TypesTest):
+
+    def test_is_fp_type_session(self):
+        fp_sessions = [
+            SessionType24.PRACTICE_1,
+            SessionType24.PRACTICE_2,
+            SessionType24.PRACTICE_3,
+            SessionType24.SHORT_PRACTICE
+        ]
+        for session in fp_sessions:
+            with self.subTest(session=session):
+                self.assertTrue(session.isFpTypeSession())
+
+        non_fp_sessions = [
+            SessionType24.QUALIFYING_1,
+            SessionType24.SPRINT_SHOOTOUT_1,
+            SessionType24.RACE,
+            SessionType24.TIME_TRIAL
+        ]
+        for session in non_fp_sessions:
+            with self.subTest(session=session):
+                self.assertFalse(session.isFpTypeSession())
+
+    def test_is_quali_type_session(self):
+        quali_sessions = [
+            SessionType24.QUALIFYING_1,
+            SessionType24.QUALIFYING_2,
+            SessionType24.QUALIFYING_3,
+            SessionType24.SHORT_QUALIFYING,
+            SessionType24.ONE_SHOT_QUALIFYING,
+            SessionType24.SPRINT_SHOOTOUT_1,
+            SessionType24.SPRINT_SHOOTOUT_2,
+            SessionType24.SPRINT_SHOOTOUT_3,
+            SessionType24.SHORT_SPRINT_SHOOTOUT,
+            SessionType24.ONE_SHOT_SPRINT_SHOOTOUT,
+        ]
+        for session in quali_sessions:
+            with self.subTest(session=session):
+                self.assertTrue(session.isQualiTypeSession())
+
+        non_quali_sessions = [
+            SessionType24.PRACTICE_1,
+            SessionType24.RACE,
+            SessionType24.TIME_TRIAL
+        ]
+        for session in non_quali_sessions:
+            with self.subTest(session=session):
+                self.assertFalse(session.isQualiTypeSession())
+
+    def test_is_race_type_session(self):
+        race_sessions = [
+            SessionType24.RACE,
+            SessionType24.RACE_2,
+            SessionType24.RACE_3,
+            SessionType24.TIME_TRIAL
+        ]
+        for session in race_sessions:
+            with self.subTest(session=session):
+                self.assertTrue(session.isRaceTypeSession())
+
+        non_race_sessions = [
+            SessionType24.QUALIFYING_1,
+            SessionType24.SPRINT_SHOOTOUT_1,
+            SessionType24.PRACTICE_1
+        ]
+        for session in non_race_sessions:
+            with self.subTest(session=session):
+                self.assertFalse(session.isRaceTypeSession())
+

--- a/tests/tests_config/tests_capture_settings.py
+++ b/tests/tests_config/tests_capture_settings.py
@@ -45,7 +45,7 @@ class TestCaptureSettings(TestF1ConfigBase):
         self.assertTrue(settings.post_quali_data_autosave)
         self.assertFalse(settings.post_fp_data_autosave)
 
-    def test_boolean_validation(self):
+    def test_boolean_validation_post_race_data_autosave(self):
         capture_true = CaptureSettings(post_race_data_autosave=True)
         self.assertTrue(capture_true.post_race_data_autosave)
 
@@ -59,6 +59,40 @@ class TestCaptureSettings(TestF1ConfigBase):
         capture_str_false = CaptureSettings(post_race_data_autosave="False")
         self.assertFalse(capture_str_false.post_race_data_autosave)
 
+    def test_boolean_validation_post_quali_data_autosave(self):
+        capture_true = CaptureSettings(post_quali_data_autosave=True)
+        self.assertTrue(capture_true.post_quali_data_autosave)
+
+        capture_false = CaptureSettings(post_quali_data_autosave=False)
+        self.assertFalse(capture_false.post_quali_data_autosave)
+
+        # Also test coercion from strings if you want
+        capture_str_true = CaptureSettings(post_quali_data_autosave="True")
+        self.assertTrue(capture_str_true.post_quali_data_autosave)
+
+        capture_str_false = CaptureSettings(post_quali_data_autosave="False")
+        self.assertFalse(capture_str_false.post_quali_data_autosave)
+
+    def test_boolean_validation_post_fp_data_autosave(self):
+        capture_true = CaptureSettings(post_fp_data_autosave=True)
+        self.assertTrue(capture_true.post_fp_data_autosave)
+
+        capture_false = CaptureSettings(post_fp_data_autosave=False)
+        self.assertFalse(capture_false.post_fp_data_autosave)
+
+        # Also test coercion from strings if you want
+        capture_str_true = CaptureSettings(post_fp_data_autosave="True")
+        self.assertTrue(capture_str_true.post_fp_data_autosave)
+
+        capture_str_false = CaptureSettings(post_fp_data_autosave="False")
+        self.assertFalse(capture_str_false.post_fp_data_autosave)
+
     def test_invalid_type_raises(self):
         with self.assertRaises(ValidationError):
             CaptureSettings(post_race_data_autosave="notaboolean")
+
+        with self.assertRaises(ValidationError):
+            CaptureSettings(post_quali_data_autosave="notaboolean")
+
+        with self.assertRaises(ValidationError):
+            CaptureSettings(post_fp_data_autosave="notaboolean")

--- a/tests/tests_config/tests_capture_settings.py
+++ b/tests/tests_config/tests_capture_settings.py
@@ -41,7 +41,9 @@ class TestCaptureSettings(TestF1ConfigBase):
     def test_default_values(self):
         """Test default values"""
         settings = CaptureSettings()
-        self.assertFalse(settings.post_race_data_autosave)
+        self.assertTrue(settings.post_race_data_autosave)
+        self.assertTrue(settings.post_quali_data_autosave)
+        self.assertFalse(settings.post_fp_data_autosave)
 
     def test_boolean_validation(self):
         capture_true = CaptureSettings(post_race_data_autosave=True)

--- a/tests/tests_config/tests_config_edge.py
+++ b/tests/tests_config/tests_config_edge.py
@@ -301,7 +301,9 @@ udp_custom_action_code = 5
         self.assertEqual(config.Network.udp_tyre_delta_action_code, 11)
         self.assertEqual(config.Network.udp_custom_action_code, 12)
 
-        self.assertFalse(config.Capture.post_race_data_autosave)
+        self.assertTrue(config.Capture.post_race_data_autosave)
+        self.assertTrue(config.Capture.post_quali_data_autosave)
+        self.assertFalse(config.Capture.post_fp_data_autosave)
 
         self.assertEqual(config.Display.refresh_interval, 200)
         self.assertFalse(config.Display.disable_browser_autoload)
@@ -353,7 +355,9 @@ target_2 = example.com:9090
         self.assertEqual(config.Forwarding.target_3, "")
 
         # Verify completely missing sections have all defaults
-        self.assertFalse(config.Capture.post_race_data_autosave)
+        self.assertTrue(config.Capture.post_race_data_autosave)
+        self.assertTrue(config.Capture.post_quali_data_autosave)
+        self.assertFalse(config.Capture.post_fp_data_autosave)
         self.assertEqual(config.Logging.log_file, "png.log")
         self.assertEqual(config.Logging.log_file_size, 1_000_000)
         self.assertFalse(config.StreamOverlay.show_sample_data_at_start)
@@ -376,7 +380,9 @@ log_file_size = 500000
         # Verify all other sections have defaults
         self.assertEqual(config.Network.telemetry_port, 20777)
         self.assertEqual(config.Network.server_port, 4768)
-        self.assertFalse(config.Capture.post_race_data_autosave)
+        self.assertTrue(config.Capture.post_race_data_autosave)
+        self.assertTrue(config.Capture.post_quali_data_autosave)
+        self.assertFalse(config.Capture.post_fp_data_autosave)
         self.assertEqual(config.Display.refresh_interval, 200)
         self.assertFalse(config.Privacy.process_car_setup)
         self.assertEqual(config.Forwarding.target_1, "")

--- a/tests/tests_config/tests_config_io.py
+++ b/tests/tests_config/tests_config_io.py
@@ -175,7 +175,9 @@ target_1 = localhost:8080
 
             # Should return default settings
             self.assertEqual(settings.Network.telemetry_port, 20777)
-            self.assertFalse(settings.Capture.post_race_data_autosave)
+            self.assertTrue(settings.Capture.post_race_data_autosave)
+            self.assertTrue(settings.Capture.post_quali_data_autosave)
+            self.assertFalse(settings.Capture.post_fp_data_autosave)
             self.assertEqual(settings.Display.refresh_interval, 200)
 
             # File should have been created

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -38,7 +38,8 @@ from f1_types import (TestPacketCarDamageData, TestPacketCarMotionData,
                       TestPacketLapPositionsData, TestPacketLobbyInfoData,
                       TestPacketMotionExData, TestPacketParticipantsData,
                       TestPacketSessionData, TestPacketSessionHistoryData,
-                      TestPacketTimeTrialData, TestPacketTyreSetsData)
+                      TestPacketTimeTrialData, TestPacketTyreSetsData,
+                      TestSessionType23, TestSessionType24)
 # pylint: disable=unused-import wrong-import-position
 # sourcery skip: dont-import-test-modules
 from tests_base import CustomTestResult, F1TelemetryUnitTestsBase


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Makes post FP, post quali and post race save config fields separate and configurable
    Updated SessionType23 and SessionType24 class to check this. Added test cases for the same
    Updated backend for the same.
Makes socket used error clear in launcher
In launcher, added a monitoring thread for each app.
Refactoring in telemetry_handler class for consistency.

![image](https://github.com/user-attachments/assets/d152df6e-68b3-4f08-9b7a-86797af46d82)
![image](https://github.com/user-attachments/assets/6df8cece-fb2c-4c2c-90fc-388a9634d81d)
![image](https://github.com/user-attachments/assets/5d1e80e2-d591-4116-852d-e8f964ad180f)


Fixes #72 #67 

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [ ] New feature 🚀
- [x] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Unit Tests

- [x] All unit tests pass
- Attach test command/output (e.g., `poetry run python tests/unit_tests.py`):

```
----------------------------------------------------------------------
Ran 259 tests in 8.080s

OK
```

### ✅ Integration Tests

* [x] All integration tests pass
* Attach test command/output (e.g., `poetry run python tests/integration_test/runner.py `):

```
===== TEST RESULTS =====
Passed: 16/16
PASS: f1_23_sp_austria.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_sp_aus_5lap_1stop.f1pcap
PASS: f1_25_sp_aus_5lap_1stop_flashback.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_sp_imola_5lap_1stop.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
```

### ✅ Pylint

* [x] Code passes `pylint`
* Paste summary report:

```
$ pylint --rcfile scripts/.pylintrc lib apps

-------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 9.99/10, +0.01)
```

To run pylint
```
pylint --rcfile scripts/.pylintrc lib apps
```

---

## 🧱 `lib/` Directory Changes

* [x] This PR modifies or adds files under `lib/`
* [x] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
In the parser module, added extended functionality in SessionType23 and SessionType24 classes to check session type.
Added unit tests for the same
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Separate autosave settings for free practice, qualifying, and race sessions and update components to support these configurable data capture rules; improve error detection and user feedback in launcher and server startup; extend session type enums with classification helpers; update tests and default config schema; and bump version to 2.7.1.

New Features:
- Add separate config flags for autosaving after free practice, qualifying, and race sessions
- Add monitoring thread in launcher to detect unexpected app exits and display port conflict or unknown error dialogs

Bug Fixes:
- Clear socket-in-use errors in save viewer launcher
- Handle port-in-use and unknown error codes on server startup

Enhancements:
- Extend SessionType23 and SessionType24 with isFpTypeSession, isQualiTypeSession, and isRaceTypeSession methods
- Refactor TelemetryHandler to use unified CaptureSettings and conditionally autosave session data based on session type
- Pre-flight port availability check in telemetry_web_server and propagate socket errors with specific exit codes in save viewer

Build:
- Bump application version to 2.7.1 in packaging script

Tests:
- Add unit tests for new session type classification methods
- Update config tests to reflect new CaptureSettings defaults

Chores:
- Add lib/error_codes.py to centralize error code constants

## Summary by Sourcery

Separate autosave settings for each session type and update core components to honor configurable data-capture rules; enhance launcher with process monitoring and clearer error dialogs; refactor telemetry_handler and session enums for consistency; adjust config schema defaults and bump version to 2.7.1.

New Features:
- Provide separate autosave config for post-free-practice, post-qualifying, and post-race sessions
- Add session type classification methods to SessionType23 and SessionType24
- Launch monitoring threads in the launcher to detect process exits and display error dialogs
- Perform pre-flight port availability checks in telemetry_web_server with specific exit codes

Bug Fixes:
- Clear socket-in-use errors in the launcher and surface appropriate user feedback
- Handle port-in-use and unknown errors on server startup and save viewer launch

Enhancements:
- Refactor TelemetryHandler to use unified CaptureSettings and conditionally autosave based on session type
- Consolidate event-type filtering in telemetry_layer using new classification helpers
- Standardize variable naming and remove redundant logic in TelemetryHandler

Build:
- Bump application version to 2.7.1

Tests:
- Add unit tests for session classification methods and CaptureSettings defaults
- Update existing config tests to reflect new autosave default values

Chores:
- Add lib/error_codes.py to centralize exit code constants
- Update launcher UI label for subsystems