### PR TITLE
Tt enhanced

### DIFF
--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -735,6 +735,13 @@ class DriversListRsp:
         Returns:
             Dict[str, Any]: TT setup JSON data.
         """
+        if not self.m_time_trial_packet:
+            return {
+                "personal-best-setup": None,
+                "player-session-best-setup": None,
+                "rival-session-best-setup": None
+            }
+
         personal_best_setup: Optional[dict[str, Any]] = None
         session_best_setup: Optional[dict[str, Any]] = None
         rival_setup: Optional[dict[str, Any]] = None

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -701,7 +701,6 @@ class DriversListRsp:
         if (player_index is None) or (_session_state_ref.m_num_active_cars is None):
             return
 
-
         # Player object must be found in TT mode
         player_obj = _session_state_ref.m_driver_data[player_index]
         if not player_obj:
@@ -719,6 +718,10 @@ class DriversListRsp:
                     if (index + 1) in player_obj.m_per_lap_snapshots else None
         else:
             session_history = None
+
+        self.m_fastest_lap = player_obj.m_lap_info.m_best_lap_ms
+        self.m_fastest_lap_driver = player_obj.m_driver_info.name
+        self.m_fastest_lap_tyre = player_obj.m_lap_info.m_best_lap_tyre
         self.m_json_rsp = {
             "current-lap" : player_obj.m_lap_info.m_current_lap,
             "session-history": session_history,

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -754,8 +754,8 @@ class DriversListRsp:
 
         return {
             "personal-best-setup": personal_best_setup,
-            "session-best-setup": session_best_setup,
-            "rival-setup": rival_setup,
+            "player-session-best-setup": session_best_setup,
+            "rival-session-best-setup": rival_setup,
         }
 
     def _safeGetDriver(self, index: int) -> Optional[DataPerDriver]:

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -750,6 +750,10 @@ class DriversListRsp:
         session_best_idx = self.m_time_trial_packet.m_playerSessionBestDataSet.m_carIdx
         rival_idx = self.m_time_trial_packet.m_rivalSessionBestDataSet.m_carIdx
 
+        # Since game doesn't do this, possible bug
+        if self.m_time_trial_packet.m_playerSessionBestDataSet.m_lapTimeInMS == self.m_time_trial_packet.m_personalBestDataSet.m_lapTimeInMS:
+            personal_best_idx = session_best_idx
+
         if (driver := self._safeGetDriver(personal_best_idx)) and driver.m_packet_copies.m_packet_car_setup:
             personal_best_setup = driver.m_packet_copies.m_packet_car_setup.toJSON()
 

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -726,7 +726,45 @@ class DriversListRsp:
             "current-lap" : player_obj.m_lap_info.m_current_lap,
             "session-history": session_history,
             "tt-data": self.m_time_trial_packet.toJSON() if self.m_time_trial_packet else None,
+            "tt-setups" : self._getTTSetupJSON(),
         }
+
+    def _getTTSetupJSON(self) -> Dict[str, Any]:
+        """Get the TT setup JSON data.
+
+        Returns:
+            Dict[str, Any]: TT setup JSON data.
+        """
+        personal_best_setup: Optional[dict[str, Any]] = None
+        session_best_setup: Optional[dict[str, Any]] = None
+        rival_setup: Optional[dict[str, Any]] = None
+
+        personal_best_idx = self.m_time_trial_packet.m_personalBestDataSet.m_carIdx
+        session_best_idx = self.m_time_trial_packet.m_playerSessionBestDataSet.m_carIdx
+        rival_idx = self.m_time_trial_packet.m_rivalSessionBestDataSet.m_carIdx
+
+        if (driver := self._safeGetDriver(personal_best_idx)) and driver.m_packet_copies.m_packet_car_setup:
+            personal_best_setup = driver.m_packet_copies.m_packet_car_setup.toJSON()
+
+        if (driver := self._safeGetDriver(session_best_idx)) and driver.m_packet_copies.m_packet_car_setup:
+            session_best_setup = driver.m_packet_copies.m_packet_car_setup.toJSON()
+
+        if (driver := self._safeGetDriver(rival_idx)) and driver.m_packet_copies.m_packet_car_setup:
+            rival_setup = driver.m_packet_copies.m_packet_car_setup.toJSON()
+
+        return {
+            "personal-best-setup": personal_best_setup,
+            "session-best-setup": session_best_setup,
+            "rival-setup": rival_setup,
+        }
+
+    def _safeGetDriver(self, index: int) -> Optional[DataPerDriver]:
+        """Safely get a non-None DataPerDriver from m_driver_data by index."""
+        if 0 <= index < len(_session_state_ref.m_driver_data):
+            driver = _session_state_ref.m_driver_data[index]
+            if driver is not None:
+                return driver
+        return None
 
     def _getDriverJSON(self, index: int, driver_data: DataPerDriver) -> Dict[str, Any]:
         """Get the driver JSON data.

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -750,7 +750,9 @@ class DriversListRsp:
         session_best_idx = self.m_time_trial_packet.m_playerSessionBestDataSet.m_carIdx
         rival_idx = self.m_time_trial_packet.m_rivalSessionBestDataSet.m_carIdx
 
-        # Since game doesn't do this, possible bug
+        # The game always references personal best with index 2 and session best with index 0
+        # If the personal best is the same as the session best, then we can use the session best index
+        # since the personal best index may contain some unrelated car setup
         if self.m_time_trial_packet.m_playerSessionBestDataSet.m_lapTimeInMS == self.m_time_trial_packet.m_personalBestDataSet.m_lapTimeInMS:
             personal_best_idx = session_best_idx
 

--- a/apps/frontend/css/timeTrial.css
+++ b/apps/frontend/css/timeTrial.css
@@ -90,13 +90,13 @@
 }
 
 .tt-best-time {
-    color: #ff6b35 !important;
+    color: #45ff35 !important;
     font-weight: bold;
 }
 
 .tt-invalid-lap {
     color: #ff4757 !important;
-    text-decoration: line-through;
+    font-weight: bold;
 }
 
 /* Comparison Section */

