### PR TITLE
Tyre delta toast

### DIFF
--- a/apps/backend/state_mgmt_layer/telemetry_state.py
+++ b/apps/backend/state_mgmt_layer/telemetry_state.py
@@ -25,7 +25,7 @@
 import logging
 from typing import Optional
 
-from lib.inter_task_communicator import AsyncInterTaskCommunicator, ITCMessage
+from lib.inter_task_communicator import AsyncInterTaskCommunicator, ITCMessage, TyreDeltaNotificationMessageCollection
 
 from .session_state import SessionState
 
@@ -51,11 +51,12 @@ async def processTyreDeltaSound() -> None:
     """
 
     messages = _session_state.getTyreDeltaNotificationMessages()
-    for message in messages:
-        await AsyncInterTaskCommunicator().send("frontend-update",
-            ITCMessage(
-                m_message_type=ITCMessage.MessageType.TYRE_DELTA_NOTIFICATION,
-                m_message=message))
+    if not messages:
+        return
+
+    await AsyncInterTaskCommunicator().send("frontend-update",
+        ITCMessage(m_message_type=ITCMessage.MessageType.TYRE_DELTA_NOTIFICATION_V2,
+                   m_message=TyreDeltaNotificationMessageCollection(messages)))
 
 # -------------------------------------- UTILTIES ----------------------------------------------------------------------
 

--- a/apps/backend/state_mgmt_layer/telemetry_state.py
+++ b/apps/backend/state_mgmt_layer/telemetry_state.py
@@ -47,16 +47,15 @@ async def processCustomMarkerCreate() -> None:
             m_message=custom_marker_obj))
 
 async def processTyreDeltaSound() -> None:
-    """Send the tyre delta notification to the frontend
-    """
-
-    messages = _session_state.getTyreDeltaNotificationMessages()
-    if not messages:
-        return
-
-    await AsyncInterTaskCommunicator().send("frontend-update",
-        ITCMessage(m_message_type=ITCMessage.MessageType.TYRE_DELTA_NOTIFICATION_V2,
-                   m_message=TyreDeltaNotificationMessageCollection(messages)))
+    """Send the tyre delta notification to the frontend."""
+    if messages := _session_state.getTyreDeltaNotificationMessages():
+        await AsyncInterTaskCommunicator().send(
+            "frontend-update",
+            ITCMessage(
+                m_message_type=ITCMessage.MessageType.TYRE_DELTA_NOTIFICATION_V2,
+                m_message=TyreDeltaNotificationMessageCollection(messages)
+            )
+        )
 
 # -------------------------------------- UTILTIES ----------------------------------------------------------------------
 

--- a/apps/frontend/css/tyreDeltaToast.css
+++ b/apps/frontend/css/tyreDeltaToast.css
@@ -1,0 +1,159 @@
+/* Tyre Delta Toast Styles */
+.tyre-delta-toast {
+    pointer-events: auto;
+    width: 800px;
+    max-width: 95vw;
+    background-color: #0d0d0d;
+    border: 1px solid #222;
+    border-radius: 12px;
+    box-shadow: 0 12px 48px rgba(0, 0, 0, 0.9);
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+}
+
+.tyre-delta-toast.show {
+    opacity: 1;
+}
+
+.tyre-delta-toast.showing {
+    opacity: 1;
+}
+
+.tyre-delta-toast.hide {
+    opacity: 0;
+}
+
+.tyre-delta-toast-header {
+    background-color: #1a1a1a;
+    border-bottom: 1px solid #333;
+    border-radius: 12px 12px 0 0;
+    padding: 1rem 1.5rem;
+    color: #fff;
+    text-align: center;
+}
+
+.tyre-delta-header-title {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: #fff;
+}
+
+.tyre-delta-toast-body {
+    padding: 2rem;
+    background-color: #0d0d0d;
+    border-radius: 0 0 12px 12px;
+}
+
+.tyre-delta-card {
+    background-color: #1a1a1a;
+    border: 1px solid #333;
+    border-radius: 12px;
+    height: 120px;
+}
+
+.tyre-delta-card-body {
+    padding: 0;
+    height: 100%;
+    display: flex;
+    color: #fff;
+}
+
+.tyre-delta-icon-section {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #262626;
+    border-radius: 12px 0 0 12px;
+    border-right: 1px solid #333;
+}
+
+.tyre-delta-icon-container {
+    width: 80px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.tyre-delta-icon-container svg {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.tyre-delta-content-section {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 1.5rem;
+}
+
+.tyre-delta-tyre-name {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: #fff;
+    margin-bottom: 0.5rem;
+}
+
+.tyre-delta-label {
+    font-size: 0.8rem;
+    color: #888;
+    margin-bottom: 0.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.tyre-delta-value {
+    font-size: 1.4rem;
+    font-weight: 700;
+    font-family: 'Courier New', monospace;
+    color: #fff;
+}
+
+.tyre-delta-positive {
+    color: #ffd700;
+}
+
+.tyre-delta-negative {
+    color: #10e71b;
+}
+
+.tyre-delta-neutral {
+    color: #fff;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .tyre-delta-toast {
+        width: 95vw;
+        margin: 0 2.5vw;
+    }
+
+    .tyre-delta-toast-header,
+    .tyre-delta-toast-body {
+        padding: 1.5rem;
+    }
+
+    .tyre-delta-card {
+        height: 100px;
+    }
+
+    .tyre-delta-icon-container {
+        width: 60px;
+        height: 60px;
+    }
+
+    .tyre-delta-content-section {
+        padding: 1rem;
+    }
+
+    .tyre-delta-tyre-name {
+        font-size: 1rem;
+    }
+
+    .tyre-delta-value {
+        font-size: 1.2rem;
+    }
+}

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -448,6 +448,20 @@
                 </div>
               </div>
             </div>
+            <!-- Tyre delta format -->
+            <div class="mb-3">
+              <label class="form-label">Tyre Delta Notification Format</label>
+              <div>
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="radio" id="tyreDeltaTTS" name="tyreDeltaNotificationFormat" value="tts" checked>
+                  <label class="form-check-label" for="fuelTargetAverage">Text to Speech</label>
+                </div>
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="radio" id="tyreDeltaOSD" name="tyreDeltaNotificationFormat" value="osd">
+                  <label class="form-check-label" for="fuelTargetNextLap">On Screen Display</label>
+                </div>
+              </div>
+            </div>
             <!-- TTS voice -->
             <div class="mb-3 d-none">
               <label for="voiceSelect" class="form-label">Text to Speech Voice</label>

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -20,6 +20,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreSetsCards.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/lapSectorRecords.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreRecords.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreDeltaToast.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@10"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/4.4.1/socket.io.min.js"></script>
@@ -533,6 +534,20 @@
       </div>
     </div>
 
+    <!-- Tyre Delta Toast Container -->
+    <div class="position-fixed top-50 start-50 translate-middle" style="z-index: 1055;">
+        <div id="tyreDeltaToast" class="toast tyre-delta-toast" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-header tyre-delta-toast-header text-center">
+                <strong class="tyre-delta-header-title">Tyre Delta</strong>
+            </div>
+            <div class="toast-body tyre-delta-toast-body">
+                <div class="row g-3" id="tyreDeltaCards">
+                    <!-- Cards will be populated by JavaScript -->
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='js/preferences.js') }}"></script>
     <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
@@ -550,6 +565,7 @@
     <script src="{{ url_for('static', filename='js/timeTrialDataPopulator.js') }}"></script>
     <script src="{{ url_for('static', filename='js/telemetryRenderer.js') }}"></script>
     <script src="{{ url_for('static', filename='js/frontendUpdate.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/tyreDeltaToast.js') }}"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     <script src="{{ url_for('static', filename='js/updater.js') }}"></script>
     <script>

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -543,12 +543,53 @@
     <!-- Tyre Delta Toast Container -->
     <div class="position-fixed top-50 start-50 translate-middle" style="z-index: 1055;">
         <div id="tyreDeltaToast" class="toast tyre-delta-toast" role="alert" aria-live="assertive" aria-atomic="true">
-            <div class="toast-header tyre-delta-toast-header text-center">
+            <div class="toast-header tyre-delta-toast-header">
                 <strong class="tyre-delta-header-title">Tyre Delta</strong>
             </div>
             <div class="toast-body tyre-delta-toast-body">
                 <div class="row g-3" id="tyreDeltaCards">
-                    <!-- Cards will be populated by JavaScript -->
+                    <!-- Card 1 -->
+                    <div class="col-md-6">
+                        <div class="card tyre-delta-card">
+                            <div class="card-body tyre-delta-card-body">
+                                <div class="tyre-delta-icon-section">
+                                    <div class="tyre-delta-icon-container" id="iconContainer1">
+                                        <!-- Icon will be inserted here -->
+                                    </div>
+                                </div>
+                                <div class="tyre-delta-content-section">
+                                    <div class="tyre-delta-tyre-name" id="tyreName1">
+                                        <!-- Tyre name will be set here -->
+                                    </div>
+                                    <div class="tyre-delta-label">Time Delta</div>
+                                    <div class="tyre-delta-value" id="deltaValue1">
+                                        <!-- Delta value will be set here -->
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Card 2 -->
+                    <div class="col-md-6">
+                        <div class="card tyre-delta-card">
+                            <div class="card-body tyre-delta-card-body">
+                                <div class="tyre-delta-icon-section">
+                                    <div class="tyre-delta-icon-container" id="iconContainer2">
+                                        <!-- Icon will be inserted here -->
+                                    </div>
+                                </div>
+                                <div class="tyre-delta-content-section">
+                                    <div class="tyre-delta-tyre-name" id="tyreName2">
+                                        <!-- Tyre name will be set here -->
+                                    </div>
+                                    <div class="tyre-delta-label">Time Delta</div>
+                                    <div class="tyre-delta-value" id="deltaValue2">
+                                        <!-- Delta value will be set here -->
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -490,6 +490,12 @@
               </div>
               <button id="playSampleButton" class="btn btn-secondary" type="button">Preview</button>
             </div>
+
+            <!-- Tyre Delta OSD duration -->
+            <div class="mb-3">
+              <label for="tyreDeltaOsdDuration" class="form-label">Tyre Delta OSD Duration (seconds)</label>
+              <input type="number" class="form-control" id="tyreDeltaOsdDuration" value="5" min="1" max="20">
+            </div>
           </div>
           <div class="modal-footer">
             <a href="https://www.pitsngiggles.com" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">Download latest</a>

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -455,11 +455,11 @@
               <div>
                 <div class="form-check form-check-inline">
                   <input class="form-check-input" type="radio" id="tyreDeltaTTS" name="tyreDeltaNotificationFormat" value="tts" checked>
-                  <label class="form-check-label" for="fuelTargetAverage">Text to Speech</label>
+                  <label class="form-check-label" for="tyreDeltaTTS">Text to Speech</label>
                 </div>
                 <div class="form-check form-check-inline">
                   <input class="form-check-input" type="radio" id="tyreDeltaOSD" name="tyreDeltaNotificationFormat" value="osd">
-                  <label class="form-check-label" for="fuelTargetNextLap">On Screen Display</label>
+                  <label class="form-check-label" for="tyreDeltaOSD">On Screen Display</label>
                 </div>
               </div>
             </div>

--- a/apps/frontend/js/app.js
+++ b/apps/frontend/js/app.js
@@ -77,9 +77,12 @@ socketio.on('frontend-update', function (data) {
         case 'tyre-delta':
             processTyreDeltaMessage(data['message']);
             break;
+        case 'tyre-delta-v2':
+            processTyreDeltaMessageV2(data['message'], iconCache);
+            break;
         case 'final-classification-notification':
             processFinalClassificationNotification(data['message']);
-            break
+            break;
         default:
             console.error("received unsupported message type in frontend-update");
     }

--- a/apps/frontend/js/frontendUpdate.js
+++ b/apps/frontend/js/frontendUpdate.js
@@ -52,3 +52,13 @@ function processFinalClassificationNotification(data) {
         shootConfetti(confettiDurationMs);
     }
 }
+
+function processTyreDeltaMessageV2(data, iconCache) {
+    if (g_pref_tyreDeltaNotificationTtsFormat) {
+        // Since its TTS format, reuse the old format code
+        data["tyre-delta-messages"].forEach(message => processTyreDeltaMessage(message));
+    } else {
+        const tyreDeltaToast = new TyreDeltaToast(iconCache);
+        tyreDeltaToast.show(data);
+    }
+}

--- a/apps/frontend/js/frontendUpdate.js
+++ b/apps/frontend/js/frontendUpdate.js
@@ -58,7 +58,7 @@ function processTyreDeltaMessageV2(data, iconCache) {
         // Since its TTS format, reuse the old format code
         data["tyre-delta-messages"].forEach(message => processTyreDeltaMessage(message));
     } else {
-        const tyreDeltaToast = new TyreDeltaToast(iconCache);
+        const tyreDeltaToast = new TyreDeltaToast(iconCache, g_pref_tyreDeltaNotificationOsdDurationSec * 1000);
         tyreDeltaToast.show(data);
     }
 }

--- a/apps/frontend/js/modals.js
+++ b/apps/frontend/js/modals.js
@@ -21,9 +21,6 @@ class ModalManager {
       document.getElementById('fuelTargetEnabled').addEventListener('change', (event) => {
         this.toggleFuelTargetShowSetting(event.target.checked);
       });
-      document.getElementById('fuelTargetEnabled').addEventListener('change', (event) => {
-        this.toggleFuelTargetShowSetting(event.target.checked);
-      });
 
       const ttsRadio = document.getElementById("tyreDeltaTTS");
       const osdRadio = document.getElementById("tyreDeltaOSD");

--- a/apps/frontend/js/modals.js
+++ b/apps/frontend/js/modals.js
@@ -21,6 +21,9 @@ class ModalManager {
       document.getElementById('fuelTargetEnabled').addEventListener('change', (event) => {
         this.toggleFuelTargetShowSetting(event.target.checked);
       });
+      document.getElementById('fuelTargetEnabled').addEventListener('change', (event) => {
+        this.toggleFuelTargetShowSetting(event.target.checked);
+      });
     }
     if (this.raceStatsModal) {
       document.getElementById('race-stats-btn').addEventListener('click', () => {
@@ -181,6 +184,7 @@ class ModalManager {
     // Validate numAdjacentCars input
     const numAdjacentCars_temp = this.validateIntField('carsToShow', "Number of adjacent cars");
     const numWeatherForecastSamples_temp = this.validateIntField('weatherSamplesToShow', 'Number of weather forecast samples');
+    const osdDurationSec_temp = this.validateIntField('tyreDeltaOsdDuration', 'OSD duration in seconds');
     if ((null === numAdjacentCars_temp) || (null === numWeatherForecastSamples_temp)) {
       return;
     }
@@ -200,6 +204,7 @@ class ModalManager {
     g_pref_ttsVoice = document.getElementById('voiceSelect').value;
     g_pref_ttsVolume = parseInt(document.getElementById('volumeRange').value, 10);
     g_pref_tyreDeltaNotificationTtsFormat = (document.querySelector('input[name="tyreDeltaNotificationFormat"]:checked').value === "tts") ? (true) : (false);
+    g_pref_tyreDeltaNotificationOsdDurationSec = osdDurationSec_temp;
     savePreferences();
 
     this.settingsModal.hide();

--- a/apps/frontend/js/modals.js
+++ b/apps/frontend/js/modals.js
@@ -129,6 +129,10 @@ class ModalManager {
     document.getElementById("fuelTargetAverage").checked = g_pref_fuelTargetAverageFormat;
     document.getElementById("fuelTargetNextLap").checked = !g_pref_fuelTargetAverageFormat;
 
+    // Set the radio buttons for tyre delta notification
+    document.getElementById("tyreDeltaTTS").checked = g_pref_tyreDeltaNotificationTtsFormat;
+    document.getElementById("tyreDeltaOSD").checked = !g_pref_tyreDeltaNotificationTtsFormat;
+
     // Set initial value for volume slider
     const volumeSlider = document.getElementById('volumeRange');
     const volumeLabel = document.getElementById('volumeLabel');
@@ -195,6 +199,7 @@ class ModalManager {
     g_pref_numWeatherPredictionSamples = numWeatherForecastSamples_temp;
     g_pref_ttsVoice = document.getElementById('voiceSelect').value;
     g_pref_ttsVolume = parseInt(document.getElementById('volumeRange').value, 10);
+    g_pref_tyreDeltaNotificationTtsFormat = (document.querySelector('input[name="tyreDeltaNotificationFormat"]:checked').value === "tts") ? (true) : (false);
     savePreferences();
 
     this.settingsModal.hide();

--- a/apps/frontend/js/modals.js
+++ b/apps/frontend/js/modals.js
@@ -24,6 +24,20 @@ class ModalManager {
       document.getElementById('fuelTargetEnabled').addEventListener('change', (event) => {
         this.toggleFuelTargetShowSetting(event.target.checked);
       });
+
+      const ttsRadio = document.getElementById("tyreDeltaTTS");
+      const osdRadio = document.getElementById("tyreDeltaOSD");
+      ttsRadio.addEventListener("change", () => {
+        if (ttsRadio.checked) {
+          this.handleTyreDeltaFormatChange("tts");
+        }
+      });
+
+      osdRadio.addEventListener("change", () => {
+        if (osdRadio.checked) {
+          this.handleTyreDeltaFormatChange("osd");
+        }
+      });
     }
     if (this.raceStatsModal) {
       document.getElementById('race-stats-btn').addEventListener('click', () => {
@@ -31,6 +45,25 @@ class ModalManager {
       });
     }
   }
+
+  handleTyreDeltaFormatChange(format) {
+    console.log("Tyre Delta Notification Format changed to:", format);
+
+    const ttsFields = ['volumeRange', 'playSampleButton'];
+    const osdFields = ['tyreDeltaOsdDuration'];
+
+    const enable = ids => ids.forEach(id => document.getElementById(id).disabled = false);
+    const disable = ids => ids.forEach(id => document.getElementById(id).disabled = true);
+
+    if (format === "tts") {
+      enable(ttsFields);
+      disable(osdFields);
+    } else if (format === "osd") {
+      disable(ttsFields);
+      enable(osdFields);
+    }
+  }
+
 
   toggleFuelTargetShowSetting(enabled) {
     const isDisabled = !enabled; // Disable when checkbox is unchecked
@@ -175,6 +208,9 @@ class ModalManager {
       const randomLine = lines[Math.floor(Math.random() * lines.length)];
       textToSpeech(randomLine, volume);
     };
+
+    // set initial tyre delta mode
+    this.handleTyreDeltaFormatChange(g_pref_tyreDeltaNotificationTtsFormat ? "tts" : "osd");
 
     this.settingsModal.show();
   }

--- a/apps/frontend/js/preferences.js
+++ b/apps/frontend/js/preferences.js
@@ -12,6 +12,7 @@ let g_pref_numAdjacentCars;
 let g_pref_numWeatherPredictionSamples;
 let g_pref_ttsVoice;
 let g_pref_ttsVolume;
+let g_pref_tyreDeltaNotificationTtsFormat;
 
 function loadPreferences() {
     let missingPreference = false;
@@ -111,6 +112,13 @@ function loadPreferences() {
         g_pref_ttsVolume = parseInt(g_pref_ttsVolume, 10);
     }
 
+    if (localStorage.getItem('tyreDeltaNotificationTtsFormat') !== null) {
+        g_pref_tyreDeltaNotificationTtsFormat = localStorage.getItem('tyreDeltaNotificationTtsFormat') === 'true';
+    } else {
+        g_pref_tyreDeltaNotificationTtsFormat = true;
+        missingPreference = true;
+    }
+
     // If any preference was missing, save all current preferences
     if (missingPreference) {
         savePreferences();
@@ -130,6 +138,7 @@ function loadPreferences() {
         g_pref_numWeatherPredictionSamples,
         g_pref_ttsVoice,
         g_pref_ttsVolume,
+        g_pref_tyreDeltaNotificationTtsFormat
     });
     updateAllTooltips();
 }
@@ -148,6 +157,7 @@ function savePreferences() {
     localStorage.setItem('numWeatherPredictionSamples', g_pref_numWeatherPredictionSamples);
     localStorage.setItem('ttsVoice', g_pref_ttsVoice);
     localStorage.setItem('ttsVolume', g_pref_ttsVolume);
+    localStorage.setItem('tyreDeltaNotificationTtsFormat', g_pref_tyreDeltaNotificationTtsFormat);
 
     console.log("Saved Preferences:", {
         g_pref_myTeamName,
@@ -163,6 +173,7 @@ function savePreferences() {
         g_pref_numWeatherPredictionSamples,
         g_pref_ttsVoice,
         g_pref_ttsVolume,
+        g_pref_tyreDeltaNotificationTtsFormat
     });
 
     updateAllTooltips();

--- a/apps/frontend/js/preferences.js
+++ b/apps/frontend/js/preferences.js
@@ -13,6 +13,7 @@ let g_pref_numWeatherPredictionSamples;
 let g_pref_ttsVoice;
 let g_pref_ttsVolume;
 let g_pref_tyreDeltaNotificationTtsFormat;
+let g_pref_tyreDeltaNotificationOsdDurationSec;
 
 function loadPreferences() {
     let missingPreference = false;
@@ -119,6 +120,14 @@ function loadPreferences() {
         missingPreference = true;
     }
 
+    g_pref_tyreDeltaNotificationOsdDurationSec = localStorage.getItem('tyreDeltaNotificationOsdDurationSec');
+    if ((g_pref_tyreDeltaNotificationOsdDurationSec === null) || (g_pref_tyreDeltaNotificationOsdDurationSec === "")) {
+        g_pref_tyreDeltaNotificationOsdDurationSec = 5;
+        missingPreference = true;
+    } else {
+        g_pref_tyreDeltaNotificationOsdDurationSec = parseInt(g_pref_tyreDeltaNotificationOsdDurationSec, 10); // localstorage saves everthing as string
+    }
+
     // If any preference was missing, save all current preferences
     if (missingPreference) {
         savePreferences();
@@ -138,7 +147,8 @@ function loadPreferences() {
         g_pref_numWeatherPredictionSamples,
         g_pref_ttsVoice,
         g_pref_ttsVolume,
-        g_pref_tyreDeltaNotificationTtsFormat
+        g_pref_tyreDeltaNotificationTtsFormat,
+        g_pref_tyreDeltaNotificationOsdDurationSec
     });
     updateAllTooltips();
 }
@@ -158,6 +168,7 @@ function savePreferences() {
     localStorage.setItem('ttsVoice', g_pref_ttsVoice);
     localStorage.setItem('ttsVolume', g_pref_ttsVolume);
     localStorage.setItem('tyreDeltaNotificationTtsFormat', g_pref_tyreDeltaNotificationTtsFormat);
+    localStorage.setItem('tyreDeltaNotificationOsdDurationSec', g_pref_tyreDeltaNotificationOsdDurationSec);
 
     console.log("Saved Preferences:", {
         g_pref_myTeamName,
@@ -173,7 +184,8 @@ function savePreferences() {
         g_pref_numWeatherPredictionSamples,
         g_pref_ttsVoice,
         g_pref_ttsVolume,
-        g_pref_tyreDeltaNotificationTtsFormat
+        g_pref_tyreDeltaNotificationTtsFormat,
+        g_pref_tyreDeltaNotificationOsdDurationSec
     });
 
     updateAllTooltips();

--- a/apps/frontend/js/tyreDeltaToast.js
+++ b/apps/frontend/js/tyreDeltaToast.js
@@ -1,0 +1,142 @@
+class TyreDeltaToast {
+    constructor(iconCache, timeout = 8000) {
+        this.iconCache = iconCache;
+        this.timeout = timeout;
+        this.toastElement = document.getElementById('tyreDeltaToast');
+        this.toast = null;
+        this.initializeToast();
+    }
+
+    initializeToast() {
+        this.toast = new bootstrap.Toast(this.toastElement, {
+            delay: this.timeout,
+            autohide: true
+        });
+    }
+
+    show(data) {
+        this.populateToastContent(data);
+        this.toast.show();
+    }
+
+    hide() {
+        this.toast.hide();
+    }
+
+    // Helper method to get the correct icon parameter
+    getIconParam(tyreType) {
+        return tyreType === 'Slick' ? 'Soft' : tyreType;
+    }
+
+    // Helper method to safely render icon
+    renderIcon(tyreType) {
+        const iconParam = this.getIconParam(tyreType);
+        const icon = this.iconCache.getIcon(iconParam);
+
+        // Handle different icon return types
+        if (typeof icon === 'string') {
+            return icon;
+        } else if (icon && icon.outerHTML) {
+            // SVG element
+            return icon.outerHTML;
+        } else if (icon && typeof icon.toString === 'function') {
+            return icon.toString();
+        }
+
+        return ''; // fallback
+    }
+
+    populateToastContent(data) {
+        // Populate delta cards
+        const cardsContainer = document.getElementById('tyreDeltaCards');
+        cardsContainer.innerHTML = '';
+
+        data['tyre-delta-messages'].forEach((message, index) => {
+            const card = this.createDeltaCard(message, index);
+            cardsContainer.appendChild(card);
+        });
+    }
+
+    createDeltaCard(message, index) {
+        const col = document.createElement('div');
+        col.className = 'col-md-6';
+
+        const card = document.createElement('div');
+        card.className = 'card tyre-delta-card';
+
+        const cardBody = document.createElement('div');
+        cardBody.className = 'card-body tyre-delta-card-body';
+
+        // Left half - Icon section
+        const iconSection = document.createElement('div');
+        iconSection.className = 'tyre-delta-icon-section';
+
+        const iconContainer = document.createElement('div');
+        iconContainer.className = 'tyre-delta-icon-container';
+        iconContainer.innerHTML = this.renderIcon(message['other-tyre-type']);
+
+        iconSection.appendChild(iconContainer);
+
+        // Right half - Content section
+        const contentSection = document.createElement('div');
+        contentSection.className = 'tyre-delta-content-section';
+
+        // Tyre type name
+        const tyreName = document.createElement('div');
+        tyreName.className = 'tyre-delta-tyre-name';
+        tyreName.textContent = message['other-tyre-type'];
+
+        // Delta label
+        const deltaLabel = document.createElement('div');
+        deltaLabel.className = 'tyre-delta-label';
+        deltaLabel.textContent = 'Time Delta';
+
+        // Delta value
+        const deltaValue = document.createElement('div');
+        deltaValue.className = 'tyre-delta-value';
+        const deltaSign = message['tyre-delta'] > 0 ? '+' : '';
+        deltaValue.textContent = `${deltaSign}${message['tyre-delta'].toFixed(3)}s`;
+
+        // Add color coding for delta
+        if (message['tyre-delta'] > 0) {
+            deltaValue.classList.add('tyre-delta-positive');
+        } else if (message['tyre-delta'] < 0) {
+            deltaValue.classList.add('tyre-delta-negative');
+        } else {
+            deltaValue.classList.add('tyre-delta-neutral');
+        }
+
+        contentSection.appendChild(tyreName);
+        contentSection.appendChild(deltaLabel);
+        contentSection.appendChild(deltaValue);
+
+        cardBody.appendChild(iconSection);
+        cardBody.appendChild(contentSection);
+        card.appendChild(cardBody);
+        col.appendChild(card);
+
+        return col;
+    }
+
+    // Method to check if toast is currently showing
+    isShowing() {
+        return this.toastElement.classList.contains('show');
+    }
+
+    // Method to add event listeners
+    onShow(callback) {
+        this.toastElement.addEventListener('show.bs.toast', callback);
+    }
+
+    onHide(callback) {
+        this.toastElement.addEventListener('hide.bs.toast', callback);
+    }
+
+    onShown(callback) {
+        this.toastElement.addEventListener('shown.bs.toast', callback);
+    }
+
+    onHidden(callback) {
+        this.toastElement.addEventListener('hidden.bs.toast', callback);
+    }
+}

--- a/lib/inter_task_communicator.py
+++ b/lib/inter_task_communicator.py
@@ -97,6 +97,34 @@ class TyreDeltaMessage:
             "tyre-delta": self.m_delta
         }
 
+class TyreDeltaNotificationMessageCollection:
+    def __init__(self, tyre_delta_messages: list[TyreDeltaMessage]) -> None:
+        """Initialize the TyreDeltaNotificationMessageCollection object.
+
+        Args:
+            tyre_delta_messages (list[TyreDeltaMessage]): The list of tyre delta messages
+        """
+        self.m_tyre_delta_messages = tyre_delta_messages
+
+    def __repr__(self) -> str:
+        """Return a string representation of the TyreDeltaNotificationMessageCollection object."""
+        return f"TyreDeltaNotificationMessageCollection(tyre_delta_messages={self.m_tyre_delta_messages})"
+
+    def __str__(self) -> str:
+        """Return a string representation of the TyreDeltaNotificationMessageCollection object."""
+        return self.__repr__()
+
+    def toJSON(self) -> Dict[str, Any]:
+        """Get the JSON representation of this object.
+
+        Returns:
+            Dict[str, Any]: The JSON representation of this object.
+        """
+        return {
+            "curr-tyre-type" : str(self.m_tyre_delta_messages[0].m_curr_tyre_type),
+            "tyre-delta-messages": [message.toJSON() for message in self.m_tyre_delta_messages]
+        }
+
 class FinalClassificationNotification:
     def __init__(self, player_position: int) -> None:
         """Initialize the FinalClassificationNotification object.
