### PR TITLE
Add telemetry connection watchdog and receiver refactor

### DIFF
--- a/apps/backend/pits_n_giggles.py
+++ b/apps/backend/pits_n_giggles.py
@@ -82,6 +82,7 @@ class PngRunner:
             udp_tyre_delta_action_code=self.m_config.Network.udp_tyre_delta_action_code,
             forwarding_targets=self.m_config.Forwarding.forwarding_targets,
             ver_str=self.m_version,
+            wdt_interval=float(self.m_config.Network.wdt_interval_sec),
             tasks=self.m_tasks
         )
         self.m_web_server = self._setupUiIntfLayer(

--- a/apps/backend/pits_n_giggles.py
+++ b/apps/backend/pits_n_giggles.py
@@ -70,7 +70,8 @@ class PngRunner:
         initStateManagementLayer(
             logger=self.m_logger,
             process_car_setups=self.m_config.Privacy.process_car_setup,
-            ver_str=self.m_version
+            ver_str=self.m_version,
+            port_number=self.m_config.Network.telemetry_port
         )
 
         initTelemetryLayer(

--- a/apps/backend/pits_n_giggles.py
+++ b/apps/backend/pits_n_giggles.py
@@ -70,8 +70,7 @@ class PngRunner:
         initStateManagementLayer(
             logger=self.m_logger,
             process_car_setups=self.m_config.Privacy.process_car_setup,
-            ver_str=self.m_version,
-            port_number=self.m_config.Network.telemetry_port
+            ver_str=self.m_version
         )
 
         initTelemetryLayer(

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -220,6 +220,7 @@ class SessionState:
         m_first_session_update_received (bool): Flag indicating whether the first session update packet has been received.
         m_version (str): Version string
         m_connected_to_sim (bool): Flag indicating whether the client is connected to the simulator
+        m_port_number (int): Port number that Pits n' Giggles is listening on
     """
 
     MAX_DRIVERS: int = 22
@@ -245,19 +246,22 @@ class SessionState:
         'm_custom_markers_history',
         'm_first_session_update_received',
         'm_version',
-        'm_connected_to_sim'
+        'm_connected_to_sim',
+        'm_port_number'
     ]
 
     def __init__(self,
                  logger: logging.Logger,
                  process_car_setups: bool,
-                 ver_str: str) -> None:
+                 ver_str: str,
+                 port_number: int) -> None:
         """Init the DriverData object
 
         Args:
             logger (logging.Logger): Logger
             process_car_setups (bool): Whether to process car setups packets
             ver_str (str): Version string
+            port_number (int): Port number
         """
 
         self.m_logger = logger
@@ -284,6 +288,7 @@ class SessionState:
 
         self.m_custom_markers_history = CustomMarkersHistory()
         self.m_connected_to_sim: bool = False
+        self.m_port_number: int = port_number
 
     ####### Control Methods ########
 

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -216,6 +216,10 @@ class SessionState:
         m_udp_custom_marker_action_code (Optional[int]): The UDP action code for custom marker
         m_udp_tyre_delta_action_code (Optional[int]): The UDP action code for tyre delta notification
         m_process_car_setups (bool): Flag indicating whether to process car setups packets.
+        m_custom_markers_history (CustomMarkersHistory): An instance tracking custom markers history.
+        m_first_session_update_received (bool): Flag indicating whether the first session update packet has been received.
+        m_version (str): Version string
+        m_connected_to_sim (bool): Flag indicating whether the client is connected to the simulator
     """
 
     MAX_DRIVERS: int = 22
@@ -240,7 +244,8 @@ class SessionState:
         'm_process_car_setups',
         'm_custom_markers_history',
         'm_first_session_update_received',
-        'm_version'
+        'm_version',
+        'm_connected_to_sim'
     ]
 
     def __init__(self,
@@ -278,6 +283,7 @@ class SessionState:
         self.m_process_car_setups: bool = process_car_setups
 
         self.m_custom_markers_history = CustomMarkersHistory()
+        self.m_connected_to_sim: bool = False
 
     ####### Control Methods ########
 
@@ -329,6 +335,15 @@ class SessionState:
         Set the race as completed.
         """
         self.m_race_completed = True
+
+    def setConnectedToSim(self, connected: bool) -> None:
+        """Set whether the client is connected to the simulator. Based on WDT
+
+        Args:
+            connected (bool): Whether the client is connected to the simulator
+        """
+        self.m_logger.debug("WDT: Connected to sim: [%s]->[%s]", self.m_connected_to_sim, connected)
+        self.m_connected_to_sim = connected
 
     ##### Packet event entry points #####
 

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -220,7 +220,6 @@ class SessionState:
         m_first_session_update_received (bool): Flag indicating whether the first session update packet has been received.
         m_version (str): Version string
         m_connected_to_sim (bool): Flag indicating whether the client is connected to the simulator
-        m_port_number (int): Port number that Pits n' Giggles is listening on
     """
 
     MAX_DRIVERS: int = 22
@@ -246,22 +245,19 @@ class SessionState:
         'm_custom_markers_history',
         'm_first_session_update_received',
         'm_version',
-        'm_connected_to_sim',
-        'm_port_number'
+        'm_connected_to_sim'
     ]
 
     def __init__(self,
                  logger: logging.Logger,
                  process_car_setups: bool,
-                 ver_str: str,
-                 port_number: int) -> None:
+                 ver_str: str) -> None:
         """Init the DriverData object
 
         Args:
             logger (logging.Logger): Logger
             process_car_setups (bool): Whether to process car setups packets
             ver_str (str): Version string
-            port_number (int): Port number
         """
 
         self.m_logger = logger
@@ -288,7 +284,6 @@ class SessionState:
 
         self.m_custom_markers_history = CustomMarkersHistory()
         self.m_connected_to_sim: bool = False
-        self.m_port_number: int = port_number
 
     ####### Control Methods ########
 

--- a/apps/backend/state_mgmt_layer/state_layer_init.py
+++ b/apps/backend/state_mgmt_layer/state_layer_init.py
@@ -29,13 +29,14 @@ from .telemetry_web_api import initApiLayer
 
 # -------------------------------------- FUNCTIONS ---------------------------------------------------------------------
 
-def initStateManagementLayer(logger: logging.Logger, process_car_setups: bool, ver_str: str) -> None:
+def initStateManagementLayer(logger: logging.Logger, process_car_setups: bool, ver_str: str, port_number: int) -> None:
     """Initialise the state management layer
 
     Args:
         logger (logging.Logger): Logger
         process_car_setups (bool): Whether to process car setups
         ver_str (str): Version string
+        port_number (int): Port number
     """
-    initSessionState(logger=logger, process_car_setups=process_car_setups, ver_str=ver_str)
+    initSessionState(logger=logger, process_car_setups=process_car_setups, ver_str=ver_str, port_number=port_number)
     initApiLayer(logger=logger)

--- a/apps/backend/state_mgmt_layer/state_layer_init.py
+++ b/apps/backend/state_mgmt_layer/state_layer_init.py
@@ -29,14 +29,13 @@ from .telemetry_web_api import initApiLayer
 
 # -------------------------------------- FUNCTIONS ---------------------------------------------------------------------
 
-def initStateManagementLayer(logger: logging.Logger, process_car_setups: bool, ver_str: str, port_number: int) -> None:
+def initStateManagementLayer(logger: logging.Logger, process_car_setups: bool, ver_str: str) -> None:
     """Initialise the state management layer
 
     Args:
         logger (logging.Logger): Logger
         process_car_setups (bool): Whether to process car setups
         ver_str (str): Version string
-        port_number (int): Port number
     """
-    initSessionState(logger=logger, process_car_setups=process_car_setups, ver_str=ver_str, port_number=port_number)
+    initSessionState(logger=logger, process_car_setups=process_car_setups, ver_str=ver_str)
     initApiLayer(logger=logger)

--- a/apps/backend/state_mgmt_layer/telemetry_state.py
+++ b/apps/backend/state_mgmt_layer/telemetry_state.py
@@ -72,21 +72,19 @@ def isDriverIndexValid(index: int) -> bool:
     return  (0 <= index < len(_session_state.m_driver_data)) and \
             (_session_state.m_driver_data[index] and _session_state.m_driver_data[index].is_valid)
 
-def initSessionState(logger: logging.Logger, process_car_setups: bool, ver_str: str, port_number: int) -> None:
+def initSessionState(logger: logging.Logger, process_car_setups: bool, ver_str: str) -> None:
     """Init the DriverData object
 
     Args:
         logger (logging.Logger): Logger
         process_car_setups (bool): Whether to process car setups packets
         ver_str (str): Version string
-        port_number (int): Port number
     """
     global _session_state
     _session_state = SessionState(
         logger,
         process_car_setups,
-        ver_str,
-        port_number
+        ver_str
     )
 
 def getSessionStateRef() -> SessionState:

--- a/apps/backend/state_mgmt_layer/telemetry_state.py
+++ b/apps/backend/state_mgmt_layer/telemetry_state.py
@@ -72,19 +72,21 @@ def isDriverIndexValid(index: int) -> bool:
     return  (0 <= index < len(_session_state.m_driver_data)) and \
             (_session_state.m_driver_data[index] and _session_state.m_driver_data[index].is_valid)
 
-def initSessionState(logger: logging.Logger, process_car_setups: bool, ver_str: str) -> None:
+def initSessionState(logger: logging.Logger, process_car_setups: bool, ver_str: str, port_number: int) -> None:
     """Init the DriverData object
 
     Args:
         logger (logging.Logger): Logger
         process_car_setups (bool): Whether to process car setups packets
         ver_str (str): Version string
+        port_number (int): Port number
     """
     global _session_state
     _session_state = SessionState(
         logger,
         process_car_setups,
-        ver_str
+        ver_str,
+        port_number
     )
 
 def getSessionStateRef() -> SessionState:

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -78,7 +78,6 @@ class RaceInfoUpdate:
 
         self.m_session_info = _session_state_ref.m_session_info
         self.m_wdt_status = _session_state_ref.m_connected_to_sim
-        self.m_port_number = _session_state_ref.m_port_number
         track_length = self.m_session_info.m_packet_session.m_trackLength if self.m_session_info.m_packet_session else None
         self.m_driver_list_rsp = DriversListRsp(self.m_session_info.m_is_spectating, track_length,
                                                 (str(self.m_session_info.m_session_type) == "Time Trial"))
@@ -131,7 +130,6 @@ class RaceInfoUpdate:
             "player-pit-window" : _getValueOrDefaultValue(self.m_driver_list_rsp.m_next_pit_stop_window, None),
             "spectator-car-index" : _getValueOrDefaultValue(self.m_session_info.m_spectator_car_index, None),
             "wdt-status" : self.m_wdt_status,
-            "port-number" : self.m_port_number
         }
 
         if str(self.m_session_info.m_session_type) == "Time Trial":

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -78,6 +78,7 @@ class RaceInfoUpdate:
 
         self.m_session_info = _session_state_ref.m_session_info
         self.m_wdt_status = _session_state_ref.m_connected_to_sim
