### PR TITLE
Imperial

### DIFF
--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -444,7 +444,35 @@
               <label for="tyreDeltaOsdDuration" class="form-label">Tyre Delta OSD Duration (seconds)</label>
               <input type="number" class="form-control" id="tyreDeltaOsdDuration" value="5" min="1" max="20">
             </div>
-          </div>
+            <!-- Speed format -->
+            <div class="mb-3">
+              <label class="form-label">Speed Format</label>
+              <div>
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="radio" id="speedUnitMetric" name="speedUnit" value="metric" checked>
+                  <label class="form-check-label" for="speedUnitMetric">Metric (kmph)</label>
+                </div>
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="radio" id="speedUnitImperial" name="speedUnit" value="imperial">
+                  <label class="form-check-label" for="speedUnitImperial">Imperial (mph)</label>
+                </div>
+              </div>
+            </div>
+            <!-- Temperature format -->
+            <div class="mb-3">
+              <label class="form-label">Temperature Format</label>
+              <div>
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="radio" id="tempUnitMetric" name="tempUnit" value="metric" checked>
+                  <label class="form-check-label" for="tempUnitMetric">°C (Celsius)</label>
+                </div>
+                <div class="form-check form-check-inline">
+                  <input class="form-check-input" type="radio" id="tempUnitImperial" name="tempUnit" value="imperial">
+                  <label class="form-check-label" for="tempUnitImperial">°F (Fahrenheit)</label>
+                </div>
+              </div>
+            </div>
+          </div> <!-- End of Modal Body -->
           <div class="modal-footer">
             <a href="https://www.pitsngiggles.com" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">Download latest</a>
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -474,6 +474,11 @@
             </div>
           </div> <!-- End of Modal Body -->
           <div class="modal-footer">
+            {% if not live_data_mode %}
+              <div class="text-warning w-100 mb-2 text-center">
+                Refresh the page after saving to see the changes.
+              </div>
+            {% endif %}
             <a href="https://www.pitsngiggles.com" class="btn btn-secondary" target="_blank" rel="noopener noreferrer">Download latest</a>
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             <button type="button" class="btn btn-primary" id="saveSettings">Save changes</button>

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -120,7 +120,7 @@
                                   <th>S2</th>
                                   <th>S3</th>
                                   <th>Lap Time</th>
-                                  <th>vMax</th>
+                                  <th id="tt-vmax-th" data-bs-toggle="tooltip">vMax 🛈</th>
                               </tr>
                           </thead>
                           <tbody id="tt-lap-table-body">

--- a/apps/frontend/js/app.js
+++ b/apps/frontend/js/app.js
@@ -112,3 +112,8 @@ document.getElementById('volumeRange').addEventListener('input', function (e) {
     document.getElementById('volumeLabel').textContent = e.target.value;
 });
 
+document.getElementById('tt-vmax-th').addEventListener('click', function (e) {
+    g_pref_speedUnitMetric = !g_pref_speedUnitMetric;
+    showToast("Speed Format Changed to " + (g_pref_speedUnitMetric ? ("km/h") : ("mph")));
+    savePreferences();
+});