@@ -129,6 +157,7 @@ class ITCMessage:
     class MessageType(str, Enum):
         CUSTOM_MARKER                      = "custom-marker"
         TYRE_DELTA_NOTIFICATION            = "tyre-delta"
+        TYRE_DELTA_NOTIFICATION_V2         = "tyre-delta-v2"
         UDP_PACKET_FORWARD                 = "udp-packet-forward"
         FINAL_CLASSIFICATION_NOTIFICATION  = "final-classification-notification"
 

--- a/lib/inter_task_communicator.py
+++ b/lib/inter_task_communicator.py
@@ -54,9 +54,9 @@ class TyreDeltaMessage:
         def __repr__(self) -> str:
             """Return a string representation of the TyreDeltaMessage object."""
             return {
-                TyreDeltaMessage.TyreType.SLICK: "slick",
-                TyreDeltaMessage.TyreType.WET: "wet",
-                TyreDeltaMessage.TyreType.INTER: "intermediate"
+                TyreDeltaMessage.TyreType.SLICK: "Slick",
+                TyreDeltaMessage.TyreType.WET: "Wet",
+                TyreDeltaMessage.TyreType.INTER: "Intermediate"
             }.get(self, "")
 
         def __str__(self) -> str:

--- a/tests/tests_itc.py
+++ b/tests/tests_itc.py
@@ -38,7 +38,7 @@ from lib.inter_task_communicator import (AsyncInterTaskCommunicator,
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-class TestAsyncInterThreadCommunicator(F1TelemetryUnitTestsBase):
+class TestAsyncInterTaskCommunicator(F1TelemetryUnitTestsBase):
     def setUp(self):
         """Create a fresh communicator for each test"""
         self.communicator = AsyncInterTaskCommunicator()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -60,7 +60,7 @@ from tests_debouncer import TestMultiButtonDebouncer
 from tests_fuel_recommender import (TestFuelRateRecommenderMisc,
                                     TestFuelRateRecommenderRemove,
                                     TestFuelRemainingPerLap)
-from tests_itc import TestAsyncInterThreadCommunicator
+from tests_itc import TestAsyncInterTaskCommunicator
 from tests_overtake_analyzer import (TestOvertakeAnalyzerEmptyInput,
                                      TestOvertakeAnalyzerFileCsv,
                                      TestOvertakeAnalyzerInvalidData,


### PR DESCRIPTION
## 📝 Description

Tyre delta notifications now has 2 modes
1. Text to speech (default)
2. Toast

Adding settings to toggle between these
When one mode is selected, the settings related to the other mode will be disabled.

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Unit Tests

- [x] All unit tests pass
- Attach test command/output (e.g., `poetry run python tests/unit_tests.py`):

```
----------------------------------------------------------------------
Ran 262 tests in 9.283s

OK
```

### ✅ Integration Tests

* [x] All integration tests pass
* Attach test command/output (e.g., `poetry run python tests/integration_test/runner.py `):

```
===== TEST RESULTS =====
Passed: 20/20
PASS: f1_23_sp_austria.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_sp_aus_5lap_1stop.f1pcap
PASS: f1_25_sp_imola_5lap_1stop.f1pcap
PASS: f1_25_sp_aus_5lap_1stop_flashback.f1pcap
PASS: f1_25_mp_fp_jeddah.f1pcap
PASS: f1_25_mp_fp_jeddah_player.f1pcap
PASS: f1_25_mp_fp_jeddah_player_2.f1pcap
PASS: f1_25_sp_baku_mid_session_save_load.f1pcap
```

### ✅ Pylint

* [x] Code passes `pylint`
* Paste summary report:

```
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

To run pylint
```
pylint --rcfile scripts/.pylintrc lib apps
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```

```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Add an on-screen toast mode for tyre delta notifications alongside existing text-to-speech, expose a settings toggle, persist the choice, and implement the toast UI and messaging flow

New Features:
- Provide two modes for tyre delta notifications: text-to-speech and on-screen toast display
- Add settings UI to toggle between notification modes with conditional enabling/disabling of related options
- Implement a new toast-based UI component with custom CSS and JavaScript to render tyre delta cards

Enhancements:
- Introduce a new TyreDeltaNotificationMessageCollection and message type (tyre-delta-v2) in the backend
- Persist user preferences for notification mode and OSD duration in localStorage
- Update frontendUpdate handler to route messages to the appropriate display method based on user preference