--- a/apps/frontend/css/timeTrial.css
+++ b/apps/frontend/css/timeTrial.css
@@ -1,0 +1,307 @@
+/* Time Trial UI Styles - Horizontal Layout */
+.tt-container {
+    height: 100%;
+    display: flex;
+    background: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 100%);
+    color: #ffffff;
+    overflow: hidden;
+}
+
+/* Left Panel - Lap Times Table */
+.tt-left-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 15px;
+    border-right: 2px solid #444;
+    min-width: 0; /* Allows flex shrinking */
+    overflow: hidden;
+}
+
+/* Right Panel - Comparison Data */
+.tt-right-panel {
+    width: 400px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    padding: 15px;
+    overflow: hidden;
+}
+
+/* Current Lap Display */
+.tt-current-lap {
+    font-size: 20px;
+    color: #ccc;
+    margin-bottom: 15px;
+    flex-shrink: 0;
+}
+
+.tt-lap-badge {
+    background: #00ff41;
+    color: #000;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-weight: bold;
+    margin-left: 5px;
+    font-size: 20px;
+}
+
+/* Lap Times Table */
+.tt-table-container {
+    flex: 1;
+    overflow-y: auto;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 8px;
+    min-height: 0;
+}
+
+.tt-lap-table {
+    margin: 0;
+    font-size: 20px;
+}
+
+.tt-table-head th {
+    background: #333;
+    color: #ffffff;
+    font-weight: 600;
+    text-align: center;
+    border: none;
+    padding: 10px 6px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    font-size: 20px;
+}
+
+.tt-lap-table tbody tr {
+    transition: background-color 0.2s ease;
+}
+
+.tt-lap-table tbody tr:hover {
+    background-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+.tt-lap-table td {
+    text-align: center;
+    padding: 8px 4px;
+    border: none;
+    font-weight: 500;
+    font-size: 20px;
+}
+
+.tt-best-time {
+    color: #ff6b35 !important;
+    font-weight: bold;
+}
+
+.tt-invalid-lap {
+    color: #ff4757 !important;
+    text-decoration: line-through;
+}
+
+/* Comparison Section */
+.tt-comparison-container {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    min-height: 0;
+}
+
+.tt-comparison-card {
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid #444;
+    border-radius: 8px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    flex-shrink: 0;
+}
+
+.tt-comparison-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(255, 255, 255, 0.1);
+}
+
+.tt-personal-best {
+    border-left: 4px solid #00ff41;
+}
+
+.tt-session-best {
+    border-left: 4px solid #ffa502;
+}
+
+.tt-rival-best {
+    border-left: 4px solid #ff4757;
+}
+
+.tt-theoretical-best {
+    border-left: 4px solid #9c88ff;
+}
+
+.tt-card-header {
+    padding: 10px 12px;
+    border-bottom: 1px solid #555;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
+.tt-card-header-content {
+    flex: 1;
+}
+
+.tt-card-title {
+    margin: 0 0 5px 0;
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.tt-personal-best .tt-card-title {
+    color: #00ff41;
+}
+
+.tt-session-best .tt-card-title {
+    color: #ffa502;
+}
+
+.tt-rival-best .tt-card-title {
+    color: #ff4757;
+}
+
+.tt-theoretical-best .tt-card-title {
+    color: #9c88ff;
+}
+
+.tt-main-time {
+    font-size: 18px;
+    font-weight: bold;
+    color: #ffffff;
+    font-family: 'Courier New', monospace;
+    margin: 0;
+}
+
+.tt-wings {
+    font-size: 11px;
+    color: #ccc;
+    margin-top: 3px;
+    flex-shrink: 0;
+    margin-left: 10px;
+}
+
+.tt-card-body {
+    padding: 12px;
+}
+
+.tt-sectors {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+    font-size: 13px;
+}
+
+.tt-sector {
+    color: #ccc;
+    font-family: 'Courier New', monospace;
+}
+
+.tt-details {
+    border-top: 1px solid #555;
+    padding-top: 8px;
+}
+
+.tt-assists {
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.tt-assist {
+    font-size: 10px;
+    background: #333;
+    padding: 2px 6px;
+    border-radius: 3px;
+    color: #ccc;
+}
+
+.tt-theoretical-note {
+    font-size: 11px;
+    color: #9c88ff;
+    text-align: center;
+    font-style: italic;
+    margin-bottom: 8px;
+}
+
+.tt-session-info-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+    font-size: 11px;
+}
+
+.tt-info-item {
+    display: flex;
+    justify-content: space-between;
+}
+
+.tt-info-label {
+    color: #ccc;
+}
+
+.tt-info-value {
+    color: #ffffff;
+    font-weight: 600;
+}
+
+/* Scrollbar Styling */
+.tt-table-container::-webkit-scrollbar,
+.tt-comparison-container::-webkit-scrollbar {
+    width: 6px;
+}
+
+.tt-table-container::-webkit-scrollbar-track,
+.tt-comparison-container::-webkit-scrollbar-track {
+    background: #333;
+    border-radius: 3px;
+}
+
+.tt-table-container::-webkit-scrollbar-thumb,
+.tt-comparison-container::-webkit-scrollbar-thumb {
+    background: #666;
+    border-radius: 3px;
+}
+
+.tt-table-container::-webkit-scrollbar-thumb:hover,
+.tt-comparison-container::-webkit-scrollbar-thumb:hover {
+    background: #888;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .tt-container {
+        flex-direction: column;
+    }
+
+    .tt-left-panel {
+        border-right: none;
+        border-bottom: 2px solid #444;
+        flex: 1;
+    }
+
+    .tt-right-panel {
+        width: auto;
+        height: 300px;
+        flex-shrink: 0;
+    }
+
+    .tt-main-time {
+        font-size: 16px;
+    }
+
+    .tt-sectors {
+        flex-direction: column;
+        gap: 2px;
+    }
+}

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -21,6 +21,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/lapSectorRecords.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreRecords.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreDeltaToast.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/timeTrial.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@10"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/4.4.1/socket.io.min.js"></script>
@@ -103,181 +104,145 @@
 
         <!-- Time Trial Body -->
         <div class="telemetry-time-trial-wrapper" id="time-trial-div" style="display: none;">
-          <div class="telemetry-time-trial-wrapper d-flex w-100 h-100">
-            <!-- Left Side (50%) -->
-            <div class="flex-grow-1 h-100 telemetry-time-trial-wrapper overflow-auto" id="time-trial-table-div" style="width: 50%;">
-              <div class="section-header text-center fw-bold">Lap Time History</div>
-              <table class="table table-striped table-bordered table-dark text-center" >
-                <thead>
-                  <tr>
-                    <th>Lap</th>
-                    <th>S1</th>
-                    <th>S2</th>
-                    <th>S3</th>
-                    <th>Total</th>
-                    <th>Top Speed</th>
-                  </tr>
-                </thead>
-                <tbody id="tt-lap-time-table">
-                  <!-- Populated by JavaScript -->
-                </tbody>
-              </table>
-            </div>
-
-            <!-- Right Side (50%) -->
-            <div class="d-flex flex-column telemetry-time-trial-wrapper time-trial-tt-data overflow-none" id="time-trial-tt-data-div" style="width: 50%;">
-              <!-- Section 1 -->
-              <div class="time-trial-tt-data-section" id="tt-data-section-1">
-                <div class="section-header text-center fw-bold">Player Session Best</div>
-                <div class="time-trial-tt-data-tables" id="ttPlayerSessionBestDiv">
-                  <!-- First Table -->
-                  <table class="table table-striped table-bordered table-dark text-center time-trial-tt-data-table">
-                    <thead>
-                      <tr>
-                        <th>Total</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
-                        <th>Valid</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td id="ttPlayerSessionBestTotal">---</td>
-                        <td id="ttPlayerSessionBestS1">---</td>
-                        <td id="ttPlayerSessionBestS2">---</td>
-                        <td id="ttPlayerSessionBestS3">---</td>
-                        <td id="ttPlayerSessionBestValid">---</td>
-                      </tr>
-                    </tbody>
-                  </table>
-
-                  <!-- Second Table -->
-                  <table class="table table-striped table-bordered table-dark text-center time-trial-tt-data-table">
-                    <thead>
-                      <tr>
-                        <th>TC</th>
-                        <th>ABS</th>
-                        <th>Gears</th>
-                        <th>Eq. Perf.</th>
-                        <th>Cust. Setup</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td id="ttPlayerSessionBestTC">---</td>
-                        <td id="ttPlayerSessionBestABS">---</td>
-                        <td id="ttPlayerSessionBestGearbox">---</td>
-                        <td id="ttPlayerSessionBestEqualPerformance">---</td>
-                        <td id="ttPlayerSessionBestCustomSetup">---</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
+          <div id="tt-container" class="tt-container">
+              <!-- Left Half - Lap Times Table -->
+              <div class="tt-left-panel">
+                  <div class="tt-table-container">
+                      <table class="table table-dark table-striped tt-lap-table">
+                          <thead class="tt-table-head">
+                              <tr>
+                                  <th>Lap</th>
+                                  <th>S1</th>
+                                  <th>S2</th>
+                                  <th>S3</th>
+                                  <th>Lap Time</th>
+                                  <th>vMax</th>
+                              </tr>
+                          </thead>
+                          <tbody id="tt-lap-table-body">
+                              <!-- Lap data will be inserted here -->
+                          </tbody>
+                      </table>
+                  </div>
               </div>
 
-              <!-- Section 2 -->
-              <div class="time-trial-tt-data-section" id="tt-data-section-2">
-                <div class="section-header text-center fw-bold">Player Personal Best</div>
+              <!-- Right Half - Comparison Data -->
+              <div class="tt-right-panel">
+                  <div class="tt-comparison-container">
+                      <!-- Personal Best -->
+                      <div class="tt-comparison-card tt-personal-best">
+                          <div class="tt-card-header">
+                              <div class="tt-card-header-content">
+                                  <h6 class="tt-card-title">Personal Best</h6>
+                                  <div class="tt-main-time" id="tt-pb-time">--:--:---</div>
+                              </div>
+                              <div class="tt-wings">Wings: <span id="tt-pb-wings">50-50</span></div>
+                          </div>
+                          <div class="tt-card-body">
+                              <div class="tt-sectors">
+                                  <div class="tt-sector">S1: <span id="tt-pb-s1">--:---</span></div>
+                                  <div class="tt-sector">S2: <span id="tt-pb-s2">--:---</span></div>
+                                  <div class="tt-sector">S3: <span id="tt-pb-s3">--:---</span></div>
+                              </div>
+                              <div class="tt-details">
+                                  <div class="tt-assists">
+                                      <span class="tt-assist" id="tt-pb-tc">TC: -</span>
+                                      <span class="tt-assist" id="tt-pb-abs">ABS: -</span>
+                                      <span class="tt-assist" id="tt-pb-gears">Gears: -</span>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
 
-                <div class="time-trial-tt-data-tables" id="ttPlayerPersonalBestDiv">
-                  <!-- First Table -->
-                  <table class="table table-striped table-bordered table-dark text-center time-trial-tt-data-table">
-                    <thead>
-                      <tr>
-                        <th>Total</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
-                        <th>Valid</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td id="ttPlayerPersonalBestTotal">---</td>
-                        <td id="ttPlayerPersonalBestS1">---</td>
-                        <td id="ttPlayerPersonalBestS2">---</td>
-                        <td id="ttPlayerPersonalBestS3">---</td>
-                        <td id="ttPlayerPersonalBestValid">---</td>
-                      </tr>
-                    </tbody>
-                  </table>
+                      <!-- Session Best -->
+                      <div class="tt-comparison-card tt-session-best">
+                          <div class="tt-card-header">
+                              <div class="tt-card-header-content">
+                                  <h6 class="tt-card-title">Session Best</h6>
+                                  <div class="tt-main-time" id="tt-sb-time">--:--:---</div>
+                              </div>
+                              <div class="tt-wings">Wings: <span id="tt-sb-wings">50-50</span></div>
+                          </div>
+                          <div class="tt-card-body">
+                              <div class="tt-sectors">
+                                  <div class="tt-sector">S1: <span id="tt-sb-s1">--:---</span></div>
+                                  <div class="tt-sector">S2: <span id="tt-sb-s2">--:---</span></div>
+                                  <div class="tt-sector">S3: <span id="tt-sb-s3">--:---</span></div>
+                              </div>
+                              <div class="tt-details">
+                                  <div class="tt-assists">
+                                      <span class="tt-assist" id="tt-sb-tc">TC: -</span>
+                                      <span class="tt-assist" id="tt-sb-abs">ABS: -</span>
+                                      <span class="tt-assist" id="tt-sb-gears">Gears: -</span>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
 
-                  <!-- Second Table -->
-                  <table class="table table-striped table-bordered table-dark text-center time-trial-tt-data-table">
-                    <thead>
-                      <tr>
-                        <th>TC</th>
-                        <th>ABS</th>
-                        <th>Gears</th>
-                        <th>Eq. Perf.</th>
-                        <th>Cust. Setup</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td id="ttPlayerPersonalBestTC">---</td>
-                        <td id="ttPlayerPersonalBestABS">---</td>
-                        <td id="ttPlayerPersonalBestGearbox">---</td>
-                        <td id="ttPlayerPersonalBestEqualPerformance">---</td>
-                        <td id="ttPlayerPersonalBestCustomSetup">---</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
+                      <!-- Rival Best -->
+                      <div class="tt-comparison-card tt-rival-best">
+                          <div class="tt-card-header">
+                              <div class="tt-card-header-content">
+                                  <h6 class="tt-card-title">Rival Best</h6>
+                                  <div class="tt-main-time" id="tt-rival-time">--:--:---</div>
+                              </div>
+                              <div class="tt-wings">Wings: <span id="tt-rival-wings">50-50</span></div>
+                          </div>
+                          <div class="tt-card-body">
+                              <div class="tt-sectors">
+                                  <div class="tt-sector">S1: <span id="tt-rival-s1">--:---</span></div>
+                                  <div class="tt-sector">S2: <span id="tt-rival-s2">--:---</span></div>
+                                  <div class="tt-sector">S3: <span id="tt-rival-s3">--:---</span></div>
+                              </div>
+                              <div class="tt-details">
+                                  <div class="tt-assists">
+                                      <span class="tt-assist" id="tt-rival-tc">TC: -</span>
+                                      <span class="tt-assist" id="tt-rival-abs">ABS: -</span>
+                                      <span class="tt-assist" id="tt-rival-gears">Gears: -</span>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+
+                      <!-- Theoretical Best & Session Info Combined -->
+                      <div class="tt-comparison-card tt-theoretical-best">
+                          <div class="tt-card-header">
+                              <div class="tt-card-header-content">
+                                  <h6 class="tt-card-title">Theoretical Best</h6>
+                                  <div class="tt-main-time" id="tt-theoretical-time">--:--:---</div>
+                              </div>
+                          </div>
+                          <div class="tt-card-body">
+                              <div class="tt-sectors">
+                                  <div class="tt-sector">S1: <span id="tt-theoretical-s1">--:---</span></div>
+                                  <div class="tt-sector">S2: <span id="tt-theoretical-s2">--:---</span></div>
+                                  <div class="tt-sector">S3: <span id="tt-theoretical-s3">--:---</span></div>
+                              </div>
+                              <div class="tt-details">
+                                  <div class="tt-theoretical-note">Best sectors combined</div>
+                                  <div class="tt-session-info-grid">
+                                      <div class="tt-info-item">
+                                          <span class="tt-info-label">Best Lap:</span>
+                                          <span id="tt-best-lap-num" class="tt-info-value">-</span>
+                                      </div>
+                                      <div class="tt-info-item">
+                                          <span class="tt-info-label">Best S1:</span>
+                                          <span id="tt-best-s1-lap" class="tt-info-value">Lap -</span>
+                                      </div>
+                                      <div class="tt-info-item">
+                                          <span class="tt-info-label">Best S2:</span>
+                                          <span id="tt-best-s2-lap" class="tt-info-value">Lap -</span>
+                                      </div>
+                                      <div class="tt-info-item">
+                                          <span class="tt-info-label">Best S3:</span>
+                                          <span id="tt-best-s3-lap" class="tt-info-value">Lap -</span>
+                                      </div>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
               </div>
-
-              <!-- Section 3 -->
-              <div class="time-trial-tt-data-section" id="tt-data-section-3">
-                <div class="section-header text-center fw-bold">Rival Session Best</div>
-
-                <div class="time-trial-tt-data-tables" id="ttRivalSessionBestDiv">
-                  <!-- First Table -->
-                  <table class="table table-striped table-bordered table-dark text-center time-trial-tt-data-table">
-                    <thead>
-                      <tr>
-                        <th>Total</th>
-                        <th>S1</th>
-                        <th>S2</th>
-                        <th>S3</th>
-                        <th>Valid</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td id="ttRivalSessionBestTotal">---</td>
-                        <td id="ttRivalSessionBestS1">---</td>
-                        <td id="ttRivalSessionBestS2">---</td>
-                        <td id="ttRivalSessionBestS3">---</td>
-                        <td id="ttRivalSessionBestValid">---</td>
-                      </tr>
-                    </tbody>
-                  </table>
-
-                  <!-- Second Table -->
-                  <table class="table table-striped table-bordered table-dark text-center time-trial-tt-data-table">
-                    <thead>
-                      <tr>
-                        <th>TC</th>
-                        <th>ABS</th>
-                        <th>Gears</th>
-                        <th>Eq. Perf.</th>
-                        <th>Cust. Setup</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td id="ttRivalSessionBestTC">---</td>
-                        <td id="ttRivalSessionBestABS">---</td>
-                        <td id="ttRivalSessionBestGearbox">---</td>
-                        <td id="ttRivalSessionBestEqualPerformance">---</td>
-                        <td id="ttRivalSessionBestCustomSetup">---</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
           </div>
         </div>
       </main>

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreRecords.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreDeltaToast.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/timeTrial.css') }}">
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@10"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/4.4.1/socket.io.min.js"></script>

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -218,27 +218,6 @@
                                   <div class="tt-sector">S2: <span id="tt-theoretical-s2">--:---</span></div>
                                   <div class="tt-sector">S3: <span id="tt-theoretical-s3">--:---</span></div>
                               </div>
-                              <div class="tt-details">
-                                  <div class="tt-theoretical-note">Best sectors combined</div>
-                                  <div class="tt-session-info-grid">
-                                      <div class="tt-info-item">
-                                          <span class="tt-info-label">Best Lap:</span>
-                                          <span id="tt-best-lap-num" class="tt-info-value">-</span>
-                                      </div>
-                                      <div class="tt-info-item">
-                                          <span class="tt-info-label">Best S1:</span>
-                                          <span id="tt-best-s1-lap" class="tt-info-value">Lap -</span>
-                                      </div>
-                                      <div class="tt-info-item">
-                                          <span class="tt-info-label">Best S2:</span>
-                                          <span id="tt-best-s2-lap" class="tt-info-value">Lap -</span>
-                                      </div>
-                                      <div class="tt-info-item">
-                                          <span class="tt-info-label">Best S3:</span>
-                                          <span id="tt-best-s3-lap" class="tt-info-value">Lap -</span>
-                                      </div>
-                                  </div>
-                              </div>
                           </div>
                       </div>
                   </div>

--- a/apps/frontend/js/timeTrialDataPopulator.js
+++ b/apps/frontend/js/timeTrialDataPopulator.js
@@ -23,7 +23,7 @@ class TimeTrialDataPopulator {
             // Only update comparison data if packet format is 2024 or later
             if (packetFormat >= 2024) {
                 this.restoreComparisonCards();
-                this.updateComparisonData(data['tt-data']);
+                this.updateComparisonData(data['tt-data'], data['tt-setups']);
             } else {
                 this.hideComparisonCardsForOlderFormat();
             }
@@ -286,32 +286,35 @@ class TimeTrialDataPopulator {
     /**
      * Update comparison data (personal best, session best, rival best)
      */
-    updateComparisonData(ttData) {
+    updateComparisonData(ttData, ttSetups) {
         if (!ttData) return;
 
         // Personal Best
         const pbData = ttData['personal-best-data-set'];
+        const pbSetup = ttSetups['personal-best-setup'];
         if (pbData) {
-            this.updateComparisonCard('pb', pbData);
+            this.updateComparisonCard('pb', pbData, pbSetup);
         }
 
         // Session Best
         const sbData = ttData['player-session-best-data-set'];
+        const sbSetup = ttSetups['player-session-best-setup'];
         if (sbData) {
-            this.updateComparisonCard('sb', sbData);
+            this.updateComparisonCard('sb', sbData, sbSetup);
         }
 
         // Rival Best
         const rivalData = ttData['rival-session-best-data-set'];
+        const rivalSetup = ttSetups['rival-session-best-setup'];
         if (rivalData) {
-            this.updateComparisonCard('rival', rivalData);
+            this.updateComparisonCard('rival', rivalData, rivalSetup);
         }
     }
 
     /**
      * Update individual comparison card
      */
-    updateComparisonCard(prefix, data) {
+    updateComparisonCard(prefix, data, setup) {
         const timeElement = document.getElementById(`tt-${prefix}-time`);
         const s1Element = document.getElementById(`tt-${prefix}-s1`);
         const s2Element = document.getElementById(`tt-${prefix}-s2`);
@@ -319,8 +322,6 @@ class TimeTrialDataPopulator {
         const tcElement = document.getElementById(`tt-${prefix}-tc`);
         const absElement = document.getElementById(`tt-${prefix}-abs`);
         const gearsElement = document.getElementById(`tt-${prefix}-gears`);
-        // TODO: Populate wings data from actual data source
-        // const wingsElement = document.getElementById(`tt-${prefix}-wings`);
 
         if (timeElement) timeElement.textContent = data['lap-time-str'] || '--:--:---';
         if (s1Element) s1Element.textContent = data['sector-1-time-str'] || '--:---';
@@ -329,6 +330,13 @@ class TimeTrialDataPopulator {
         if (tcElement) tcElement.textContent = `TC: ${this.getAssistText(data['traction-control'])}`;
         if (absElement) absElement.textContent = `ABS: ${this.getAssistText(data['anti-lock-brakes'])}`;
         if (gearsElement) gearsElement.textContent = `Gears: ${this.getAssistText(data['gearbox-assist'])}`;
+
+        const wingsElement = document.getElementById(`tt-${prefix}-wings`);
+        if (wingsElement && setup && setup['is-valid']) {
+            const frontWing = setup['front-wing'];
+            const rearWing = setup['rear-wing'];
+            wingsElement.textContent = `${frontWing} - ${rearWing}`;
+        }
     }
 
     getAssistText(assistValue) {
@@ -406,6 +414,7 @@ class TimeTrialDataPopulator {
             const tcEl = document.getElementById(`tt-${prefix}-tc`);
             const absEl = document.getElementById(`tt-${prefix}-abs`);
             const gearsEl = document.getElementById(`tt-${prefix}-gears`);
+            const wingsEl = document.getElementById(`tt-${prefix}-wings`);
 
             if (timeEl) timeEl.textContent = '--:--:---';
             if (s1El) s1El.textContent = '--:---';
@@ -414,6 +423,7 @@ class TimeTrialDataPopulator {
             if (tcEl) tcEl.textContent = 'TC: -';
             if (absEl) absEl.textContent = 'ABS: -';
             if (gearsEl) gearsEl.textContent = 'Gears: -';
+            if (wingsEl) wingsEl.textContent = '-';
         });
 
         // Clear theoretical best and session info

--- a/apps/frontend/js/timeTrialDataPopulator.js
+++ b/apps/frontend/js/timeTrialDataPopulator.js
@@ -33,12 +33,25 @@ class TimeTrialDataPopulator {
         const bestLapIndex = sessionHistory['best-lap-time-lap-num'] - 1;
 
         tbody.innerHTML = '';
+        const lapValidMask = 1;
+        const s1ValidMask = 2;
+        const s2ValidMask = 4;
+        const s3ValidMask = 8;
+
+        const bestLapTimeLapNum = sessionHistory["best-lap-time-lap-num"];
+        const bestS1TimeLapNum  = sessionHistory["best-sector-1-lap-num"];
+        const bestS2TimeLapNum  = sessionHistory["best-sector-2-lap-num"];
+        const bestS3TimeLapNum  = sessionHistory["best-sector-3-lap-num"];
 
         lapData.forEach((lap, index) => {
             const row = document.createElement('tr');
             const lapNum = index + 1;
-            const isBestLap = index === bestLapIndex;
-            const isValid = this.isLapValid(lap['lap-valid-bit-flags']);
+
+            const validBitFlags = lap['lap-valid-bit-flags'];
+            const isLapValid = validBitFlags & lapValidMask;
+            const isS1Valid = validBitFlags & s1ValidMask;
+            const isS2Valid = validBitFlags & s2ValidMask;
+            const isS3Valid = validBitFlags & s3ValidMask;
 
             const lapCell = document.createElement('td');
             const lapStrong = document.createElement('strong');
@@ -46,25 +59,23 @@ class TimeTrialDataPopulator {
             lapCell.appendChild(lapStrong);
 
             const s1Cell = document.createElement('td');
-            s1Cell.textContent = lap['sector-1-time-str'] || '--:---';
-            if (!isValid) s1Cell.classList.add('tt-invalid-lap');
+            s1Cell.textContent = (lap["sector-1-time-in-ms"]) ? (lap['sector-1-time-str']) : ('--:---');
+            this.applyColourToCell(s1Cell, lapNum, bestS1TimeLapNum, isS1Valid);
 
             const s2Cell = document.createElement('td');
-            s2Cell.textContent = lap['sector-2-time-str'] || '--:---';
-            if (!isValid) s2Cell.classList.add('tt-invalid-lap');
+            s2Cell.textContent = (lap["sector-2-time-in-ms"]) ? (lap['sector-2-time-str']) : ('--:---');
+            this.applyColourToCell(s2Cell, lapNum, bestS2TimeLapNum, isS2Valid);
 
             const s3Cell = document.createElement('td');
-            s3Cell.textContent = lap['sector-3-time-str'] || '--:---';
-            if (!isValid) s3Cell.classList.add('tt-invalid-lap');
+            s3Cell.textContent = (lap["sector-3-time-in-ms"]) ? (lap['sector-3-time-str']) : ('--:---');
+            this.applyColourToCell(s3Cell, lapNum, bestS3TimeLapNum, isS3Valid);
 
             const lapTimeCell = document.createElement('td');
-            lapTimeCell.textContent = lap['lap-time-str'] || '--:--:---';
-            if (isBestLap) lapTimeCell.classList.add('tt-best-time');
-            if (!isValid) lapTimeCell.classList.add('tt-invalid-lap');
+            lapTimeCell.textContent = (lap["lap-time-in-ms"]) ? (lap['lap-time-str']) : ('--:---');;
+            this.applyColourToCell(lapTimeCell, lapNum, bestLapTimeLapNum, isLapValid);
 
             const speedCell = document.createElement('td');
             speedCell.textContent = lap['top-speed-kmph'] || '-';
-            if (!isValid) speedCell.classList.add('tt-invalid-lap');
 
             row.appendChild(lapCell);
             row.appendChild(s1Cell);
@@ -79,6 +90,19 @@ class TimeTrialDataPopulator {
         // Scroll to bottom to show latest lap
         if (tbody.parentElement) {
             tbody.parentElement.scrollTop = tbody.parentElement.scrollHeight;
+        }
+    }
+
+    /**
+     * Apply color based on conditions
+     */
+    applyColourToCell(cell, lapNum, pbLapNum, isValid) {
+        if (pbLapNum && (lapNum === pbLapNum)) {
+            // green time
+            cell.classList.add("tt-best-time");
+        } else if (!isValid) {
+            // red time
+            cell.classList.add("tt-invalid-lap");
         }
     }
 
@@ -140,33 +164,34 @@ class TimeTrialDataPopulator {
         }
 
         const lapData = sessionHistory['lap-history-data'];
-        let bestS1 = null, bestS2 = null, bestS3 = null;
-        let bestS1Time = Infinity, bestS2Time = Infinity, bestS3Time = Infinity;
+        let bestS1TimeStr = null, bestS2TimeStr = null, bestS3TimeStr = null;
+        let bestS1TimeMs = Infinity, bestS2TimeMs = Infinity, bestS3TimeMs = Infinity;
 
-        // Find best sector times from valid laps
-        lapData.forEach(lap => {
-            if (this.isLapValid(lap['lap-valid-bit-flags'])) {
-                if (lap['sector-1-time-in-ms'] && lap['sector-1-time-in-ms'] < bestS1Time) {
-                    bestS1Time = lap['sector-1-time-in-ms'];
-                    bestS1 = lap['sector-1-time-str'];
-                }
-                if (lap['sector-2-time-in-ms'] && lap['sector-2-time-in-ms'] < bestS2Time) {
-                    bestS2Time = lap['sector-2-time-in-ms'];
-                    bestS2 = lap['sector-2-time-str'];
-                }
-                if (lap['sector-3-time-in-ms'] && lap['sector-3-time-in-ms'] < bestS3Time) {
-                    bestS3Time = lap['sector-3-time-in-ms'];
-                    bestS3 = lap['sector-3-time-str'];
-                }
-            }
-        });
+        const bestS1LapNum = sessionHistory["best-sector-1-lap-num"];
+        const bestS2LapNum = sessionHistory["best-sector-2-lap-num"];
+        const bestS3LapNum = sessionHistory["best-sector-3-lap-num"];
+
+        if (bestS1LapNum && bestS1LapNum < lapData.length) {
+            bestS1TimeStr = lapData[bestS1LapNum - 1]['sector-1-time-str'];
+            bestS1TimeMs = lapData[bestS1LapNum - 1]['sector-1-time-in-ms'];
+        }
+
+        if (bestS2LapNum && bestS2LapNum < lapData.length) {
+            bestS2TimeStr = lapData[bestS2LapNum - 1]['sector-2-time-str'];
+            bestS2TimeMs = lapData[bestS2LapNum - 1]['sector-2-time-in-ms'];
+        }
+
+        if (bestS3LapNum && bestS3LapNum < lapData.length) {
+            bestS3TimeStr = lapData[bestS3LapNum - 1]['sector-3-time-str'];
+            bestS3TimeMs = lapData[bestS3LapNum - 1]['sector-3-time-in-ms'];
+        }
 
         // Calculate theoretical best time
         let theoreticalTimeMs = 0;
         let theoreticalTimeStr = '--:--:---';
 
-        if (bestS1Time !== Infinity && bestS2Time !== Infinity && bestS3Time !== Infinity) {
-            theoreticalTimeMs = bestS1Time + bestS2Time + bestS3Time;
+        if (bestS1TimeMs !== Infinity && bestS2TimeMs !== Infinity && bestS3TimeMs !== Infinity) {
+            theoreticalTimeMs = bestS1TimeMs + bestS2TimeMs + bestS3TimeMs;
             const minutes = Math.floor(theoreticalTimeMs / 60000);
             const seconds = Math.floor((theoreticalTimeMs % 60000) / 1000);
             const milliseconds = theoreticalTimeMs % 1000;
@@ -180,37 +205,9 @@ class TimeTrialDataPopulator {
         const s3Element = document.getElementById('tt-theoretical-s3');
 
         if (timeElement) timeElement.textContent = theoreticalTimeStr;
-        if (s1Element) s1Element.textContent = bestS1 || '--:---';
-        if (s2Element) s2Element.textContent = bestS2 || '--:---';
-        if (s3Element) s3Element.textContent = bestS3 || '--:---';
-
-        // Update session info
-        const bestLapElement = document.getElementById('tt-best-lap-num');
-        const bestS1Element = document.getElementById('tt-best-s1-lap');
-        const bestS2Element = document.getElementById('tt-best-s2-lap');
-        const bestS3Element = document.getElementById('tt-best-s3-lap');
-
-        if (bestLapElement) {
-            bestLapElement.textContent = sessionHistory['best-lap-time-lap-num'] || '-';
-        }
-        if (bestS1Element) {
-            bestS1Element.textContent = `Lap ${sessionHistory['best-sector-1-lap-num'] || '-'}`;
-        }
-        if (bestS2Element) {
-            bestS2Element.textContent = `Lap ${sessionHistory['best-sector-2-lap-num'] || '-'}`;
-        }
-        if (bestS3Element) {
-            bestS3Element.textContent = `Lap ${sessionHistory['best-sector-3-lap-num'] || '-'}`;
-        }
-    }
-
-    /**
-     * Check if lap is valid based on bit flags
-     */
-    isLapValid(validBitFlags) {
-        // Assuming valid lap has certain bits set
-        // This is a simplified check - adjust based on your data format
-        return validBitFlags && validBitFlags > 0;
+        if (s1Element) s1Element.textContent = bestS1TimeStr || '--:---';
+        if (s2Element) s2Element.textContent = bestS2TimeStr || '--:---';
+        if (s3Element) s3Element.textContent = bestS3TimeStr || '--:---';
     }
 
     /**
@@ -252,14 +249,6 @@ class TimeTrialDataPopulator {
                     el.textContent = '--:---';
                 }
             }
-        });
-
-        const sessionInfoElements = [
-            'tt-best-lap-num', 'tt-best-s1-lap', 'tt-best-s2-lap', 'tt-best-s3-lap'
-        ];
-        sessionInfoElements.forEach(id => {
-            const el = document.getElementById(id);
-            if (el) el.textContent = '-';
         });
     }
 }

--- a/apps/frontend/js/timeTrialDataPopulator.js
+++ b/apps/frontend/js/timeTrialDataPopulator.js
@@ -326,10 +326,13 @@ class TimeTrialDataPopulator {
         if (s1Element) s1Element.textContent = data['sector-1-time-str'] || '--:---';
         if (s2Element) s2Element.textContent = data['sector-2-time-str'] || '--:---';
         if (s3Element) s3Element.textContent = data['sector-3-time-str'] || '--:---';
-        if (tcElement) tcElement.textContent = `TC: ${data['traction-control'] || '-'}`;
-        if (absElement) absElement.textContent = `ABS: ${data['anti-lock-brakes'] ? 'ON' : 'OFF'}`;
-        // TODO: Populate gears data from actual data source instead of hardcoding
-        if (gearsElement) gearsElement.textContent = `Gears: AUTO`;
+        if (tcElement) tcElement.textContent = `TC: ${this.getAssistText(data['traction-control'])}`;
+        if (absElement) absElement.textContent = `ABS: ${this.getAssistText(data['anti-lock-brakes'])}`;
+        if (gearsElement) gearsElement.textContent = `Gears: ${this.getAssistText(data['gearbox-assist'])}`;
+    }
+
+    getAssistText(assistValue) {
+        return assistValue ? '✅' : '❌';
     }
 
     /**

--- a/apps/frontend/js/timeTrialDataPopulator.js
+++ b/apps/frontend/js/timeTrialDataPopulator.js
@@ -332,10 +332,12 @@ class TimeTrialDataPopulator {
         if (gearsElement) gearsElement.textContent = `Gears: ${this.getAssistText(data['gearbox-assist'])}`;
 
         const wingsElement = document.getElementById(`tt-${prefix}-wings`);
-        if (wingsElement && setup && setup['is-valid']) {
+        if (wingsElement && setup && setup['is-valid'] && data['is-valid']) {
             const frontWing = setup['front-wing'];
             const rearWing = setup['rear-wing'];
             wingsElement.textContent = `${frontWing} - ${rearWing}`;
+        } else {
+            wingsElement.textContent = '-';
         }
     }
 

--- a/apps/frontend/js/timeTrialDataPopulator.js
+++ b/apps/frontend/js/timeTrialDataPopulator.js
@@ -1,183 +1,265 @@
-class TimeTrialTtDataPopulator {
-    constructor(sectionPrefix) {
-
-        // For logging purposes
-        this.sectionPrefix = sectionPrefix;
-
-        // Init the overall div
-        this.sectionDiv     = document.getElementById(`${sectionPrefix}Div`);
-
-        // Init the first table's cells
-        this.totalTimeCell  = document.getElementById(`${sectionPrefix}Total`);
-        this.s1Cell         = document.getElementById(`${sectionPrefix}S1`);
-        this.s2Cell         = document.getElementById(`${sectionPrefix}S2`);
-        this.s3Cell         = document.getElementById(`${sectionPrefix}S3`);
-        this.validCell      = document.getElementById(`${sectionPrefix}Valid`);
-
-        // Init the second table's cells
-        this.tcCell         = document.getElementById(`${sectionPrefix}TC`);
-        this.absCell        = document.getElementById(`${sectionPrefix}ABS`);
-        this.gearboxCell    = document.getElementById(`${sectionPrefix}Gearbox`);
-        this.eqPerfCell     = document.getElementById(`${sectionPrefix}EqualPerformance`);
-        this.custSetupCell  = document.getElementById(`${sectionPrefix}CustomSetup`);
-    }
-
-    populate(ttPacket, packetFormat) {
-
-        if (packetFormat < 2024) {
-            this.clearCells();
-            this.showUnsupportedDiv();
-            return;
-        }
-
-        if (!ttPacket) {
-            this.clearCells();
-            return;
-        }
-
-        this.populateCells(ttPacket);
-    }
-
-    showUnsupportedDiv() {
-        // console.log("Should render unsupp div", this.sectionPrefix);
-        return;
-    }
-
-    clearCells() {
-        this.totalTimeCell.textContent = '---';
-        this.s1Cell.textContent = '---';
-        this.s2Cell.textContent = '---';
-        this.s3Cell.textContent = '---';
-        this.validCell.textContent = '---';
-
-        this.tcCell.textContent = '---';
-        this.absCell.textContent = '---';
-        this.gearboxCell.textContent = '---';
-        this.eqPerfCell.textContent = '---';
-        this.custSetupCell.textContent = '---';
-    }
-
-    populateCells(ttPacket) {
-
-        this.totalTimeCell.textContent = ttPacket["lap-time-str"];
-        this.s1Cell.textContent = ttPacket["sector-1-time-str"];
-        this.s2Cell.textContent = ttPacket["sector-2-time-str"];
-        this.s3Cell.textContent = ttPacket["sector-3-time-str"];
-        this.validCell.textContent = (ttPacket["valid"]) ? ('✔️') : ('❌');
-
-        this.tcCell.textContent = (ttPacket["traction-control"] != "OFF") ? ('✔️') : ('❌');
-        this.absCell.textContent = (ttPacket["anti-lock-brakes"]) ? ('✔️') : ('❌');
-
-        this.eqPerfCell.textContent = (ttPacket["equal-car-performance"]) ? ('✔️') : ('❌');
-        this.custSetupCell.textContent = (ttPacket["custom-setup"]) ? ('✔️') : ('❌');
-
-        let gearBoxStatus;
-        switch (ttPacket["gearbox-assist"]) {
-            case "Manual":
-            case "Manual With Suggested Gear":
-                gearBoxStatus = '❌';
-                break;
-            case "Auto":
-                gearBoxStatus = '✔️';
-                break;
-            default:
-                gearBoxStatus = '❔❕';
-        }
-        this.gearboxCell.textContent = (gearBoxStatus);
-    }
-}
-
 class TimeTrialDataPopulator {
     constructor() {
-        this.timeTrialTable                 = document.getElementById('tt-lap-time-table');
-
-        this.playerSessionBestPopulator     = new TimeTrialTtDataPopulator('ttPlayerSessionBest');
-        this.playerPersonalBestPopulator    = new TimeTrialTtDataPopulator('ttPlayerPersonalBest');
-        this.rivalSessionBestPopulator      = new TimeTrialTtDataPopulator('ttRivalSessionBest');
+        this.container = document.getElementById('tt-container');
+        if (!this.container) {
+            throw new Error('Time Trial container not found');
+        }
     }
 
-    populate(incomingData, packetFormat) {
-        this.populateTimeTrialTable(incomingData["session-history"], packetFormat);
-        this.populateTimeTrialTtData(incomingData["tt-data"], packetFormat);
+    /**
+     * Main method to populate the UI with time trial data
+     * @param {Object} data - The time trial data object
+     */
+    populate(data) {
+        try {
+            this.updateLapHistory(data['session-history']);
+            this.updateComparisonData(data['tt-data']);
+            this.updateTheoreticalBestAndSessionInfo(data['session-history']);
+        } catch (error) {
+            console.error('Error populating time trial data:', error);
+        }
     }
 
-    populateTimeTrialTable(incomingData, packetFormat) {
-        if (!incomingData || !incomingData["lap-history-data"]) {
+    /**
+     * Update lap history table
+     */
+    updateLapHistory(sessionHistory) {
+        const tbody = document.getElementById('tt-lap-table-body');
+        if (!tbody || !sessionHistory || !sessionHistory['lap-history-data']) {
             return;
         }
 
-        const lapValidMask = 1;
-        const s1ValidMask = 2;
-        const s2ValidMask = 4;
-        const s3ValidMask = 8;
+        const lapData = sessionHistory['lap-history-data'];
+        const bestLapIndex = sessionHistory['best-lap-time-lap-num'] - 1;
 
-        const bestLapTimeLapNum = incomingData["best-lap-time-lap-num"];
-        const bestS1TimeLapNum  = incomingData["best-sector-1-time-lap-num"];
-        const bestS2TimeLapNum  = incomingData["best-sector-2-time-lap-num"];
-        const bestS3TimeLapNum  = incomingData["best-sector-3-time-lap-num"];
+        tbody.innerHTML = '';
 
-        // Clear existing rows except the header
-        this.timeTrialTable.innerHTML = '';
-        const lapHistory = incomingData["lap-history-data"];
-        lapHistory.forEach((lap, index) => {
-            if (lap["sector-1-time-in-ms"] === 0) {
-              return;
-            }
-
-            const lapValidBitFlags = lap["lap-valid-bit-flags"];
-            const lapNum = index + 1;
+        lapData.forEach((lap, index) => {
             const row = document.createElement('tr');
+            const lapNum = index + 1;
+            const isBestLap = index === bestLapIndex;
+            const isValid = this.isLapValid(lap['lap-valid-bit-flags']);
 
             const lapCell = document.createElement('td');
-            lapCell.textContent = lapNum; // Lap number
-            row.appendChild(lapCell);
+            const lapStrong = document.createElement('strong');
+            lapStrong.textContent = lapNum;
+            lapCell.appendChild(lapStrong);
 
-            const sector1Cell = document.createElement('td');
-            sector1Cell.textContent = (lap["sector-1-time-in-ms"]) ? (lap["sector-1-time-str"]) : ('---');
-            this.applyColourToCell(sector1Cell, lapNum, bestS1TimeLapNum, lapValidBitFlags & s1ValidMask);
-            row.appendChild(sector1Cell);
+            const s1Cell = document.createElement('td');
+            s1Cell.textContent = lap['sector-1-time-str'] || '--:---';
+            if (!isValid) s1Cell.classList.add('tt-invalid-lap');
 
-            const sector2Cell = document.createElement('td');
-            sector2Cell.textContent = (lap["sector-2-time-in-ms"]) ? (lap["sector-2-time-str"]) : ('---');
-            this.applyColourToCell(sector2Cell, lapNum, bestS2TimeLapNum, lapValidBitFlags & s2ValidMask);
-            row.appendChild(sector2Cell);
+            const s2Cell = document.createElement('td');
+            s2Cell.textContent = lap['sector-2-time-str'] || '--:---';
+            if (!isValid) s2Cell.classList.add('tt-invalid-lap');
 
-            const sector3Cell = document.createElement('td');
-            sector3Cell.textContent = (lap["sector-3-time-in-ms"]) ? (lap["sector-3-time-str"]) : ('---');
-            this.applyColourToCell(sector3Cell, lapNum, bestS3TimeLapNum, lapValidBitFlags & s3ValidMask);
-            row.appendChild(sector3Cell);
+            const s3Cell = document.createElement('td');
+            s3Cell.textContent = lap['sector-3-time-str'] || '--:---';
+            if (!isValid) s3Cell.classList.add('tt-invalid-lap');
 
             const lapTimeCell = document.createElement('td');
-            lapTimeCell.textContent = (lap["lap-time-in-ms"]) ? (lap["lap-time-str"]) : ('---');
-            this.applyColourToCell(lapTimeCell, lapNum, bestLapTimeLapNum, lapValidBitFlags & lapValidMask);
+            lapTimeCell.textContent = lap['lap-time-str'] || '--:--:---';
+            if (isBestLap) lapTimeCell.classList.add('tt-best-time');
+            if (!isValid) lapTimeCell.classList.add('tt-invalid-lap');
+
+            const speedCell = document.createElement('td');
+            speedCell.textContent = lap['top-speed-kmph'] || '-';
+            if (!isValid) speedCell.classList.add('tt-invalid-lap');
+
+            row.appendChild(lapCell);
+            row.appendChild(s1Cell);
+            row.appendChild(s2Cell);
+            row.appendChild(s3Cell);
             row.appendChild(lapTimeCell);
+            row.appendChild(speedCell);
 
-            const topSpeedCell = document.createElement('td');
-            topSpeedCell.textContent = lap["top-speed-kmph"] || '---';
-            row.appendChild(topSpeedCell);
-
-            this.timeTrialTable.appendChild(row);
+            tbody.appendChild(row);
         });
-    }
 
-    populateTimeTrialTtData(ttData, packetFormat) {
-
-        const playerPersonalBestPacket = (ttData) ? (ttData["personal-best-data-set"]) : (null);
-        const playerSessionBestPacket = (ttData) ? (ttData["player-session-best-data-set"]) : (null);
-        const rivalSessionBestPacket = (ttData) ? (ttData["rival-session-best-data-set"]) : (null);
-
-        this.playerPersonalBestPopulator.populate(playerPersonalBestPacket, packetFormat);
-        this.playerSessionBestPopulator.populate(playerSessionBestPacket, packetFormat);
-        this.rivalSessionBestPopulator.populate(rivalSessionBestPacket, packetFormat);
-    }
-
-    applyColourToCell(cell, lapNum, pbLapNum, isValid) {
-        if (pbLapNum && (lapNum === pbLapNum)) {
-            // green time
-            cell.classList.add("text-success");
-        } else if (!isValid) {
-            // red time
-            cell.classList.add("text-danger");
+        // Scroll to bottom to show latest lap
+        if (tbody.parentElement) {
+            tbody.parentElement.scrollTop = tbody.parentElement.scrollHeight;
         }
+    }
+
+    /**
+     * Update comparison data (personal best, session best, rival best)
+     */
+    updateComparisonData(ttData) {
+        if (!ttData) return;
+
+        // Personal Best
+        const pbData = ttData['personal-best-data-set'];
+        if (pbData) {
+            this.updateComparisonCard('pb', pbData);
+        }
+
+        // Session Best
+        const sbData = ttData['player-session-best-data-set'];
+        if (sbData) {
+            this.updateComparisonCard('sb', sbData);
+        }
+
+        // Rival Best
+        const rivalData = ttData['rival-session-best-data-set'];
+        if (rivalData) {
+            this.updateComparisonCard('rival', rivalData);
+        }
+    }
+
+    /**
+     * Update individual comparison card
+     */
+    updateComparisonCard(prefix, data) {
+        const timeElement = document.getElementById(`tt-${prefix}-time`);
+        const s1Element = document.getElementById(`tt-${prefix}-s1`);
+        const s2Element = document.getElementById(`tt-${prefix}-s2`);
+        const s3Element = document.getElementById(`tt-${prefix}-s3`);
+        const tcElement = document.getElementById(`tt-${prefix}-tc`);
+        const absElement = document.getElementById(`tt-${prefix}-abs`);
+        const gearsElement = document.getElementById(`tt-${prefix}-gears`);
+        // TODO: Populate wings data from actual data source
+        // const wingsElement = document.getElementById(`tt-${prefix}-wings`);
+
+        if (timeElement) timeElement.textContent = data['lap-time-str'] || '--:--:---';
+        if (s1Element) s1Element.textContent = data['sector-1-time-str'] || '--:---';
+        if (s2Element) s2Element.textContent = data['sector-2-time-str'] || '--:---';
+        if (s3Element) s3Element.textContent = data['sector-3-time-str'] || '--:---';
+        if (tcElement) tcElement.textContent = `TC: ${data['traction-control'] || '-'}`;
+        if (absElement) absElement.textContent = `ABS: ${data['anti-lock-brakes'] ? 'ON' : 'OFF'}`;
+        // TODO: Populate gears data from actual data source instead of hardcoding
+        if (gearsElement) gearsElement.textContent = `Gears: AUTO`;
+    }
+
+    /**
+     * Update theoretical best time and session info combined
+     */
+    updateTheoreticalBestAndSessionInfo(sessionHistory) {
+        if (!sessionHistory || !sessionHistory['lap-history-data']) {
+            return;
+        }
+
+        const lapData = sessionHistory['lap-history-data'];
+        let bestS1 = null, bestS2 = null, bestS3 = null;
+        let bestS1Time = Infinity, bestS2Time = Infinity, bestS3Time = Infinity;
+
+        // Find best sector times from valid laps
+        lapData.forEach(lap => {
+            if (this.isLapValid(lap['lap-valid-bit-flags'])) {
+                if (lap['sector-1-time-in-ms'] && lap['sector-1-time-in-ms'] < bestS1Time) {
+                    bestS1Time = lap['sector-1-time-in-ms'];
+                    bestS1 = lap['sector-1-time-str'];
+                }
+                if (lap['sector-2-time-in-ms'] && lap['sector-2-time-in-ms'] < bestS2Time) {
+                    bestS2Time = lap['sector-2-time-in-ms'];
+                    bestS2 = lap['sector-2-time-str'];
+                }
+                if (lap['sector-3-time-in-ms'] && lap['sector-3-time-in-ms'] < bestS3Time) {
+                    bestS3Time = lap['sector-3-time-in-ms'];
+                    bestS3 = lap['sector-3-time-str'];
+                }
+            }
+        });
+
+        // Calculate theoretical best time
+        let theoreticalTimeMs = 0;
+        let theoreticalTimeStr = '--:--:---';
+
+        if (bestS1Time !== Infinity && bestS2Time !== Infinity && bestS3Time !== Infinity) {
+            theoreticalTimeMs = bestS1Time + bestS2Time + bestS3Time;
+            const minutes = Math.floor(theoreticalTimeMs / 60000);
+            const seconds = Math.floor((theoreticalTimeMs % 60000) / 1000);
+            const milliseconds = theoreticalTimeMs % 1000;
+            theoreticalTimeStr = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}.${milliseconds.toString().padStart(3, '0')}`;
+        }
+
+        // Update theoretical best elements
+        const timeElement = document.getElementById('tt-theoretical-time');
+        const s1Element = document.getElementById('tt-theoretical-s1');
+        const s2Element = document.getElementById('tt-theoretical-s2');
+        const s3Element = document.getElementById('tt-theoretical-s3');
+
+        if (timeElement) timeElement.textContent = theoreticalTimeStr;
+        if (s1Element) s1Element.textContent = bestS1 || '--:---';
+        if (s2Element) s2Element.textContent = bestS2 || '--:---';
+        if (s3Element) s3Element.textContent = bestS3 || '--:---';
+
+        // Update session info
+        const bestLapElement = document.getElementById('tt-best-lap-num');
+        const bestS1Element = document.getElementById('tt-best-s1-lap');
+        const bestS2Element = document.getElementById('tt-best-s2-lap');
+        const bestS3Element = document.getElementById('tt-best-s3-lap');
+
+        if (bestLapElement) {
+            bestLapElement.textContent = sessionHistory['best-lap-time-lap-num'] || '-';
+        }
+        if (bestS1Element) {
+            bestS1Element.textContent = `Lap ${sessionHistory['best-sector-1-lap-num'] || '-'}`;
+        }
+        if (bestS2Element) {
+            bestS2Element.textContent = `Lap ${sessionHistory['best-sector-2-lap-num'] || '-'}`;
+        }
+        if (bestS3Element) {
+            bestS3Element.textContent = `Lap ${sessionHistory['best-sector-3-lap-num'] || '-'}`;
+        }
+    }
+
+    /**
+     * Check if lap is valid based on bit flags
+     */
+    isLapValid(validBitFlags) {
+        // Assuming valid lap has certain bits set
+        // This is a simplified check - adjust based on your data format
+        return validBitFlags && validBitFlags > 0;
+    }
+
+    /**
+     * Clear all data from the UI
+     */
+    clear() {
+        const tbody = document.getElementById('tt-lap-table-body');
+        if (tbody) tbody.innerHTML = '';
+
+        // Clear comparison data
+        ['pb', 'sb', 'rival'].forEach(prefix => {
+            const timeEl = document.getElementById(`tt-${prefix}-time`);
+            const s1El = document.getElementById(`tt-${prefix}-s1`);
+            const s2El = document.getElementById(`tt-${prefix}-s2`);
+            const s3El = document.getElementById(`tt-${prefix}-s3`);
+            const tcEl = document.getElementById(`tt-${prefix}-tc`);
+            const absEl = document.getElementById(`tt-${prefix}-abs`);
+            const gearsEl = document.getElementById(`tt-${prefix}-gears`);
+
+            if (timeEl) timeEl.textContent = '--:--:---';
+            if (s1El) s1El.textContent = '--:---';
+            if (s2El) s2El.textContent = '--:---';
+            if (s3El) s3El.textContent = '--:---';
+            if (tcEl) tcEl.textContent = 'TC: -';
+            if (absEl) absEl.textContent = 'ABS: -';
+            if (gearsEl) gearsEl.textContent = 'Gears: -';
+        });
+
+        // Clear theoretical best and session info
+        const theoreticalElements = [
+            'tt-theoretical-time', 'tt-theoretical-s1', 'tt-theoretical-s2', 'tt-theoretical-s3'
+        ];
+        theoreticalElements.forEach(id => {
+            const el = document.getElementById(id);
+            if (el) {
+                if (id === 'tt-theoretical-time') {
+                    el.textContent = '--:--:---';
+                } else {
+                    el.textContent = '--:---';
+                }
+            }
+        });
+
+        const sessionInfoElements = [
+            'tt-best-lap-num', 'tt-best-s1-lap', 'tt-best-s2-lap', 'tt-best-s3-lap'
+        ];
+        sessionInfoElements.forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = '-';
+        });
     }
 }

--- a/lib/f1_types/packet_14_time_trial_data.py
+++ b/lib/f1_types/packet_14_time_trial_data.py
@@ -62,6 +62,19 @@ class TimeTrialDataSet:
     )
     PACKET_LEN = struct.calcsize(PACKET_FORMAT)
 
+    m_carIdx: int
+    m_teamId: Union[TeamID24, TeamID25]
+    m_lapTimeInMS: int
+    m_sector1TimeInMS: int
+    m_sector2TimeInMS: int
+    m_sector3TimeInMS: int
+    m_tractionControl: bool
+    m_gearboxAssist: bool
+    m_antiLockBrakes: bool
+    m_equalCarPerformance: bool
+    m_customSetup: bool
+    m_isValid: bool
+
     def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initializes a TimeTrialDataSet object by unpacking the provided binary data.

--- a/lib/f1_types/packet_14_time_trial_data.py
+++ b/lib/f1_types/packet_14_time_trial_data.py
@@ -24,8 +24,7 @@
 import struct
 from typing import Any, Dict, Union
 
-from .common import (F1Utils, GearboxAssistMode, PacketHeader, TeamID24, TeamID25,
-                     TractionControlAssistMode)
+from .common import F1Utils, PacketHeader, TeamID24, TeamID25
 
 # --------------------- CLASS DEFINITIONS --------------------------------------
 

--- a/lib/f1_types/packet_14_time_trial_data.py
+++ b/lib/f1_types/packet_14_time_trial_data.py
@@ -39,9 +39,9 @@ class TimeTrialDataSet:
         m_sector1TimeInMS (uint32): Sector 1 time in milliseconds
         m_sector2TimeInMS (uint32): Sector 2 time in milliseconds
         m_sector3TimeInMS (uint32): Sector 3 time in milliseconds
-        m_tractionControl (TractionControlAssistMode): Refer TractionControlAssistMode enumeration
-        m_gearboxAssist (int): 1 = manual, 2 = manual & suggested gear, 3 = auto
-        m_antiLockBrakes (bool): 0 (off) - 1 (on)
+        m_tractionControl (bool): false = assist off, true = assist on
+        m_gearboxAssist (bool): false = assist off, true = assist on
+        m_antiLockBrakes (bool): false = assist off, true = assist on
         m_equalCarPerformance (bool): 0 = Realistic, 1 = Equal
         m_customSetup (bool): 0 = No, 1 = Yes
         m_valid (bool): 0 = invalid, 1 = valid
@@ -53,9 +53,9 @@ class TimeTrialDataSet:
         "I" # uint32    m_sector1TimeInMS;          // Sector 1 time in milliseconds
         "I" # uint32    m_sector2TimeInMS;          // Sector 2 time in milliseconds
         "I" # uint32    m_sector3TimeInMS;          // Sector 3 time in milliseconds
-        "B" # uint8     m_tractionControl;          // 0 = off, 1 = medium, 2 = full
-        "B" # uint8     m_gearboxAssist;            // 1 = manual, 2 = manual & suggested gear, 3 = auto
-        "B" # uint8     m_antiLockBrakes;           // 0 (off) - 1 (on)
+        "B" # uint8     m_tractionControl;          // 0 = assist off, 1 = assist on
+        "B" # uint8     m_gearboxAssist;            // 0 = assist off, 1 = assist on
+        "B" # uint8     m_antiLockBrakes;           // 0 = assist off, 1 = assist on
         "B" # uint8     m_equalCarPerformance;      // 0 = Realistic, 1 = Equal
         "B" # uint8     m_customSetup;              // 0 = No, 1 = Yes
         "B" # uint8     m_valid;                    // 0 = invalid, 1 = valid
@@ -95,10 +95,8 @@ class TimeTrialDataSet:
                 self.m_teamId = TeamID24(self.m_teamId)
         elif TeamID25.isValid(self.m_teamId):
             self.m_teamId = TeamID25(self.m_teamId)
-        if TractionControlAssistMode.isValid(self.m_tractionControl):
-            self.m_tractionControl = TractionControlAssistMode(self.m_tractionControl)
-        if GearboxAssistMode.isValid(self.m_gearboxAssist):
-            self.m_gearboxAssist = GearboxAssistMode(self.m_gearboxAssist)
+        self.m_tractionControl = bool(self.m_tractionControl)
+        self.m_gearboxAssist = bool(self.m_gearboxAssist)
         self.m_antiLockBrakes = bool(self.m_antiLockBrakes)
         self.m_equalCarPerformance = bool(self.m_equalCarPerformance)
         self.m_customSetup = bool(self.m_customSetup)
@@ -122,8 +120,8 @@ class TimeTrialDataSet:
             "sector-2-time-str": F1Utils.getLapTimeStr(self.m_sector2TimeInMS),
             "sector3-time-in-ms": self.m_sector3TimeInMS,
             "sector-3-time-str": F1Utils.getLapTimeStr(self.m_sector3TimeInMS),
-            "traction-control": str(self.m_tractionControl),
-            "gearbox-assist": str(self.m_gearboxAssist),
+            "traction-control": self.m_tractionControl,
+            "gearbox-assist": self.m_gearboxAssist,
             "anti-lock-brakes": self.m_antiLockBrakes,
             "equal-car-performance": self.m_equalCarPerformance,
             "custom-setup": self.m_customSetup,
@@ -181,8 +179,8 @@ class TimeTrialDataSet:
             self.m_sector1TimeInMS,
             self.m_sector2TimeInMS,
             self.m_sector3TimeInMS,
-            self.m_tractionControl.value,
-            self.m_gearboxAssist.value,
+            self.m_tractionControl,
+            self.m_gearboxAssist,
             self.m_antiLockBrakes,
             self.m_equalCarPerformance,
             self.m_customSetup,
@@ -198,8 +196,8 @@ class TimeTrialDataSet:
                     sector1_time_in_ms: int,
                     sector2_time_in_ms: int,
                     sector3_time_in_ms: int,
-                    traction_control: TractionControlAssistMode,
-                    gearbox_assist: GearboxAssistMode,
+                    traction_control: bool,
+                    gearbox_assist: bool,
                     anti_lock_brakes: bool,
                     equal_car_performance: bool,
                     custom_setup: bool,
@@ -233,8 +231,8 @@ class TimeTrialDataSet:
                 sector1_time_in_ms,
                 sector2_time_in_ms,
                 sector3_time_in_ms,
-                traction_control.value,
-                gearbox_assist.value,
+                traction_control,
+                gearbox_assist,
                 anti_lock_brakes,
                 equal_car_performance,
                 custom_setup,

--- a/scripts/png.spec
+++ b/scripts/png.spec
@@ -18,7 +18,7 @@ from typing import List, Tuple, Any, Optional
 
 # Core application info
 APP_NAME = "pits_n_giggles"
-APP_VERSION = "2.7.2"
+APP_VERSION = "2.8.0"
 ICON_PATH = "../assets/favicon.ico"
 
 # Define all applications to be built

--- a/tests/f1_types/tests_packet_14_time_trial_data.py
+++ b/tests/f1_types/tests_packet_14_time_trial_data.py
@@ -59,8 +59,8 @@ class TestPacketTimeTrialData(F1TypesTest):
             "sector-2-time-str": "00.000",
             "sector3-time-in-ms": 0,
             "sector-3-time-str": "00.000",
-            "traction-control": "MEDIUM",
-            "gearbox-assist": "Unknown",
+            "traction-control": True,
+            "gearbox-assist": False,
             "anti-lock-brakes": False,
             "equal-car-performance": True,
             "custom-setup": False,
@@ -77,8 +77,8 @@ class TestPacketTimeTrialData(F1TypesTest):
             "sector-2-time-str": "28.112",
             "sector3-time-in-ms": 41278,
             "sector-3-time-str": "41.278",
-            "traction-control": "OFF",
-            "gearbox-assist": "Unknown",
+            "traction-control": False,
+            "gearbox-assist": False,
             "anti-lock-brakes": False,
             "equal-car-performance": True,
             "custom-setup": True,
@@ -95,8 +95,8 @@ class TestPacketTimeTrialData(F1TypesTest):
             "sector-2-time-str": "28.310",
             "sector3-time-in-ms": 40350,
             "sector-3-time-str": "40.350",
-            "traction-control": "MEDIUM",
-            "gearbox-assist": "Unknown",
+            "traction-control": True,
+            "gearbox-assist": False,
             "anti-lock-brakes": True,
             "equal-car-performance": False,
             "custom-setup": False,
@@ -111,7 +111,7 @@ class TestPacketTimeTrialData(F1TypesTest):
     def test_f1_25_actual(self):
 
         raw_packet = b'\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-        expected_json = {"player-session-best-data-set": {"car-index": 0, "team": "Williams", "lap-time-ms": 0, "lap-time-str": "00.000", "sector-1-time-ms": 0, "sector-1-time-str": "00.000", "sector-2-time-in-ms": 0, "sector-2-time-str": "00.000", "sector3-time-in-ms": 0, "sector-3-time-str": "00.000", "traction-control": "OFF", "gearbox-assist": "Unknown", "anti-lock-brakes": False, "equal-car-performance": True, "custom-setup": False, "is-valid": True}, "personal-best-data-set": {"car-index": 0, "team": "Mercedes", "lap-time-ms": 0, "lap-time-str": "00.000", "sector-1-time-ms": 0, "sector-1-time-str": "00.000", "sector-2-time-in-ms": 0, "sector-2-time-str": "00.000", "sector3-time-in-ms": 0, "sector-3-time-str": "00.000", "traction-control": "OFF", "gearbox-assist": "Unknown", "anti-lock-brakes": False, "equal-car-performance": False, "custom-setup": False, "is-valid": False}, "rival-session-best-data-set": {"car-index": 0, "team": "Mercedes", "lap-time-ms": 0, "lap-time-str": "00.000", "sector-1-time-ms": 0, "sector-1-time-str": "00.000", "sector-2-time-in-ms": 0, "sector-2-time-str": "00.000", "sector3-time-in-ms": 0, "sector-3-time-str": "00.000", "traction-control": "OFF", "gearbox-assist": "Unknown", "anti-lock-brakes": False, "equal-car-performance": False, "custom-setup": False, "is-valid": False}}
+        expected_json = {"player-session-best-data-set": {"car-index": 0, "team": "Williams", "lap-time-ms": 0, "lap-time-str": "00.000", "sector-1-time-ms": 0, "sector-1-time-str": "00.000", "sector-2-time-in-ms": 0, "sector-2-time-str": "00.000", "sector3-time-in-ms": 0, "sector-3-time-str": "00.000", "traction-control": False, "gearbox-assist": False, "anti-lock-brakes": False, "equal-car-performance": True, "custom-setup": False, "is-valid": True}, "personal-best-data-set": {"car-index": 0, "team": "Mercedes", "lap-time-ms": 0, "lap-time-str": "00.000", "sector-1-time-ms": 0, "sector-1-time-str": "00.000", "sector-2-time-in-ms": 0, "sector-2-time-str": "00.000", "sector3-time-in-ms": 0, "sector-3-time-str": "00.000", "traction-control": False, "gearbox-assist": False, "anti-lock-brakes": False, "equal-car-performance": False, "custom-setup": False, "is-valid": False}, "rival-session-best-data-set": {"car-index": 0, "team": "Mercedes", "lap-time-ms": 0, "lap-time-str": "00.000", "sector-1-time-ms": 0, "sector-1-time-str": "00.000", "sector-2-time-in-ms": 0, "sector-2-time-str": "00.000", "sector3-time-in-ms": 0, "sector-3-time-str": "00.000", "traction-control": False, "gearbox-assist": False, "anti-lock-brakes": False, "equal-car-performance": False, "custom-setup": False, "is-valid": False}}
 
         parsed_packet = PacketTimeTrialData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
@@ -175,8 +175,8 @@ class TestPacketTimeTrialData(F1TypesTest):
             sector1_time_in_ms=s1_time_ms,
             sector2_time_in_ms=s2_time_ms,
             sector3_time_in_ms=s3_time_ms,
-            traction_control=random.choice(list(TractionControlAssistMode)),
-            gearbox_assist=random.choice(list(GearboxAssistMode)),
+            traction_control=F1TypesTest.getRandomBool(),
+            gearbox_assist=F1TypesTest.getRandomBool(),
             anti_lock_brakes=F1TypesTest.getRandomBool(),
             equal_car_performance=F1TypesTest.getRandomBool(),
             custom_setup=F1TypesTest.getRandomBool(),


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Redid the Time trial UI. Updated the backend TT parser to deal with bool assist values, not enum
![image](https://github.com/user-attachments/assets/b1bd199d-03b3-49da-93df-c1a0fdd378fb)

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Unit Tests

- [x] All unit tests pass
- Attach test command/output (e.g., `poetry run python tests/unit_tests.py`):

```
----------------------------------------------------------------------
Ran 262 tests in 6.588s

OK
```

### ✅ Integration Tests

* [x] All integration tests pass
* Attach test command/output (e.g., `poetry run python tests/integration_test/runner.py `):

```
===== TEST RESULTS =====
Passed: 20/20

PASS: f1_23_sp_austria.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_mp_fp_jeddah.f1pcap
PASS: f1_25_mp_fp_jeddah_player.f1pcap
PASS: f1_25_mp_fp_jeddah_player_2.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_sp_aus_5lap_1stop.f1pcap
PASS: f1_25_sp_aus_5lap_1stop_flashback.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_sp_baku_mid_session_save_load.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_sp_imola_5lap_1stop.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
```
No app level errors (this is after server died)
![image](https://github.com/user-attachments/assets/9c60c261-20b6-4cde-a8c4-ff673815ea71)

### ✅ Pylint

* [x] Code passes `pylint`
* Paste summary report:

```
$ pylint --rcfile scripts/.pylintrc apps lib

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

To run pylint
```
pylint --rcfile scripts/.pylintrc lib apps
```

---

## 🧱 `lib/` Directory Changes

* [x] This PR modifies or adds files under `lib/`
* [x] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Fixed the Time trial packet parser to use bool fields for assists and updated the tests with the same
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Revamp the Time Trial feature by redesigning the frontend UI, enhancing backend telemetry parsing for boolean assist flags and TT setups, and updating tests to match the new data format

New Features:
- Revamp Time Trial UI with a modern flex-based layout featuring lap history, comparison cards (personal best, session best, rival best), and a theoretical best card
- Expose TT setup details in the backend API and display wing setup data on comparison cards
- Update TimeTrialDataSet parser to treat traction control and gearbox assist as boolean flags
- Add responsive CSS styling and HTML structure for the new Time Trial interface

Enhancements:
- Refactor JavaScript TimeTrialDataPopulator to centralize UI updates, comparison logic, and error handling
- Simplify assist value rendering and card structure restoration for older packet formats in the frontend
- Extend telemetry_web_api to include TT setup JSON and fastest lap metadata

Build:
- Bump application version to 2.8.0 in build script

Tests:
- Update packet_14_time_trial_data tests to expect boolean assist fields instead of enum values