--- a/apps/frontend/js/driverDataModalPopulator.js
+++ b/apps/frontend/js/driverDataModalPopulator.js
@@ -77,7 +77,8 @@ class DriverModalPopulator {
                 row.appendChild(wearCell);
 
                 const topSpeedCell = document.createElement('td');
-                const topSpeed = lap["top-speed-kmph"]
+                const topSpeed = formatSpeed(lap["top-speed-kmph"],
+                    { isMetric: g_pref_speedUnitMetric, decimalPlaces: 0, addUnitSuffix: false });
                 topSpeedCell.textContent = (topSpeed != null) ? (topSpeed) : ('---');
                 row.appendChild(topSpeedCell);
 

--- a/apps/frontend/js/modals.js
+++ b/apps/frontend/js/modals.js
@@ -224,6 +224,14 @@ class ModalManager {
     // set initial tyre delta mode
     this.handleTyreDeltaFormatChange(g_pref_tyreDeltaNotificationTtsFormat ? "tts" : "osd");
 
+    // Set the radio buttons for speed units
+    document.getElementById("speedUnitMetric").checked = g_pref_speedUnitMetric;
+    document.getElementById("speedUnitImperial").checked = !g_pref_speedUnitMetric;
+
+    // Set the radio buttons for temperature units
+    document.getElementById("tempUnitMetric").checked = g_pref_tempUnitMetric;
+    document.getElementById("tempUnitImperial").checked = !g_pref_tempUnitMetric;
+
     this.settingsModal.show();
   }
 
@@ -253,6 +261,9 @@ class ModalManager {
     g_pref_ttsVolume = parseInt(document.getElementById('volumeRange').value, 10);
     g_pref_tyreDeltaNotificationTtsFormat = (document.querySelector('input[name="tyreDeltaNotificationFormat"]:checked').value === "tts") ? (true) : (false);
     g_pref_tyreDeltaNotificationOsdDurationSec = osdDurationSec_temp;
+    g_pref_speedUnitMetric = (document.querySelector('input[name="speedUnit"]:checked').value === "metric") ? (true) : (false);
+    g_pref_tempUnitMetric = (document.querySelector('input[name="tempUnit"]:checked').value === "metric") ? (true) : (false);
+
     savePreferences();
 
     this.settingsModal.hide();

--- a/apps/frontend/js/preferences.js
+++ b/apps/frontend/js/preferences.js
@@ -232,6 +232,8 @@ function updateAllTooltips() {
     } else {
         updateTooltip("fuel-info-th", `Target fuel rate is disabled. Enable it via the settings`);
     }
+    updateTooltip("tt-vmax-th", `Top Speed. Click to toggle between km/h and mph. Current format is ${
+                                                    (g_pref_speedUnitMetric) ? ("km/h") : ("mph")}`);
 }
 
 function updateTooltip(id, newText) {

--- a/apps/frontend/js/preferences.js
+++ b/apps/frontend/js/preferences.js
@@ -14,6 +14,8 @@ let g_pref_ttsVoice;
 let g_pref_ttsVolume;
 let g_pref_tyreDeltaNotificationTtsFormat;
 let g_pref_tyreDeltaNotificationOsdDurationSec;
+let g_pref_speedUnitMetric;
+let g_pref_tempUnitCelsius;
 
 function loadPreferences() {
     let missingPreference = false;
@@ -128,6 +130,20 @@ function loadPreferences() {
         g_pref_tyreDeltaNotificationOsdDurationSec = parseInt(g_pref_tyreDeltaNotificationOsdDurationSec, 10); // localstorage saves everthing as string
     }
 
+    if (localStorage.getItem('speedUnitMetric') !== null) {
+        g_pref_speedUnitMetric = localStorage.getItem('speedUnitMetric') === 'true';
+    } else {
+        g_pref_speedUnitMetric = true;
+        missingPreference = true;
+    }
+
+    if (localStorage.getItem('tempUnitCelsius') !== null) {
+        g_pref_tempUnitCelsius = localStorage.getItem('tempUnitCelsius') === 'true';
+    } else {
+        g_pref_tempUnitCelsius = true;
+        missingPreference = true;
+    }
+
     // If any preference was missing, save all current preferences
     if (missingPreference) {
         savePreferences();
@@ -148,7 +164,9 @@ function loadPreferences() {
         g_pref_ttsVoice,
         g_pref_ttsVolume,
         g_pref_tyreDeltaNotificationTtsFormat,
-        g_pref_tyreDeltaNotificationOsdDurationSec
+        g_pref_tyreDeltaNotificationOsdDurationSec,
+        g_pref_speedUnitMetric,
+        g_pref_tempUnitCelsius
     });
     updateAllTooltips();
 }
@@ -169,6 +187,8 @@ function savePreferences() {
     localStorage.setItem('ttsVolume', g_pref_ttsVolume);
     localStorage.setItem('tyreDeltaNotificationTtsFormat', g_pref_tyreDeltaNotificationTtsFormat);
     localStorage.setItem('tyreDeltaNotificationOsdDurationSec', g_pref_tyreDeltaNotificationOsdDurationSec);
+    localStorage.setItem('speedUnitMetric', g_pref_speedUnitMetric);
+    localStorage.setItem('tempUnitCelsius', g_pref_tempUnitCelsius);
 
     console.log("Saved Preferences:", {
         g_pref_myTeamName,
@@ -185,7 +205,9 @@ function savePreferences() {
         g_pref_ttsVoice,
         g_pref_ttsVolume,
         g_pref_tyreDeltaNotificationTtsFormat,
-        g_pref_tyreDeltaNotificationOsdDurationSec
+        g_pref_tyreDeltaNotificationOsdDurationSec,
+        g_pref_speedUnitMetric,
+        g_pref_tempUnitCelsius
     });
 
     updateAllTooltips();

--- a/apps/frontend/js/preferences.js
+++ b/apps/frontend/js/preferences.js
@@ -15,7 +15,7 @@ let g_pref_ttsVolume;
 let g_pref_tyreDeltaNotificationTtsFormat;
 let g_pref_tyreDeltaNotificationOsdDurationSec;
 let g_pref_speedUnitMetric;
-let g_pref_tempUnitCelsius;
+let g_pref_tempUnitMetric;
 
 function loadPreferences() {
     let missingPreference = false;
@@ -137,10 +137,10 @@ function loadPreferences() {
         missingPreference = true;
     }
 
-    if (localStorage.getItem('tempUnitCelsius') !== null) {
-        g_pref_tempUnitCelsius = localStorage.getItem('tempUnitCelsius') === 'true';
+    if (localStorage.getItem('tempUnitMetric') !== null) {
+        g_pref_tempUnitMetric = localStorage.getItem('tempUnitMetric') === 'true';
     } else {
-        g_pref_tempUnitCelsius = true;
+        g_pref_tempUnitMetric = true;
         missingPreference = true;
     }
 
@@ -166,7 +166,7 @@ function loadPreferences() {
         g_pref_tyreDeltaNotificationTtsFormat,
         g_pref_tyreDeltaNotificationOsdDurationSec,
         g_pref_speedUnitMetric,
-        g_pref_tempUnitCelsius
+        g_pref_tempUnitMetric
     });
     updateAllTooltips();
 }
@@ -188,7 +188,7 @@ function savePreferences() {
     localStorage.setItem('tyreDeltaNotificationTtsFormat', g_pref_tyreDeltaNotificationTtsFormat);
     localStorage.setItem('tyreDeltaNotificationOsdDurationSec', g_pref_tyreDeltaNotificationOsdDurationSec);
     localStorage.setItem('speedUnitMetric', g_pref_speedUnitMetric);
-    localStorage.setItem('tempUnitCelsius', g_pref_tempUnitCelsius);
+    localStorage.setItem('tempUnitMetric', g_pref_tempUnitMetric);
 
     console.log("Saved Preferences:", {
         g_pref_myTeamName,
@@ -207,7 +207,7 @@ function savePreferences() {
         g_pref_tyreDeltaNotificationTtsFormat,
         g_pref_tyreDeltaNotificationOsdDurationSec,
         g_pref_speedUnitMetric,
-        g_pref_tempUnitCelsius
+        g_pref_tempUnitMetric
     });
 
     updateAllTooltips();

--- a/apps/frontend/js/raceStatsModalPopulator.js
+++ b/apps/frontend/js/raceStatsModalPopulator.js
@@ -285,7 +285,7 @@ class RaceStatsModalPopulator {
         chart.render(chartData, {
             title: "Speed Trap Records",
             xLabel: "Driver",
-            yLabel: `Speed {${unit}}`,
+             yLabel: `Speed (${unit})`,
         });
 
         tabPane.appendChild(chartDiv);

--- a/apps/frontend/js/raceStatsModalPopulator.js
+++ b/apps/frontend/js/raceStatsModalPopulator.js
@@ -277,6 +277,7 @@ class RaceStatsModalPopulator {
         const chartDiv = document.createElement('div');
         const chart = new BarChart(chartDiv);
         let chartData = [];
+        // TODO: support mph
         this.data["speed-trap-records"].forEach((record) => {
             chartData.push({ label: record["name"], value: record["speed-trap-record-kmph"], color: this.getF1TeamColor(record["team"]) });
         });

--- a/apps/frontend/js/raceStatsModalPopulator.js
+++ b/apps/frontend/js/raceStatsModalPopulator.js
@@ -277,14 +277,15 @@ class RaceStatsModalPopulator {
         const chartDiv = document.createElement('div');
         const chart = new BarChart(chartDiv);
         let chartData = [];
-        // TODO: support mph
+        const unit = g_pref_speedUnitMetric ? "km/h" : "mph";
         this.data["speed-trap-records"].forEach((record) => {
-            chartData.push({ label: record["name"], value: record["speed-trap-record-kmph"], color: this.getF1TeamColor(record["team"]) });
+            chartData.push({ label: record["name"], value: this.getSpeedInCustomUnit(record["speed-trap-record-kmph"]),
+                             color: this.getF1TeamColor(record["team"]) });
         });
         chart.render(chartData, {
             title: "Speed Trap Records",
             xLabel: "Driver",
-            yLabel: "Speed (km/h)",
+            yLabel: `Speed {${unit}}`,
         });
 
         tabPane.appendChild(chartDiv);
@@ -574,5 +575,9 @@ class RaceStatsModalPopulator {
 
         // Add to the tab pane
         tabPane.appendChild(alertDiv);
+    }
+
+    getSpeedInCustomUnit(speedKmph) {
+        return g_pref_speedUnitMetric ? speedKmph : speedKmph * 0.621371;
     }
 }

--- a/apps/frontend/js/raceTableRowPopulator.js
+++ b/apps/frontend/js/raceTableRowPopulator.js
@@ -105,7 +105,7 @@ class RaceTableRowPopulator {
         });
 
         const speedTrapValue = speedTrapRecord != null
-            ? formatFloatWithTwoDecimals(speedTrapRecord) + ' kmph'
+            ? formatSpeed(speedTrapRecord, { isMetric: g_pref_speedUnitMetric, decimalPlaces: 2, addUnitSuffix: true })
             : "---";
 
         // Game-specific layout:

--- a/apps/frontend/js/telemetryRenderer.js
+++ b/apps/frontend/js/telemetryRenderer.js
@@ -16,7 +16,6 @@ class TelemetryRenderer {
     this.indexByPosition = null;
     this.iconCache = iconCache;
     this.uiMode = 'Splash';
-    this.lastData = null;
   }
 
   renderTelemetryRow(data, packetFormat, isLiveDataMode, raceEnded, spectatorIndex) {
@@ -70,7 +69,6 @@ class TelemetryRenderer {
 
     // update the header section regardless of mode
     this.updateHeader(incomingData);
-    this.lastData = incomingData;
   }
 
   updateTimeTrialData(incomingData) {
@@ -145,51 +143,29 @@ class TelemetryRenderer {
   }
 
   updateHeader(incomingData) {
+    const weatherSamples = incomingData['weather-forecast-samples'].slice(0, g_pref_numWeatherPredictionSamples);
+    this.weatherWidget.update(weatherSamples);
 
-    if (this.hasFieldChanged(incomingData, 'weather-forecast-samples')) {
-      const weatherSamples = incomingData['weather-forecast-samples'].slice(0, g_pref_numWeatherPredictionSamples);
-      this.weatherWidget.update(weatherSamples);
+    this.fastestLapTimeSpan.textContent = formatLapTime(incomingData['fastest-lap-overall']);
+    this.fastestLapNameSpan.textContent = (incomingData['event-type'] === 'Time Trial') ?
+        ('') : (truncateName(incomingData['fastest-lap-overall-driver']).toUpperCase());
+
+    this.fastestLapTyreSpan.innerHTML = '';
+    const fastestLapTyre = incomingData['fastest-lap-overall-tyre'];
+    if (fastestLapTyre) {
+      const icon = this.iconCache.getIcon(fastestLapTyre);
+      if (icon) {
+        this.fastestLapTyreSpan.appendChild(icon);
+      }
     }
 
-    if (this.hasFieldChanged(incomingData, 'fastest-lap-overall') ||
-      this.hasFieldChanged(incomingData, 'fastest-lap-overall-driver') ||
-      this.hasFieldChanged(incomingData, 'fastest-lap-overall-tyre')) {
-
-      this.fastestLapTimeSpan.textContent = formatLapTime(incomingData['fastest-lap-overall']);
-      this.fastestLapNameSpan.textContent = (incomingData['event-type'] === 'Time Trial') ?
-          ('') : (truncateName(incomingData['fastest-lap-overall-driver']).toUpperCase());
-
-          this.fastestLapTyreSpan.innerHTML = '';
-          const fastestLapTyre = incomingData['fastest-lap-overall-tyre'];
-          if (fastestLapTyre) {
-            const icon = this.iconCache.getIcon(fastestLapTyre);
-            if (icon) {
-              this.fastestLapTyreSpan.appendChild(icon);
-            }
-          }
-    }
-
-    // If the track name has changed, so has pit lane speed limit
-    if (this.hasFieldChanged(incomingData, 'track-name')) {
-      this.populateCircuitSpan(incomingData);
-    }
-    if (this.hasFieldChanged(incomingData, 'air-temperature')) {
-      this.airTempSpan.textContent = incomingData['air-temperature'] + ' °C';
-    }
-    if (this.hasFieldChanged(incomingData, 'track-temperature')) {
-      this.trackTempSpan.textContent = incomingData['track-temperature'] + ' °C';
-    }
+    this.populateCircuitSpan(incomingData);
+    this.airTempSpan.textContent = incomingData['air-temperature'] + ' °C';
+    this.trackTempSpan.textContent = incomingData['track-temperature'] + ' °C';
   }
 
 
   // Utility methods:
-  hasFieldChanged(incomingData, fieldName) {
-    if (!this.lastData) {
-      return true;
-    }
-    return incomingData[fieldName] !== this.lastData[fieldName];
-  }
-
   populateCircuitSpan(incomingData) {
     this.populateTrackName(incomingData);
     const pitLaneSpeedLimit = incomingData['pit-speed-limit'];

--- a/apps/frontend/js/telemetryRenderer.js
+++ b/apps/frontend/js/telemetryRenderer.js
@@ -160,8 +160,16 @@ class TelemetryRenderer {
     }
 
     this.populateCircuitSpan(incomingData);
-    this.airTempSpan.textContent = incomingData['air-temperature'] + ' °C';
-    this.trackTempSpan.textContent = incomingData['track-temperature'] + ' °C';
+    this.airTempSpan.textContent = formatTemperature(incomingData['air-temperature'], {
+      isMetric: g_pref_tempUnitMetric,
+      decimalPlaces: 0,
+      addUnitSuffix: true
+    });
+    this.trackTempSpan.textContent = formatTemperature(incomingData['track-temperature'], {
+      isMetric: g_pref_tempUnitMetric,
+      decimalPlaces: 0,
+      addUnitSuffix: true
+    });
   }
 
 
@@ -170,7 +178,11 @@ class TelemetryRenderer {
     this.populateTrackName(incomingData);
     const pitLaneSpeedLimit = incomingData['pit-speed-limit'];
     if (pitLaneSpeedLimit) {
-      this.pitLaneSpeedLimit.textContent = pitLaneSpeedLimit;
+      this.pitLaneSpeedLimit.textContent = formatSpeed(pitLaneSpeedLimit, {
+        isMetric: g_pref_speedUnitMetric,
+        decimalPlaces: 0,
+        addUnitSuffix: false
+      });
       this.pitLaneSpeedLimit.style.display = "inline-flex"; // Ensure it's visible if there's a value
     } else {
       this.pitLaneSpeedLimit.style.display = "none"; // Hide if the value is 0;

--- a/apps/frontend/js/timeTrialDataPopulator.js
+++ b/apps/frontend/js/timeTrialDataPopulator.js
@@ -252,7 +252,9 @@ class TimeTrialDataPopulator {
             this.applyColourToCell(lapTimeCell, lapNum, bestLapTimeLapNum, isLapValid);
 
             const speedCell = document.createElement('td');
-            speedCell.textContent = lap['top-speed-kmph'] || '-';
+            speedCell.textContent = lap['top-speed-kmph']
+                ? formatSpeed(lap['top-speed-kmph'], {isMetric: true, decimalPlaces: 0, addUnitSuffix: false})
+                : '-';
 
             row.appendChild(lapCell);
             row.appendChild(s1Cell);

--- a/apps/frontend/js/timeTrialDataPopulator.js
+++ b/apps/frontend/js/timeTrialDataPopulator.js
@@ -253,7 +253,8 @@ class TimeTrialDataPopulator {
 
             const speedCell = document.createElement('td');
             speedCell.textContent = lap['top-speed-kmph']
-                ? formatSpeed(lap['top-speed-kmph'], {isMetric: true, decimalPlaces: 0, addUnitSuffix: false})
+                ? formatSpeed(lap['top-speed-kmph'],
+                    {isMetric: g_pref_speedUnitMetric, decimalPlaces: 0, addUnitSuffix: false})
                 : '-';
 
             row.appendChild(lapCell);

--- a/apps/frontend/js/utils.js
+++ b/apps/frontend/js/utils.js
@@ -376,3 +376,37 @@ function getFormattedLapTimeStr({
 function replaceRevSuffix(str) {
   return str.replace(/\(REV\)$/, '⇄');
 }
+
+function formatSpeed(speedKmph, { isMetric = true, decimalPlaces = 1, addUnitSuffix = true } = {}) {
+    if (typeof speedKmph !== 'number' || !isFinite(speedKmph)) {
+        throw new Error(`Invalid speed: expected a finite number, got ${speedKmph} (type: ${typeof speedKmph})`);
+    }
+
+    let speed = speedKmph;
+    let unit = 'km/h';
+
+    if (!isMetric) {
+        speed *= 0.621371; // Convert km/h to mph
+        unit = 'mph';
+    }
+
+    const rounded = speed.toFixed(decimalPlaces);
+    return addUnitSuffix ? `${rounded} ${unit}` : `${rounded}`;
+}
+
+function formatTemperature(tempCelsius, { isMetric = true, decimalPlaces = 1, addUnitSuffix = true } = {}) {
+    if (typeof tempCelsius !== 'number' || !isFinite(tempCelsius)) {
+        throw new Error(`Invalid temperature: expected a finite number, got ${tempCelsius} (type: ${typeof tempCelsius})`);
+    }
+
+    let temp = tempCelsius;
+    let unit = '°C';
+
+    if (!isMetric) {
+        temp = (temp * 9 / 5) + 32; // Convert to Fahrenheit
+        unit = '°F';
+    }
+
+    const rounded = temp.toFixed(decimalPlaces);
+    return addUnitSuffix ? `${rounded} ${unit}` : `${rounded}`;
+}

--- a/tests/integration_test/runner.py
+++ b/tests/integration_test/runner.py
@@ -11,6 +11,7 @@ import ssl
 import subprocess
 import sys
 import time
+import webbrowser
 from pathlib import Path
 
 from aiohttp import ClientSession, TCPConnector
@@ -111,6 +112,10 @@ def main(telemetry_port, http_port, proto):
 
     print("Waiting for app to start...")
     time.sleep(5)
+
+    print("Launching engineer view and overlay clients")
+    webbrowser.open(f'{proto}://localhost:{http_port}/eng-view', new=2)
+    webbrowser.open(f'{proto}://localhost:{http_port}/player-stream-overlay', new=2)
 
     results = []
     try:


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Added imperial units support (temperature and speed units are separately configurable. metric by default)
Changes added to 

- speed trap in race table
- speed trap records chart
- track temp, air temp and pit lane speed limit
- time trial vMax
- made vMax column clickable to toggle between speed units
- Lap time table in driver modal

Tyre, brake and engine temp data points have not been updated to support imperial.

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Unit Tests

- [x] All unit tests pass
- Attach test command/output:

```
----------------------------------------------------------------------
Ran 287 tests in 5.172s

OK
```

To run the unit test suite
```bash
poetry run python tests/unit_tests.py
```

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
===== TEST RESULTS =====
Passed: 21/21

PASS: f1_23_sp_austria.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_mp_fp_jeddah.f1pcap
PASS: f1_25_mp_fp_jeddah_player.f1pcap
PASS: f1_25_mp_fp_jeddah_player_2.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_mp_solo_afk_fp_aus.f1pcap
PASS: f1_25_sp_aus_5lap_1stop.f1pcap
PASS: f1_25_sp_aus_5lap_1stop_flashback.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_sp_baku_mid_session_save_load.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_sp_imola_5lap_1stop.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

### ✅ Pylint

* [x] Code passes `pylint`
* Paste summary report:

```
$ pylint --rcfile scripts/.pylintrc apps lib

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

To run pylint
```bash
pylint --rcfile scripts/.pylintrc lib apps
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Fully frontend change
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Add support for configurable imperial and metric units for speed and temperature throughout the frontend.

New Features:
- Introduce radio controls in settings modal for speed (km/h or mph) and temperature (°C or °F) formats
- Add formatSpeed and formatTemperature utility functions and persist user preferences to localStorage
- Enable clicking the vMax column header to toggle speed units on the fly

Enhancements:
- Update telemetry display for air/track temperatures and pit-lane speed limit to use selected unit format
- Refactor race stats chart, time trial, driver modal, and race table rendering to apply unit conversion and labels consistently