+        self.m_port_number = _session_state_ref.m_port_number
         track_length = self.m_session_info.m_packet_session.m_trackLength if self.m_session_info.m_packet_session else None
         self.m_driver_list_rsp = DriversListRsp(self.m_session_info.m_is_spectating, track_length,
                                                 (str(self.m_session_info.m_session_type) == "Time Trial"))
@@ -130,6 +131,7 @@ class RaceInfoUpdate:
             "player-pit-window" : _getValueOrDefaultValue(self.m_driver_list_rsp.m_next_pit_stop_window, None),
             "spectator-car-index" : _getValueOrDefaultValue(self.m_session_info.m_spectator_car_index, None),
             "wdt-status" : self.m_wdt_status,
+            "port-number" : self.m_port_number
         }
 
         if str(self.m_session_info.m_session_type) == "Time Trial":

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -77,6 +77,7 @@ class RaceInfoUpdate:
         """
 
         self.m_session_info = _session_state_ref.m_session_info
+        self.m_wdt_status = _session_state_ref.m_connected_to_sim
         track_length = self.m_session_info.m_packet_session.m_trackLength if self.m_session_info.m_packet_session else None
         self.m_driver_list_rsp = DriversListRsp(self.m_session_info.m_is_spectating, track_length,
                                                 (str(self.m_session_info.m_session_type) == "Time Trial"))
@@ -128,6 +129,7 @@ class RaceInfoUpdate:
                                                           if self.m_session_info.m_packet_session else None, 0),
             "player-pit-window" : _getValueOrDefaultValue(self.m_driver_list_rsp.m_next_pit_stop_window, None),
             "spectator-car-index" : _getValueOrDefaultValue(self.m_session_info.m_spectator_car_index, None),
+            "wdt-status" : self.m_wdt_status,
         }
 
         if str(self.m_session_info.m_session_type) == "Time Trial":

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -141,7 +141,7 @@ class F1TelemetryHandler:
         self.m_version: str = ver_str
         self.m_wdt: WatchDogTimer = WatchDogTimer(
             status_callback=self.m_session_state_ref.setConnectedToSim,
-            timeout=3.0 # TODO - Make this configurable
+            timeout=30.0 # TODO - Make this configurable
         )
         self.registerCallbacks()
 

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -59,6 +59,7 @@ def setupTelemetryTask(
         udp_tyre_delta_action_code: Optional[int],
         forwarding_targets: List[Tuple[str, int]],
         ver_str: str,
+        wdt_interval: float,
         tasks: List[asyncio.Task]) -> None:
     """Entry point to start the F1 telemetry server.
 
@@ -71,6 +72,7 @@ def setupTelemetryTask(
         udp_tyre_delta_action_code (Optional[int]): UDP tyre delta action code.
         forwarding_targets (List[Tuple[str, int]]): List of IP addr port pairs to forward packets to
         ver_str (str): Version string
+        wdt_interval (float): Watchdog interval
         tasks (List[asyncio.Task]): List of tasks to be executed
     """
 
@@ -79,10 +81,11 @@ def setupTelemetryTask(
         forwarding_targets=forwarding_targets,
         logger=logger,
         capture_settings=capture_settings,
+        wdt_interval=wdt_interval,
         udp_custom_action_code=udp_custom_action_code,
         udp_tyre_delta_action_code=udp_tyre_delta_action_code,
         replay_server=replay_server,
-        ver_str=ver_str
+        ver_str=ver_str,
     )
     tasks.append(asyncio.create_task(telemetry_server.run(), name="Game Telemetry Listener Task"))
     tasks.append(asyncio.create_task(telemetry_server.getWatchdogTask(), name="Watchdog Timer Task"))
@@ -102,6 +105,7 @@ class F1TelemetryHandler:
         forwarding_targets: List[Tuple[str, int]],
         logger: logging.Logger,
         capture_settings: CaptureSettings,
+        wdt_interval: float,
         udp_custom_action_code: Optional[int] = None,
         udp_tyre_delta_action_code: Optional[int] = None,
         replay_server: bool = False,
@@ -114,6 +118,7 @@ class F1TelemetryHandler:
             - forwarding_targets (List[Tuple[str, int]]): List of IP addr port pairs to forward packets to
             - logger (logging.Logger): Logger
             - capture_settings (CaptureSettings): Capture settings
+            - wdt_interval (float): Watchdog interval
             - udp_custom_action_code (Optional[int]): UDP custom action code.
             - udp_tyre_delta_action_code (Optional[int]): UDP tyre delta action code
             - replay_server: bool: If true, init in replay mode (TCP). Else init in live mode (UDP)
@@ -141,7 +146,7 @@ class F1TelemetryHandler:
         self.m_version: str = ver_str
         self.m_wdt: WatchDogTimer = WatchDogTimer(
             status_callback=self.m_session_state_ref.setConnectedToSim,
-            timeout=30.0 # TODO - Make this configurable
+            timeout=wdt_interval
         )
         self.registerCallbacks()
 

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -141,7 +141,7 @@ class F1TelemetryHandler:
         self.m_version: str = ver_str
         self.m_wdt: WatchDogTimer = WatchDogTimer(
             status_callback=self.m_session_state_ref.setConnectedToSim,
-            timeout=30.0 # TODO - Make this configurable
+            timeout=3.0 # TODO - Make this configurable
         )
         self.registerCallbacks()
 

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -141,7 +141,7 @@ class F1TelemetryHandler:
         self.m_version: str = ver_str
         self.m_wdt: WatchDogTimer = WatchDogTimer(
             status_callback=self.m_session_state_ref.setConnectedToSim,
-            timeout=3.0 # TODO - Make this configurable
+            timeout=30.0 # TODO - Make this configurable
         )
         self.registerCallbacks()
 
@@ -175,7 +175,7 @@ class F1TelemetryHandler:
             Parameters:
                 packet (List[bytes]): The raw telemetry packet.
             """
-            self.m_wdt.on_packet_received()
+            self.m_wdt.kick()
             if self.m_should_forward:
                 await AsyncInterTaskCommunicator().send("packet-forward", packet)
 

--- a/apps/backend/telemetry_layer/telemetry_layer_init.py
+++ b/apps/backend/telemetry_layer/telemetry_layer_init.py
@@ -42,6 +42,7 @@ def initTelemetryLayer(
         udp_tyre_delta_action_code: Optional[int],
         forwarding_targets: List[Tuple[str, int]],
         ver_str: str,
+        wdt_interval: float,
         tasks: List[asyncio.Task]) -> None:
     """Initialize the telemetry layer
 
@@ -54,6 +55,7 @@ def initTelemetryLayer(
         udp_tyre_delta_action_code (Optional[int]): UDP tyre delta action code.
         forwarding_targets (List[Tuple[str, int]]): List of IP addr port pairs to forward packets to
         ver_str (str): Version string
+        wdt_interval (float): Watchdog interval
         tasks (List[asyncio.Task]): List of tasks to be executed
     """
 
@@ -66,6 +68,7 @@ def initTelemetryLayer(
         udp_tyre_delta_action_code=udp_tyre_delta_action_code,
         forwarding_targets=forwarding_targets,
         ver_str=ver_str,
+        wdt_interval=wdt_interval,
         tasks=tasks
     )
     setupForwarder(

--- a/apps/frontend/css/style.css
+++ b/apps/frontend/css/style.css
@@ -107,10 +107,17 @@ body {
 .blinking-dot {
   width: 10px;
   height: 10px;
-  background-color: red;
   border-radius: 50%;
   animation: blink 1.5s infinite alternate;
   flex-shrink: 0; /* Prevents shrinking */
+}
+
+.blinking-dot.red {
+  background-color: red;
+}
+
+.blinking-dot.green {
+  background-color: green;
 }
 
 @keyframes blink {

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -79,9 +79,8 @@
       <!-- Main Container -->
       <main class="dashboard-main">
         <div class="telemetry-splash-wrapper" id="splash-div">
-          <div class="status-wrapper">
-            <span class="blinking-dot"></span>
-            <p>Waiting for session start ...</p>
+          <div class="status-wrapper" id="status-wrapper">
+            <!-- Populated by JavaScript -->
           </div>
         </div>
         <div class="telemetry-table-wrapper" id="race-table-div" style="display: none;">

--- a/apps/frontend/js/app.js
+++ b/apps/frontend/js/app.js
@@ -2,7 +2,7 @@ loadPreferences();
 // Initialize renderer
 const iconCache = new IconCache();
 const telemetryRenderer = new TelemetryRenderer(iconCache);
-telemetryRenderer.updateConnectedStatus(false, null);
+telemetryRenderer.updateConnectedStatus(false);
 window.modalManager = new ModalManager();
 
 let awaitingResponse = false;

--- a/apps/frontend/js/app.js
+++ b/apps/frontend/js/app.js
@@ -2,6 +2,7 @@ loadPreferences();
 // Initialize renderer
 const iconCache = new IconCache();
 const telemetryRenderer = new TelemetryRenderer(iconCache);
+telemetryRenderer.updateConnectedStatus(false, null);
 window.modalManager = new ModalManager();
 
 let awaitingResponse = false;

--- a/apps/frontend/js/telemetryRenderer.js
+++ b/apps/frontend/js/telemetryRenderer.js
@@ -16,6 +16,7 @@ class TelemetryRenderer {
     this.indexByPosition = null;
     this.iconCache = iconCache;
     this.uiMode = 'Splash';
+    this.connected = null;
   }
 
   renderTelemetryRow(data, packetFormat, isLiveDataMode, raceEnded, spectatorIndex) {
@@ -60,6 +61,7 @@ class TelemetryRenderer {
         break;
       case "Unknown":
       case "---":
+        this.updateConnectedStatus(incomingData["wdt-status"]);
         this.setUIMode('Splash');
         break;
       default:
@@ -371,4 +373,40 @@ class TelemetryRenderer {
         break;
     }
   }
+
+  updateConnectedStatus(connected) {
+    if (this.uiMode !== 'Splash') {
+      return;
+    }
+
+    if (connected === this.connected) {
+      return;
+    }
+
+    this.connected = connected;
+    console.log(`Connected status changed to ${connected}`);
+
+    const container = document.getElementById('status-wrapper');
+    if (!container) return;
+
+    // Clear previous content
+    container.innerHTML = '';
+
+    // Create new status
+    const statusWrapper = document.createElement('div');
+    statusWrapper.className = 'status-wrapper';
+
+    const blinkingDot = document.createElement('span');
+    blinkingDot.className = `blinking-dot ${connected ? 'green' : 'red'}`;
+
+    const statusText = document.createElement('p');
+    statusText.textContent = connected
+      ? 'Connected to F1 game. Waiting for session start ...'
+      : 'Waiting for F1 game UDP telemetry data ...';
+
+    statusWrapper.appendChild(blinkingDot);
+    statusWrapper.appendChild(statusText);
+    container.appendChild(statusWrapper);
+  }
+
 }

--- a/apps/frontend/js/telemetryRenderer.js
+++ b/apps/frontend/js/telemetryRenderer.js
@@ -16,7 +16,14 @@ class TelemetryRenderer {
     this.indexByPosition = null;
     this.iconCache = iconCache;
     this.uiMode = 'Splash';
+
     this.connected = null;
+    this.statusContainer   = document.getElementById('status-wrapper')
+    this.blinkingDot       = document.createElement('span')
+    this.statusText        = document.createElement('p')
+
+    this.blinkingDot.classList.add('blinking-dot')
+    this.statusContainer.append(this.blinkingDot, this.statusText)
   }
 
   renderTelemetryRow(data, packetFormat, isLiveDataMode, raceEnded, spectatorIndex) {
@@ -375,38 +382,19 @@ class TelemetryRenderer {
   }
 
   updateConnectedStatus(connected) {
-    if (this.uiMode !== 'Splash') {
-      return;
+    if (this.uiMode !== 'Splash' || this.connected === connected) {
+      return
     }
+    this.connected = connected
 
-    if (connected === this.connected) {
-      return;
-    }
+    // toggle color class
+    this.blinkingDot.classList.toggle('green', connected)
+    this.blinkingDot.classList.toggle('red', !connected)
 
-    this.connected = connected;
-    console.log(`Connected status changed to ${connected}`);
-
-    const container = document.getElementById('status-wrapper');
-    if (!container) return;
-
-    // Clear previous content
-    container.innerHTML = '';
-
-    // Create new status
-    const statusWrapper = document.createElement('div');
-    statusWrapper.className = 'status-wrapper';
-
-    const blinkingDot = document.createElement('span');
-    blinkingDot.className = `blinking-dot ${connected ? 'green' : 'red'}`;
-
-    const statusText = document.createElement('p');
-    statusText.textContent = connected
+    // update text
+    this.statusText.textContent = connected
       ? 'Connected to F1 game. Waiting for session start ...'
-      : 'Waiting for F1 game UDP telemetry data ...';
-
-    statusWrapper.appendChild(blinkingDot);
-    statusWrapper.appendChild(statusText);
-    container.appendChild(statusWrapper);
+      : 'Waiting for F1 game UDP telemetry data ...'
   }
 
 }

--- a/apps/save_viewer/telemetry_post_race_data_viewer.py
+++ b/apps/save_viewer/telemetry_post_race_data_viewer.py
@@ -297,6 +297,7 @@ def getTelemetryInfo():
                 "is-spectating" : False,
                 "spectator-car-index" : None,
                 "wdt-status" : False,
+                "port-number" : 0,
             }
         if "records" in g_json_data:
             if "fastest" in g_json_data["records"]:
@@ -330,6 +331,7 @@ def getTelemetryInfo():
             "is-spectating" : False,
             "spectator-car-index" : None,
             "wdt-status" : False,
+            "port-number" : 0,
         }
         for sample in g_json_data["session-info"]["weather-forecast-samples"]:
             json_response["weather-forecast-samples"].append(

--- a/apps/save_viewer/telemetry_post_race_data_viewer.py
+++ b/apps/save_viewer/telemetry_post_race_data_viewer.py
@@ -297,7 +297,6 @@ def getTelemetryInfo():
                 "is-spectating" : False,
                 "spectator-car-index" : None,
                 "wdt-status" : False,
-                "port-number" : 0,
             }
         if "records" in g_json_data:
             if "fastest" in g_json_data["records"]:
@@ -331,7 +330,6 @@ def getTelemetryInfo():
             "is-spectating" : False,
             "spectator-car-index" : None,
             "wdt-status" : False,
-            "port-number" : 0,
         }
         for sample in g_json_data["session-info"]["weather-forecast-samples"]:
             json_response["weather-forecast-samples"].append(

--- a/apps/save_viewer/telemetry_post_race_data_viewer.py
+++ b/apps/save_viewer/telemetry_post_race_data_viewer.py
@@ -295,7 +295,8 @@ def getTelemetryInfo():
                 "f1-game-year" : None,
                 "f1-packet-format" : None,
                 "is-spectating" : False,
-                "spectator-car-index" : None
+                "spectator-car-index" : None,
+                "wdt-status" : False,
             }
         if "records" in g_json_data:
             if "fastest" in g_json_data["records"]:
@@ -327,7 +328,8 @@ def getTelemetryInfo():
             "f1-packet-format" : g_json_data.get("packet-format"),
             "packet-format" : g_json_data.get("packet-format"),
             "is-spectating" : False,
-            "spectator-car-index" : None
+            "spectator-car-index" : None,
+            "wdt-status" : False,
         }
         for sample in g_json_data["session-info"]["weather-forecast-samples"]:
             json_response["weather-forecast-samples"].append(

--- a/lib/config/config_schema.py
+++ b/lib/config/config_schema.py
@@ -38,6 +38,7 @@ class NetworkSettings(BaseModel):
     save_viewer_port: int = Field(4769, ge=0, le=65535, description="Pits n' Giggles Save Data Viewer Port")
     udp_tyre_delta_action_code: int = Field(11, ge=1, le=12, description="Tyre Delta Marker: UDP Action Code")
     udp_custom_action_code: int = Field(12, ge=1, le=12, description="Custom Marker: UDP Action Code")
+    wdt_interval_sec: int = Field(30, ge=1, le=120, description="UDP Telemetry Timeout (sec)")
 
     @model_validator(mode="after")
     def check_ports_and_action_codes(self) -> "NetworkSettings":

--- a/lib/socket_receiver/__init__.py
+++ b/lib/socket_receiver/__init__.py
@@ -1,0 +1,35 @@
+# MIT License
+#
+# Copyright (c) [2025] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------- IMPORTS -----------------------------------------------------------------------
+
+from .base_receiver import TelemetryReceiver
+from .tcp_receiver import TcpReceiver
+from .udp_receiver import UdpReceiver
+
+# -------------------------------------- EXPORTS -----------------------------------------------------------------------
+
+__all__ = [
+    "TelemetryReceiver",
+    "TcpReceiver",
+    "UdpReceiver"
+]

--- a/lib/socket_receiver/base_receiver.py
+++ b/lib/socket_receiver/base_receiver.py
@@ -1,0 +1,39 @@
+# MIT License
+#
+# Copyright (c) [2025] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------- IMPORTS -----------------------------------------------------------------------
+
+from abc import ABC, abstractmethod
+
+# -------------------------------------- EXPORTS -----------------------------------------------------------------------
+
+class TelemetryReceiver(ABC):
+    """Base class for socket receiver"""
+    @abstractmethod
+    async def getNextMessage(self, data) -> bytes:
+        """Asynchronously waits until the next message arrives, then returns it."""
+        pass
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Closes the socket receiver"""
+        pass

--- a/lib/socket_receiver/base_receiver.py
+++ b/lib/socket_receiver/base_receiver.py
@@ -29,7 +29,7 @@ from abc import ABC, abstractmethod
 class TelemetryReceiver(ABC):
     """Base class for socket receiver"""
     @abstractmethod
-    async def getNextMessage(self, data) -> bytes:
+    async def getNextMessage(self) -> bytes:
         """Asynchronously waits until the next message arrives, then returns it."""
         pass
 

--- a/lib/socket_receiver/udp_receiver.py
+++ b/lib/socket_receiver/udp_receiver.py
@@ -24,6 +24,7 @@
 
 import asyncio
 import socket
+from typing import Optional
 
 from .base_receiver import TelemetryReceiver
 
@@ -56,7 +57,7 @@ class UdpReceiver(TelemetryReceiver):
         self.m_socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         self.m_socket.setblocking(False)
         self.m_socket.bind((self.m_bind_ip, self.m_port))
-        self._loop = asyncio.get_event_loop()
+        self._loop: Optional[asyncio.AbstractEventLoop] = None  # Lazy init
 
     async def getNextMessage(self) -> bytes:
         """
@@ -65,6 +66,8 @@ class UdpReceiver(TelemetryReceiver):
         Returns:
             bytes: The raw message bytes.
         """
+        if self._loop is None:
+            self._loop = asyncio.get_running_loop()
         message, _ = await self._loop.sock_recvfrom(self.m_socket, self.m_buffer_size)
         return message
 

--- a/lib/socket_receiver/udp_receiver.py
+++ b/lib/socket_receiver/udp_receiver.py
@@ -1,0 +1,75 @@
+# MIT License
+#
+# Copyright (c) [2025] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------- IMPORTS -----------------------------------------------------------------------
+
+import asyncio
+import socket
+
+from .base_receiver import TelemetryReceiver
+
+# -------------------------------------- CLASSES -----------------------------------------------------------------------
+
+class UdpReceiver(TelemetryReceiver):
+    """An async-friendly UDP socket listener.
+
+    Attributes:
+        m_buffer_size (int): The buffer size used for receiving data.
+        m_port (int): The UDP port this client is bound to.
+        m_bind_ip (str): The IP address this client is bound to.
+        m_socket (socket.socket): The underlying UDP socket object.
+    """
+
+    def __init__(self, port: int, bind_ip: str, buffer_size: int = 16384) -> None:
+        """
+        Initialize the UDP listener.
+
+        Args:
+            port (int): Port number to bind to.
+            bind_ip (str): IP address to bind to (e.g., '127.0.0.1').
+            buffer_size (int, optional): Size of the receive buffer. Defaults to 16384 bytes.
+        """
+        self.m_buffer_size = buffer_size
+        self.m_port = port
+        self.m_bind_ip = bind_ip
+        self.m_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.m_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.m_socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        self.m_socket.setblocking(False)
+        self.m_socket.bind((self.m_bind_ip, self.m_port))
+        self._loop = asyncio.get_event_loop()
+
+    async def getNextMessage(self) -> bytes:
+        """
+        Wait asynchronously for the next UDP message.
+
+        Returns:
+            bytes: The raw message bytes.
+        """
+        message, _ = await self._loop.sock_recvfrom(self.m_socket, self.m_buffer_size)
+        return message
+
+    async def close(self) -> None:
+        """
+        Close the UDP socket.
+        """
+        self.m_socket.close()

--- a/lib/telemetry_manager.py
+++ b/lib/telemetry_manager.py
@@ -39,7 +39,7 @@ from lib.f1_types import (F1PacketType, InvalidPacketLengthError,
                           PacketParticipantsData, PacketSessionData,
                           PacketSessionHistoryData, PacketTimeTrialData,
                           PacketTyreSetsData)
-from lib.socket_receiver import AsyncTCPListener, AsyncUDPListener
+from lib.socket_receiver import TcpReceiver, UdpReceiver, TelemetryReceiver
 
 # ------------------------- GLOBALS ------------------------------------------------------------------------------------
 F1TelemetryCallback = Optional[Callable[[object], Awaitable[None]]]
@@ -116,10 +116,7 @@ class AsyncF1TelemetryManager:
         self.m_replay_server = replay_server
         self.m_port_number = port_number
         self.m_logger = logger
-        if self.m_replay_server:
-            self.m_server = AsyncTCPListener(port_number, "localhost")
-        else:
-            self.m_server = AsyncUDPListener(port_number, "0.0.0.0", buffer_size=4096)
+        self.m_receiver = telemetry_receiver_factory(port_number, replay_server, logger)
         self.m_callbacks: Dict[F1PacketType, F1TelemetryCallback] = {ptype: None for ptype in self.packet_type_map}
 
         self.m_raw_packet_callback: Optional[Callable[[object], Awaitable[None]]] = None
@@ -166,8 +163,8 @@ class AsyncF1TelemetryManager:
         # Run the client indefinitely
         while True:
 
-            # Get next UDP message (TCP in the case of replay server)
-            raw_packet = await self.m_server.getNextMessage()
+            # Get next telemetry message
+            raw_packet = await self.m_receiver.getNextMessage()
             try:
                 await self._processPacket(should_parse_packet, raw_packet)
             except UnsupportedPacketFormat as e:
@@ -250,3 +247,14 @@ class AsyncF1TelemetryManager:
             return filepath
         except Exception as e: # pylint: disable=broad-except
             return f"<Failed to write packet to file: {e}>"
+
+# ------------------------- FUNCTIONS ----------------------------------------------------------------------------------
+
+def telemetry_receiver_factory(port_number: int, replay_server: bool, logger: Logger) -> TelemetryReceiver:
+    """Creates a telemetry receiver based on the given port number and replay server mode."""
+    if replay_server:
+        logger.info("REPLAY RECEIVER MODE. PORT = %s", port_number)
+        return TcpReceiver(port_number, "localhost")
+    else:
+        logger.info("LIVE RECEIVER MODE. PORT = %s", port_number)
+        return UdpReceiver(port_number, "0.0.0.0", buffer_size=4096)

--- a/lib/telemetry_manager.py
+++ b/lib/telemetry_manager.py
@@ -255,6 +255,5 @@ def telemetry_receiver_factory(port_number: int, replay_server: bool, logger: Lo
     if replay_server:
         logger.info("REPLAY RECEIVER MODE. PORT = %s", port_number)
         return TcpReceiver(port_number, "localhost")
-    else:
-        logger.info("LIVE RECEIVER MODE. PORT = %s", port_number)
-        return UdpReceiver(port_number, "0.0.0.0", buffer_size=4096)
+    logger.info("LIVE RECEIVER MODE. PORT = %s", port_number)
+    return UdpReceiver(port_number, "0.0.0.0", buffer_size=4096)

--- a/lib/wdt.py
+++ b/lib/wdt.py
@@ -1,0 +1,79 @@
+# MIT License
+#
+# Copyright (c) [2025] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------- IMPORTS -----------------------------------------------------------------------
+
+import asyncio
+import time
+from typing import Callable
+
+# -------------------------------------- CLASSES -----------------------------------------------------------------------
+
+class WatchDogTimer:
+    """
+    Monitors incoming telemetry over UDP and infers connection status using a watchdog timer.
+
+    Args:
+        status_callback (Callable[[bool], None]): Called when connection state changes.
+        timeout (float): Time in seconds after which connection is considered lost.
+    """
+
+    def __init__(self, status_callback: Callable[[bool], None], timeout: float = 2.0) -> None:
+        self._status_callback: Callable[[bool], None] = status_callback
+        self._timeout: float = timeout
+        self._last_received_time: float = time.time()
+        self.connected: bool = False
+        self._stopped: bool = False  # Used to break the run() loop gracefully
+
+    def on_packet_received(self) -> None:
+        """
+        Call this whenever a UDP telemetry packet is received.
+
+        Updates the watchdog timer and triggers `status_callback(True)` if transitioning to connected.
+        """
+        self._last_received_time = time.time()
+        if not self.connected:
+            self.connected = True
+            self._status_callback(True)
+
+    async def run(self) -> None:
+        """
+        Coroutine that should be scheduled using `asyncio.create_task(...)`.
+
+        It checks for telemetry silence and triggers `status_callback(False)` when disconnected.
+        """
+        try:
+            while not self._stopped:
+                await asyncio.sleep(0.5)
+                time_since_last = time.time() - self._last_received_time
+                if self.connected and time_since_last > self._timeout:
+                    self.connected = False
+                    self._status_callback(False)
+        except asyncio.CancelledError:
+            # Graceful shutdown on task cancellation
+            pass
+
+    def stop(self) -> None:
+        """
+        Stop the watchdog loop gracefully. Should be called before shutdown.
+        """
+        self._stopped = True

--- a/scripts/.pylintrc
+++ b/scripts/.pylintrc
@@ -562,7 +562,6 @@ check-str-concat-over-line-jumps=no
 # Add the modules to the ignored list
 ignored-modules=
     lib.f1_types,
-    lib.socket_receiver,
     lib.packet_cap,
     lib.overtake_analyzer,
     lib.race_analyzer,

--- a/tests/tests_base.py
+++ b/tests/tests_base.py
@@ -74,7 +74,7 @@ class CustomTestResult(unittest.TextTestResult):
         super().addError(test, err)
         print(f" {Fore.RED}[ERROR]{Style.RESET_ALL}")
 
-class F1TelemetryUnitTestsBase(unittest.TestCase):
+class F1TelemetryUnitTestsBase(unittest.IsolatedAsyncioTestCase):
     """
     Base class for all unit tests.
     """
@@ -85,9 +85,9 @@ class F1TelemetryUnitTestsBase(unittest.TestCase):
         test_class = self.__class__
         test_hierarchy = [test_class.__name__]
 
-        while issubclass(test_class, unittest.TestCase):
+        while issubclass(test_class, unittest.IsolatedAsyncioTestCase):
             parent_class = test_class.__bases__[0]
-            if issubclass(parent_class, unittest.TestCase):
+            if issubclass(parent_class, unittest.IsolatedAsyncioTestCase):
                 if parent_class.__name__ == 'F1TelemetryUnitTestsBase':
                     break
                 test_hierarchy.insert(0, parent_class.__name__)

--- a/tests/tests_config/tests_network_settings.py
+++ b/tests/tests_config/tests_network_settings.py
@@ -46,6 +46,7 @@ class TestNetworkSettings(TestF1ConfigBase):
         self.assertEqual(settings.save_viewer_port, 4769)
         self.assertEqual(settings.udp_tyre_delta_action_code, 11)
         self.assertEqual(settings.udp_custom_action_code, 12)
+        self.assertEqual(settings.wdt_interval_sec, 30)
 
     def test_invalid_port_ranges(self):
         """Test that invalid port numbers raise ValidationError"""
@@ -79,12 +80,14 @@ class TestNetworkSettings(TestF1ConfigBase):
             save_viewer_port=12345,
             udp_tyre_delta_action_code=1,
             udp_custom_action_code=12,
+            wdt_interval_sec=45
         )
         self.assertEqual(net.telemetry_port, 0)
         self.assertEqual(net.server_port, 65535)
         self.assertEqual(net.save_viewer_port, 12345)
         self.assertEqual(net.udp_tyre_delta_action_code, 1)
         self.assertEqual(net.udp_custom_action_code, 12)
+        self.assertEqual(net.wdt_interval_sec, 45)
 
     def test_invalid_telemetry_port(self):
         with self.assertRaises(ValidationError):
@@ -127,3 +130,13 @@ class TestNetworkSettings(TestF1ConfigBase):
         with self.assertRaises(ValidationError) as ctx:
             NetworkSettings(udp_tyre_delta_action_code=5, udp_custom_action_code=5)
         self.assertIn("must not be the same", str(ctx.exception))
+
+    def test_wdt_interval_sec_invalid_type(self):
+        with self.assertRaises(ValidationError):
+            NetworkSettings(wdt_interval_sec="cat")
+
+    def test_wdt_interval_sec_invalid_range(self):
+        with self.assertRaises(ValidationError):
+            NetworkSettings(wdt_interval_sec=0)
+        with self.assertRaises(ValidationError):
+            NetworkSettings(wdt_interval_sec=121)

--- a/tests/tests_itc.py
+++ b/tests/tests_itc.py
@@ -39,63 +39,39 @@ from lib.inter_task_communicator import (AsyncInterTaskCommunicator,
 # ----------------------------------------------------------------------------------------------------------------------
 
 class TestAsyncInterTaskCommunicator(F1TelemetryUnitTestsBase):
-    def setUp(self):
-        """Create a fresh communicator for each test"""
+    async def asyncSetUp(self):
+        """Create a fresh communicator for each test (async version)"""
         self.communicator = AsyncInterTaskCommunicator()
 
-    async def async_test_timeout_none(self):
+    async def test_timeout_none(self):
         """Test receive with timeout=None (indefinite wait)"""
-        # This test will timeout if the receive doesn't work correctly
         async def wait_and_send():
             await asyncio.sleep(0.1)
             await self.communicator.send('wait_queue', "Delayed Message")
 
-        # Start a task to send a message after a short delay
         send_task = asyncio.create_task(wait_and_send())
 
-        # Receive should wait indefinitely
         message = await self.communicator.receive('wait_queue', timeout=None)
-
-        # Verify message
         self.assertEqual(message, "Delayed Message")
-
-        # Ensure send task completed
         await send_task
 
-    def test_timeout_none(self):
-        """Wrapper to run async test synchronously"""
-        asyncio.run(self.async_test_timeout_none())
-
-    async def async_test_timeout_zero(self):
+    async def test_timeout_zero(self):
         """Test receive with timeout=0 (non-blocking)"""
         result = await self.communicator.receive('empty_queue', timeout=0)
         self.assertIsNone(result)
 
-    def test_timeout_zero(self):
-        """Wrapper to run async test synchronously"""
-        asyncio.run(self.async_test_timeout_zero())
-
-    async def async_test_timeout_positive(self):
-        """Test receive with a positive timeout"""
+    async def test_timeout_positive(self):
+        """Test receive with a positive timeout and delayed message"""
         # No message initially
         result = await self.communicator.receive('timeout_queue', timeout=0.1)
         self.assertIsNone(result)
 
-        # Send a message after a delay
         async def delayed_send():
             await asyncio.sleep(0.05)
             await self.communicator.send('timeout_queue', "Timely Message")
 
-        # Start delayed send
         send_task = asyncio.create_task(delayed_send())
 
-        # Receive with longer timeout should get the message
         message = await self.communicator.receive('timeout_queue', timeout=0.2)
         self.assertEqual(message, "Timely Message")
-
-        # Ensure send task completed
         await send_task
-
-    def test_timeout_positive(self):
-        """Wrapper to run async test synchronously"""
-        asyncio.run(self.async_test_timeout_positive())

--- a/tests/tests_save_to_disk.py
+++ b/tests/tests_save_to_disk.py
@@ -36,20 +36,19 @@ from lib.save_to_disk import save_json_to_file
 
 
 class TestSaveRaceInfo(F1TelemetryUnitTestsBase):
-
-    def test_save_race_info_creates_file_with_correct_content(self):
+    async def test_save_race_info_creates_file_with_correct_content(self):
         test_data = {"driver": "Hamilton", "position": 2}
         test_filename = "race-info.json"
 
         with tempfile.TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
-            # Call the async function using the temp dir as base_dir
-            file_path = asyncio.run(save_json_to_file(test_data, test_filename, base_path))
 
-            # Verify file exists
+            # Await the async file-saving function directly
+            file_path = await save_json_to_file(test_data, test_filename, base_path)
+
             self.assertTrue(file_path.exists(), "Expected JSON file was not created.")
 
-            # Verify file contents
             with file_path.open("r", encoding="utf-8") as f:
                 content = json.load(f)
+
             self.assertEqual(content, test_data, "File contents do not match input data.")

--- a/tests/tests_wdt.py
+++ b/tests/tests_wdt.py
@@ -1,0 +1,96 @@
+# MIT License
+#
+# Copyright (c) [2025] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# pylint: skip-file
+
+import asyncio
+import sys
+import os
+from typing import List
+
+# Add the parent directory to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from tests_base import F1TelemetryUnitTestsBase
+
+from lib.wdt import WatchDogTimer
+
+if sys.platform == 'win32':
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+class TestWatchDogTimer(F1TelemetryUnitTestsBase):
+    async def asyncSetUp(self):
+        self.status_changes: List[bool] = []
+        self.monitor = WatchDogTimer(
+            status_callback=self.status_changes.append,
+            timeout=0.5  # Use short timeout for faster tests
+        )
+        self.task = asyncio.create_task(self.monitor.run(), name="UT Monitor Task")
+
+    async def asyncTearDown(self):
+        self.monitor.stop()
+        self.task.cancel()
+        try:
+            await self.task
+        except asyncio.CancelledError:
+            pass
+
+    async def test_starts_disconnected(self):
+        """Monitor should start in disconnected state with no callback fired."""
+        await asyncio.sleep(0.1)
+        self.assertEqual(self.status_changes, [])
+
+    async def test_transitions_to_connected_on_packet(self):
+        """Receiving a packet should trigger a connected callback."""
+        self.monitor.on_packet_received()
+        await asyncio.sleep(0.1)
+        self.assertEqual(self.status_changes, [True])
+
+    async def test_does_not_fire_duplicate_connected(self):
+        """Receiving repeated packets should not fire redundant connected events."""
+        for _ in range(3):
+            self.monitor.on_packet_received()
+            await asyncio.sleep(0.1)
+        self.assertEqual(self.status_changes, [True])
+
+    async def test_transitions_to_disconnected_on_timeout(self):
+        """No packet for timeout duration should trigger disconnected callback."""
+        self.monitor.on_packet_received()
+        await asyncio.sleep(0.1)
+        self.assertEqual(self.status_changes, [True])
+
+        await asyncio.sleep(0.6)  # Wait beyond the timeout
+        self.assertEqual(self.status_changes, [True, False])
+
+    async def test_reconnect_after_disconnection(self):
+        """Monitor should detect disconnection and reconnect if packets resume."""
+        self.monitor.on_packet_received()
+        await asyncio.sleep(0.1)
+        self.assertEqual(self.status_changes, [True])
+
+        await asyncio.sleep(0.6)
+        self.assertEqual(self.status_changes, [True, False])
+
+        self.monitor.on_packet_received()
+        await asyncio.sleep(0.1)
+        self.assertEqual(self.status_changes, [True, False, True])

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -78,7 +78,9 @@ from tests_tyre_wear_extrapolator import (
     TestTyreWearExtrapolatorWithNonRacingLaps)
 from tests_udp_forwarder import TestAsyncUDPForwarder, TestUDPForwarder
 from tests_version import TestGetVersion, TestIsUpdateAvailable
+
 from tests.tests_child_proc_mgmt import TestIsInitComplete, TestPidReport
+from tests.tests_wdt import TestWatchDogTimer
 
 # Initialize colorama
 init(autoreset=True)


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Using a watchdog timer, track if the app is receiving data from the F1 game or not
<img width="486" height="135" alt="image" src="https://github.com/user-attachments/assets/bf653567-03a0-49d3-abe5-29f42f0c8a42" />
<img width="590" height="138" alt="image" src="https://github.com/user-attachments/assets/d01234c1-fb79-4b2b-b723-121531fad3f7" />

Made TCP/UDP receiver inherit from TelemetryReceiver and added a factory method

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [x] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Unit Tests

- [x] All unit tests pass
- Attach test command/output:

```
<img width="590" height="138" alt="image" src="https://github.com/user-attachments/assets/979c79f8-b687-4b7f-b54d-390b7808bc15" />
```

To run the unit test suite
```bash
poetry run python tests/unit_tests.py
```

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
===== TEST RESULTS =====
Passed: 27/27

PASS: f1_23_sp_austria.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_mp_fp_austria_full_spec.f1pcap
PASS: f1_25_mp_fp_jeddah.f1pcap
PASS: f1_25_mp_fp_jeddah_player.f1pcap
PASS: f1_25_mp_fp_jeddah_player_2.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_mp_quali_sprint_austria_spec.f1pcap
PASS: f1_25_mp_race_japan_spec.f1pcap
PASS: f1_25_mp_race_jeddah.f1pcap
PASS: f1_25_mp_solo_afk_fp_aus.f1pcap
PASS: f1_25_sp_aus_5lap_1stop.f1pcap
PASS: f1_25_sp_aus_5lap_1stop_flashback.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_sp_baku_mid_session_save_load.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_sp_imola_5lap_1stop.f1pcap
PASS: f1_25_sp_qatar_flashback_1stop.f1pcap
PASS: f1_25_sp_qatar_partial.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

### ✅ Pylint

* [x] Code passes `pylint`
* Paste summary report:

```
$ pylint --rcfile scripts/.pylintrc apps lib

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

To run pylint
```bash
pylint --rcfile scripts/.pylintrc lib apps
```

---

## 🧱 `lib/` Directory Changes

* [x] This PR modifies or adds files under `lib/`
* [x] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Added tests for watchdog timer
Migrated tests to unittests.IsolatedAsyncioTestCase
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Integrate a watchdog timer mechanism to detect and signal when F1 telemetry data stops arriving, making the timeout interval configurable. Refactor socket receiver abstractions into a common interface with UDP and TCP implementations. Surface the connection status through the backend API and render it in the frontend UI, and modernize the test suite to use async test cases and cover the new functionality.

New Features:
- Integrate WatchDogTimer to monitor telemetry data reception and update connection status
- Add wdt_interval_sec configuration option for customizable watchdog timeout
- Expose WDT status in backend API and JSON responses and display a blinking connection indicator in the frontend

Enhancements:
- Refactor socket receivers into a TelemetryReceiver interface with concrete UdpReceiver and TcpReceiver implementations and a factory function
- Modernize test suite by switching to IsolatedAsyncioTestCase, converting tests to async methods, and updating UDP forwarder tests

Tests:
- Add unit tests for WatchDogTimer behavior