### PR TITLE
Refactor telemetry objects: Add slots and safeCast

### DIFF
--- a/apps/backend/pits_n_giggles.py
+++ b/apps/backend/pits_n_giggles.py
@@ -266,7 +266,7 @@ def entry_point():
     except asyncio.CancelledError:
         png_logger.info("Program shutdown gracefully.")
     except Exception as e: # pylint: disable=broad-exception-caught
-        png_logger.exception(f"Error in main: {e}")
+        png_logger.exception("Error in main: %s", e)
         sys.exit(1)
 
 # ---------------------------------------- PROFILER MODE ---------------------------------------------------------------

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -223,7 +223,7 @@ class SessionState:
 
     MAX_DRIVERS: int = 22
 
-    __slots__ = [
+    __slots__ = (
         'm_logger',
         'm_driver_data',
         'm_player_index',
@@ -244,8 +244,8 @@ class SessionState:
         'm_custom_markers_history',
         'm_first_session_update_received',
         'm_version',
-        'm_connected_to_sim'
-    ]
+        'm_connected_to_sim',
+    )
 
     def __init__(self,
                  logger: logging.Logger,

--- a/lib/f1_types/base_pkt.py
+++ b/lib/f1_types/base_pkt.py
@@ -101,6 +101,8 @@ class F1PacketBase:
     Base class for parsed F1 telemetry packets.
     """
 
+    __slots__ = ("m_header",)
+
     def __init__(self, header: PacketHeader) -> None:
         """
         Initializes the PacketHeaderParser with the raw packet data.

--- a/lib/f1_types/base_pkt.py
+++ b/lib/f1_types/base_pkt.py
@@ -25,9 +25,13 @@
 from abc import abstractmethod
 from enum import Enum
 from functools import total_ordering
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Type, TypeVar
 
 from .header import PacketHeader
+
+# -------------------------------------- TYPES -------------------------------------------------------------------------
+
+T = TypeVar("T", bound="F1BaseEnum")
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
@@ -46,6 +50,21 @@ class F1BaseEnum(Enum):
         if isinstance(value, cls):
             return True
         return any(value == member.value for member in cls)
+
+    @classmethod
+    def safeCast(cls: Type[T], value: int | T) -> Optional[T]:
+        """
+        Safely cast a value to the enum type.
+
+        Args:
+            value (int): The value to cast.
+
+        Returns:
+            Optional[F1BaseEnum]: The cast enum value.
+        """
+        if cls.isValid(value):
+            return cls(value)
+        return value
 
     def __str__(self):
         """Return the string representation of this object

--- a/lib/f1_types/base_pkt.py
+++ b/lib/f1_types/base_pkt.py
@@ -25,7 +25,7 @@
 from abc import abstractmethod
 from enum import Enum
 from functools import total_ordering
-from typing import Any, Dict, Optional, Type, TypeVar
+from typing import Any, Dict, Optional, Type, TypeVar, Union
 
 from .header import PacketHeader
 
@@ -52,7 +52,7 @@ class F1BaseEnum(Enum):
         return any(value == member.value for member in cls)
 
     @classmethod
-    def safeCast(cls: Type[T], value: int | T) -> Optional[T]:
+    def safeCast(cls: Type[T], value: Union[int, T]) -> Optional[T]:
         """
         Safely cast a value to the enum type.
 

--- a/lib/f1_types/base_pkt.py
+++ b/lib/f1_types/base_pkt.py
@@ -62,9 +62,7 @@ class F1BaseEnum(Enum):
         Returns:
             Optional[F1BaseEnum]: The cast enum value.
         """
-        if cls.isValid(value):
-            return cls(value)
-        return value
+        return cls(value) if cls.isValid(value) else value
 
     def __str__(self):
         """Return the string representation of this object

--- a/lib/f1_types/packet_0_car_motion_data.py
+++ b/lib/f1_types/packet_0_car_motion_data.py
@@ -78,6 +78,27 @@ class CarMotionData(F1SubPacketBase):
     )
     PACKET_LEN: int = COMPILED_PACKET_STRUCT.size
 
+    __slots__ = (
+        "m_worldPositionX",
+        "m_worldPositionY",
+        "m_worldPositionZ",
+        "m_worldVelocityX",
+        "m_worldVelocityY",
+        "m_worldVelocityZ",
+        "m_worldForwardDirX",
+        "m_worldForwardDirY",
+        "m_worldForwardDirZ",
+        "m_worldRightDirX",
+        "m_worldRightDirY",
+        "m_worldRightDirZ",
+        "m_gForceLateral",
+        "m_gForceLongitudinal",
+        "m_gForceVertical",
+        "m_yaw",
+        "m_pitch",
+        "m_roll",
+    )
+
     def __init__(self, data: bytes) -> None:
         """A class for parsing the data related to the motion of the F1 car
 
@@ -286,6 +307,10 @@ class PacketMotionData(F1PacketBase):
     """
 
     MAX_CARS = 22
+
+    __slots__ = (
+        "m_carMotionData",
+    )
 
     def __init__(self, header:PacketHeader, packet: bytes) -> None:
         """Construct the PacketMotionData object from the given packet payload

--- a/lib/f1_types/packet_10_car_damage_data.py
+++ b/lib/f1_types/packet_10_car_damage_data.py
@@ -27,9 +27,11 @@ from typing import Any, Dict, List
 from .common import _validate_parse_fixed_segments
 from .header import PacketHeader
 
+from .base_pkt import F1PacketBase, F1SubPacketBase
+
 # --------------------- CLASS DEFINITIONS --------------------------------------
 
-class CarDamageData:
+class CarDamageData(F1SubPacketBase):
     """
     Class representing the packet for car damage data.
 
@@ -511,8 +513,7 @@ class CarDamageData:
             engine_seized,
         ), packet_format)
 
-
-class PacketCarDamageData:
+class PacketCarDamageData(F1PacketBase):
     """
     Class representing the packet for car damage data.
 
@@ -526,6 +527,10 @@ class PacketCarDamageData:
 
     MAX_CARS = 22
 
+    __slots__ = (
+        "m_carDamageData",
+    )
+
     def __init__(self, header: PacketHeader, data: bytes) -> None:
         """
         Initializes PacketCarDamageData with raw data.
@@ -534,6 +539,8 @@ class PacketCarDamageData:
             header (PacketHeader): The header of the packet.
             data (bytes): Raw data representing the packet for car damage data.
         """
+
+        super().__init__(header)
 
         self.m_header: PacketHeader = header
         if header.m_packetFormat >= 2025:

--- a/lib/f1_types/packet_10_car_damage_data.py
+++ b/lib/f1_types/packet_10_car_damage_data.py
@@ -112,6 +112,32 @@ class CarDamageData:
     )
     PACKET_LEN_25 = struct.calcsize(PACKET_FORMAT_25)
 
+    __slots__ = (
+        "m_packetFormat",
+        "m_tyresWear",
+        "m_tyresDamage",
+        "m_brakesDamage",
+        "m_tyreBlisters",
+        "m_frontLeftWingDamage",
+        "m_frontRightWingDamage",
+        "m_rearWingDamage",
+        "m_floorDamage",
+        "m_diffuserDamage",
+        "m_sidepodDamage",
+        "m_drsFault",
+        "m_ersFault",
+        "m_gearBoxDamage",
+        "m_engineDamage",
+        "m_engineMGUHWear",
+        "m_engineESWear",
+        "m_engineCEWear",
+        "m_engineICEWear",
+        "m_engineMGUKWear",
+        "m_engineTCWear",
+        "m_engineBlown",
+        "m_engineSeized",
+    )
+
     def __init__(self, data, packet_format) -> None:
         """
         Initializes CarDamageData with raw data.

--- a/lib/f1_types/packet_11_session_history_data.py
+++ b/lib/f1_types/packet_11_session_history_data.py
@@ -72,6 +72,17 @@ class LapHistoryData(F1SubPacketBase):
     )
     PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
+    __slots__ = (
+        "m_lapTimeInMS",
+        "m_sector1TimeInMS",
+        "m_sector1TimeMinutes",
+        "m_sector2TimeInMS",
+        "m_sector2TimeMinutes",
+        "m_sector3TimeInMS",
+        "m_sector3TimeMinutes",
+        "m_lapValidBitFlags",
+    )
+
     def __init__(self, data: bytes) -> None:
         """
         Initializes LapHistoryData with raw data.
@@ -271,6 +282,12 @@ class TyreStintHistoryData(F1SubPacketBase):
     )
     PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
+    __slots__ = (
+        "m_endLap",
+        "m_tyreActualCompound",
+        "m_tyreVisualCompound",
+    )
+
     def __init__(self, data: bytes) -> None:
         """
         Initializes TyreStintHistoryData with raw data.
@@ -378,6 +395,18 @@ class PacketSessionHistoryData(F1PacketBase):
         "B" # uint8         m_bestSector3LapNum;        // Lap the best Sector 3 time was achieved on
     )
     PACKET_LEN = COMPILED_PACKET_STRUCT.size
+
+    __slots__ = (
+        "m_carIdx",
+        "m_numLaps",
+        "m_numTyreStints",
+        "m_bestLapTimeLapNum",
+        "m_bestSector1LapNum",
+        "m_bestSector2LapNum",
+        "m_bestSector3LapNum",
+        "m_lapHistoryData",
+        "m_tyreStintsHistoryData",
+    )
 
     def __init__(self, header, data) -> None:
         """

--- a/lib/f1_types/packet_11_session_history_data.py
+++ b/lib/f1_types/packet_11_session_history_data.py
@@ -302,10 +302,8 @@ class TyreStintHistoryData(F1SubPacketBase):
             self.m_tyreVisualCompound,
         ) = self.COMPILED_PACKET_STRUCT.unpack(data)
 
-        if ActualTyreCompound.isValid(self.m_tyreActualCompound):
-            self.m_tyreActualCompound = ActualTyreCompound(self.m_tyreActualCompound)
-        if VisualTyreCompound.isValid(self.m_tyreVisualCompound):
-            self.m_tyreVisualCompound = VisualTyreCompound(self.m_tyreVisualCompound)
+        self.m_tyreActualCompound = ActualTyreCompound.safeCast(self.m_tyreActualCompound)
+        self.m_tyreVisualCompound = VisualTyreCompound.safeCast(self.m_tyreVisualCompound)
 
     def __str__(self) -> str:
         """

--- a/lib/f1_types/packet_12_tyre_sets_packet.py
+++ b/lib/f1_types/packet_12_tyre_sets_packet.py
@@ -67,6 +67,18 @@ class TyreSetData(F1SubPacketBase):
     )
     PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
+    __slots__ = (
+        "m_actualTyreCompound",
+        "m_visualTyreCompound",
+        "m_wear",
+        "m_available",
+        "m_recommendedSession",
+        "m_lifeSpan",
+        "m_usableLife",
+        "m_lapDeltaTime",
+        "m_fitted",
+    )
+
     def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initializes TyreSetData with raw data.
@@ -249,6 +261,12 @@ class PacketTyreSetsData(F1PacketBase):
 
     COMPILED_PACKET_STRUCT_FITTED_IDX = struct.Struct("<B")
     PACKET_LEN_FITTED_IDX = COMPILED_PACKET_STRUCT_FITTED_IDX.size
+
+    __slots__ = (
+        "m_carIdx",
+        "m_tyreSetData",
+        "m_fittedIdx",
+    )
 
     def __init__(self, header: PacketHeader, data: bytes) -> None:
         """

--- a/lib/f1_types/packet_12_tyre_sets_packet.py
+++ b/lib/f1_types/packet_12_tyre_sets_packet.py
@@ -101,14 +101,12 @@ class TyreSetData(F1SubPacketBase):
             self.m_fitted,
         ) = self.COMPILED_PACKET_STRUCT.unpack(data)
 
-        if ActualTyreCompound.isValid(self.m_actualTyreCompound):
-            self.m_actualTyreCompound = ActualTyreCompound(self.m_actualTyreCompound)
-        if VisualTyreCompound.isValid(self.m_visualTyreCompound):
-            self.m_visualTyreCompound = VisualTyreCompound(self.m_visualTyreCompound)
-        if self.m_packetFormat == 2023 and SessionType23.isValid(self.m_recommendedSession):
-            self.m_recommendedSession = SessionType23(self.m_recommendedSession)
-        elif self.m_packetFormat in {2024, 2025} and SessionType24.isValid(self.m_recommendedSession):
-            self.m_recommendedSession = SessionType24(self.m_recommendedSession)
+        self.m_actualTyreCompound = ActualTyreCompound.safeCast(self.m_actualTyreCompound)
+        self.m_visualTyreCompound = VisualTyreCompound.safeCast(self.m_visualTyreCompound)
+        if self.m_packetFormat == 2023:
+            self.m_recommendedSession = SessionType23.safeCast(self.m_recommendedSession)
+        elif self.m_packetFormat in {2024, 2025}:
+            self.m_recommendedSession = SessionType24.safeCast(self.m_recommendedSession)
         self.m_fitted = bool(self.m_fitted)
 
     def __str__(self) -> str:

--- a/lib/f1_types/packet_13_motion_ex_data.py
+++ b/lib/f1_types/packet_13_motion_ex_data.py
@@ -106,6 +106,37 @@ class PacketMotionExData(F1PacketBase):
     PACKET_LEN_EXTRA_25 = COMPILED_PACKET_STRUCT_25_EXTRA.size
     PACKET_LEN_25 = PACKET_LEN_23 + PACKET_LEN_EXTRA_24 + PACKET_LEN_EXTRA_25
 
+    __slots__ = (
+        "m_suspensionPosition",
+        "m_suspensionVelocity",
+        "m_suspensionAcceleration",
+        "m_wheelSpeed",
+        "m_wheelSlipRatio",
+        "m_wheelSlipAngle",
+        "m_wheelLatForce",
+        "m_wheelLongForce",
+        "m_wheelVertForce",
+        "m_frontAeroHeight",
+        "m_rearAeroHeight",
+        "m_frontRollAngle",
+        "m_rearRollAngle",
+        "m_chassisYaw",
+        "m_chassisPitch",
+        "m_wheelCamber",
+        "m_wheelCamberGain",
+        "m_heightOfCOGAboveGround",
+        "m_localVelocityX",
+        "m_localVelocityY",
+        "m_localVelocityZ",
+        "m_angularVelocityX",
+        "m_angularVelocityY",
+        "m_angularVelocityZ",
+        "m_angularAccelerationX",
+        "m_angularAccelerationY",
+        "m_angularAccelerationZ",
+        "m_frontWheelsAngle",
+    )
+
     def __init__(self, header: PacketHeader, data: bytes) -> None:
         """
         Initializes PacketMotionExData with raw data.

--- a/lib/f1_types/packet_14_time_trial_data.py
+++ b/lib/f1_types/packet_14_time_trial_data.py
@@ -76,6 +76,21 @@ class TimeTrialDataSet(F1SubPacketBase):
     m_customSetup: bool
     m_isValid: bool
 
+    __slots__ = (
+        "m_carIdx",
+        "m_teamId",
+        "m_lapTimeInMS",
+        "m_sector1TimeInMS",
+        "m_sector2TimeInMS",
+        "m_sector3TimeInMS",
+        "m_tractionControl",
+        "m_gearboxAssist",
+        "m_antiLockBrakes",
+        "m_equalCarPerformance",
+        "m_customSetup",
+        "m_isValid",
+    )
+
     def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initializes a TimeTrialDataSet object by unpacking the provided binary data.
@@ -260,9 +275,15 @@ class PacketTimeTrialData(F1PacketBase):
         - m_header (PacketHeader): The packet header
         - m_playerSessionBestDataSet (TimeTrialDataSet): The player session best data set
         - m_personalBestDataSet (TimeTrialDataSet): The personal best data set
-        - m_rivalDataSet (TimeTrialDataSet): The rival data set
+        - m_rivalSessionBestDataSet (TimeTrialDataSet): The rival data set
 
     """
+
+    __slots__ = (
+        "m_playerSessionBestDataSet",
+        "m_personalBestDataSet",
+        "m_rivalSessionBestDataSet",
+    )
 
     def __init__(self, header: PacketHeader, data: bytes) -> None:
         """

--- a/lib/f1_types/packet_14_time_trial_data.py
+++ b/lib/f1_types/packet_14_time_trial_data.py
@@ -119,10 +119,10 @@ class TimeTrialDataSet(F1SubPacketBase):
         ) = self.COMPILED_PACKET_STRUCT.unpack(data)
 
         # No ned to check game year, since this packet type is not available in F1 23
-        if packet_format < 2025 and TeamID24.isValid(self.m_teamId):
-                self.m_teamId = TeamID24(self.m_teamId)
-        elif TeamID25.isValid(self.m_teamId):
-            self.m_teamId = TeamID25(self.m_teamId)
+        if packet_format < 2025:
+            self.m_teamId = TeamID24.safeCast(self.m_teamId)
+        else:
+            self.m_teamId = TeamID25.safeCast(self.m_teamId)
         self.m_tractionControl = bool(self.m_tractionControl)
         self.m_gearboxAssist = bool(self.m_gearboxAssist)
         self.m_antiLockBrakes = bool(self.m_antiLockBrakes)

--- a/lib/f1_types/packet_15_lap_positions_data.py
+++ b/lib/f1_types/packet_15_lap_positions_data.py
@@ -51,6 +51,12 @@ class PacketLapPositionsData(F1PacketBase):
     COMPILED_PACKET_STRUCT_ARRAY = struct.Struct(f"<{MAX_CARS * MAX_LAPS}B")
     PACKET_LEN_ARRAY = COMPILED_PACKET_STRUCT_ARRAY.size
 
+    __slots__ = (
+        "m_numLaps",
+        "m_lapStart",
+        "m_lapPositions",
+    )
+
     def __init__(self, header: PacketHeader, packet: bytes) -> None:
         super().__init__(header)
         self.m_numLaps: int

--- a/lib/f1_types/packet_1_session_data.py
+++ b/lib/f1_types/packet_1_session_data.py
@@ -49,6 +49,11 @@ class MarshalZone(F1SubPacketBase):
     )
     PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
+    __slots__ = (
+        "m_zoneStart",
+        "m_zoneFlag",
+    )
+
     class MarshalZoneFlagType(F1BaseEnum):
         """
         ENUM class for the marshal zone flag status
@@ -178,6 +183,17 @@ class WeatherForecastSample(F1SubPacketBase):
         "B" # uint8  - Rain percentage (0-100)
     )
     PACKET_LEN = COMPILED_PACKET_STRUCT.size
+
+    __slots__ = (
+        "m_session_type",
+        "m_time_offset",
+        "m_weather",
+        "m_track_temperature",
+        "m_track_temperature_change",
+        "m_air_temperature",
+        "m_air_temperature_change",
+        "m_rain_percentage",
+    )
 
     class WeatherCondition(F1BaseEnum):
         """
@@ -602,6 +618,86 @@ class PacketSessionData(F1PacketBase):
     )
     PACKET_LEN_SECTION_5 = COMPILED_PACKET_STRUCT_SECTION_5.size
 
+    __slots__ = (
+        "m_weather",
+        "m_trackTemperature",
+        "m_airTemperature",
+        "m_totalLaps",
+        "m_trackLength",
+        "m_sessionType",
+        "m_trackId",
+        "m_formula",
+        "m_sessionTimeLeft",
+        "m_sessionDuration",
+        "m_pitSpeedLimit",
+        "m_gamePaused",
+        "m_isSpectating",
+        "m_spectatorCarIndex",
+        "m_sliProNativeSupport",
+        "m_numMarshalZones",
+        "m_marshalZones",
+        "m_safetyCarStatus",
+        "m_networkGame",
+        "m_numWeatherForecastSamples",
+        "m_weatherForecastSamples",
+        "m_forecastAccuracy",
+        "m_aiDifficulty",
+        "m_seasonLinkIdentifier",
+        "m_weekendLinkIdentifier",
+        "m_sessionLinkIdentifier",
+        "m_pitStopWindowIdealLap",
+        "m_pitStopWindowLatestLap",
+        "m_pitStopRejoinPosition",
+        "m_steeringAssist",
+        "m_brakingAssist",
+        "m_gearboxAssist",
+        "m_pitAssist",
+        "m_pitReleaseAssist",
+        "m_ERSAssist",
+        "m_DRSAssist",
+        "m_dynamicRacingLine",
+        "m_dynamicRacingLineType",
+        "m_gameMode",
+        "m_ruleSet",
+        "m_timeOfDay",
+        "m_sessionLength",
+        "m_speedUnitsLeadPlayer",
+        "m_temperatureUnitsLeadPlayer",
+        "m_speedUnitsSecondaryPlayer",
+        "m_temperatureUnitsSecondaryPlayer",
+        "m_numSafetyCarPeriods",
+        "m_numVirtualSafetyCarPeriods",
+        "m_numRedFlagPeriods",
+        "m_equalCarPerformance",
+        "m_recoveryMode",
+        "m_flashbackLimit",
+        "m_surfaceType",
+        "m_lowFuelMode",
+        "m_raceStarts",
+        "m_tyreTemperatureMode",
+        "m_pitLaneTyreSim",
+        "m_carDamage",
+        "m_carDamageRate",
+        "m_collisions",
+        "m_collisionsOffForFirstLapOnly",
+        "m_mpUnsafePitRelease",
+        "m_mpOffForGriefing",
+        "m_cornerCuttingStringency",
+        "m_parcFermeRules",
+        "m_pitStopExperience",
+        "m_safetyCar",
+        "m_safetyCarExperience",
+        "m_formationLap",
+        "m_formationLapExperience",
+        "m_redFlags",
+        "m_affectsLicenceLevelSolo",
+        "m_affectsLicenceLevelMP",
+        "m_numSessionsInWeekend",
+        "m_weekendStructure",
+        "m_sector2LapDistanceStart",
+        "m_sector3LapDistanceStart",
+    )
+
     class FormulaType(F1BaseEnum):
         """An enumeration of formula types."""
 
@@ -835,11 +931,10 @@ class PacketSessionData(F1PacketBase):
         self.m_sector2LapDistanceStart: float    # // Distance in m around track where sector 2 starts
         self.m_sector3LapDistanceStart: float    # // Distance in m around track where sector 3
 
-        self.m_maxMarshalZones = self.F1_23_MAX_NUM_MARSHAL_ZONES
         if header.m_packetFormat == 2023:
-            self.m_maxWeatherForecastSamples = self.F1_23_MAX_NUM_WEATHER_FORECAST_SAMPLES
+            max_weather_forecast_samples = self.F1_23_MAX_NUM_WEATHER_FORECAST_SAMPLES
         else:
-            self.m_maxWeatherForecastSamples = self.F1_24_MAX_NUM_WEATHER_FORECAST_SAMPLES
+            max_weather_forecast_samples = self.F1_24_MAX_NUM_WEATHER_FORECAST_SAMPLES
         # First, section 0
         section_0_raw_data = data[:self.PACKET_LEN_SECTION_0]
         byte_index_so_far = self.PACKET_LEN_SECTION_0
@@ -883,7 +978,7 @@ class PacketSessionData(F1PacketBase):
             item_cls=MarshalZone,
             item_len=MarshalZone.PACKET_LEN,
             count=self.m_numMarshalZones,
-            max_count=self.m_maxMarshalZones,
+            max_count=self.F1_23_MAX_NUM_MARSHAL_ZONES,
         )
 
         # Section 2, till numWeatherForecastSamples
@@ -906,7 +1001,7 @@ class PacketSessionData(F1PacketBase):
             item_cls=WeatherForecastSample,
             item_len=WeatherForecastSample.PACKET_LEN,
             count=self.m_numWeatherForecastSamples,
-            max_count=self.m_maxWeatherForecastSamples,
+            max_count=max_weather_forecast_samples,
             packet_format=header.m_packetFormat
         )
 

--- a/lib/f1_types/packet_1_session_data.py
+++ b/lib/f1_types/packet_1_session_data.py
@@ -82,8 +82,7 @@ class MarshalZone(F1SubPacketBase):
             self.m_zoneFlag     # int8 - -1 = invalid/unknown, 0 = none, 1 = green, 2 = blue, 3 = yellow
         ) = self.COMPILED_PACKET_STRUCT.unpack(data)
 
-        if MarshalZone.MarshalZoneFlagType.isValid(self.m_zoneFlag):
-            self.m_zoneFlag = MarshalZone.MarshalZoneFlagType(self.m_zoneFlag)
+        self.m_zoneFlag = MarshalZone.MarshalZoneFlagType.safeCast(self.m_zoneFlag)
 
     def __str__(self) -> str:
         """Return the string representation of this object
@@ -312,16 +311,14 @@ class WeatherForecastSample(F1SubPacketBase):
         ) = self.COMPILED_PACKET_STRUCT.unpack(data)
 
         # Convert to typed enums wherever applicable
-        if WeatherForecastSample.WeatherCondition.isValid(self.m_weather):
-            self.m_weather = WeatherForecastSample.WeatherCondition(self.m_weather)
-        if WeatherForecastSample.AirTemperatureChange.isValid(self.m_airTemperatureChange):
-            self.m_airTemperatureChange = WeatherForecastSample.AirTemperatureChange(self.m_airTemperatureChange)
-        if WeatherForecastSample.TrackTemperatureChange.isValid(self.m_trackTemperatureChange):
-            self.m_trackTemperatureChange = WeatherForecastSample.TrackTemperatureChange(self.m_trackTemperatureChange)
-        if packet_format == 2023 and SessionType23.isValid(self.m_sessionType):
-            self.m_sessionType = SessionType23(self.m_sessionType)
-        elif SessionType24.isValid(self.m_sessionType):
-            self.m_sessionType = SessionType24(self.m_sessionType)
+        self.m_weather = WeatherForecastSample.WeatherCondition.safeCast(self.m_weather)
+        self.m_airTemperatureChange = WeatherForecastSample.AirTemperatureChange.safeCast(self.m_airTemperatureChange)
+        self.m_trackTemperatureChange = WeatherForecastSample.TrackTemperatureChange.safeCast(
+                                        self.m_trackTemperatureChange)
+        if packet_format == 2023:
+            self.m_sessionType = SessionType23.safeCast(self.m_sessionType)
+        else:
+            self.m_sessionType = SessionType24.safeCast(self.m_sessionType)
 
     def __str__(self) -> str:
         """A description of the entire function, its parameters, and its return types.
@@ -958,18 +955,15 @@ class PacketSessionData(F1PacketBase):
             self.m_numMarshalZones,
         ) = unpacked_data
         self.m_isSpectating = bool(self.m_isSpectating)
-        if WeatherForecastSample.WeatherCondition.isValid(self.m_weather):
-            self.m_weather = WeatherForecastSample.WeatherCondition(self.m_weather)
-        if TrackID.isValid(self.m_trackId):
-            self.m_trackId = TrackID(self.m_trackId)
+        self.m_weather = WeatherForecastSample.WeatherCondition.safeCast(self.m_weather)
+        self.m_trackId = TrackID.safeCast(self.m_trackId)
 
-        if header.m_packetFormat == 2023 and SessionType23.isValid(self.m_sessionType):
-            self.m_sessionType = SessionType23(self.m_sessionType)
-        elif SessionType24.isValid(self.m_sessionType):
-            self.m_sessionType = SessionType24(self.m_sessionType)
+        if header.m_packetFormat == 2023:
+            self.m_sessionType = SessionType23.safeCast(self.m_sessionType)
+        else:
+            self.m_sessionType = SessionType24.safeCast(self.m_sessionType)
 
-        if PacketSessionData.FormulaType.isValid(self.m_formula):
-            self.m_formula = PacketSessionData.FormulaType(self.m_formula)
+        self.m_formula = PacketSessionData.FormulaType.safeCast(self.m_formula)
 
         # Next section 1, marshalZones
         self.m_marshalZones, byte_index_so_far = _validate_parse_fixed_segments(
@@ -990,8 +984,7 @@ class PacketSessionData(F1PacketBase):
             self.m_networkGame, #               // 0 = offline, 1 = online
             self.m_numWeatherForecastSamples # // Number of weather samples to follow
         ) = unpacked_data
-        if SafetyCarType.isValid(self.m_safetyCarStatus):
-            self.m_safetyCarStatus = SafetyCarType(self.m_safetyCarStatus)
+        self.m_safetyCarStatus = SafetyCarType.safeCast(self.m_safetyCarStatus)
         section_2_raw_data = None
 
         # Section 3 - weather forecast samples
@@ -1040,14 +1033,10 @@ class PacketSessionData(F1PacketBase):
             self.m_numRedFlagPeriods,                # uint8
         ) = unpacked_data
         section_4_raw_data = None
-        if GearboxAssistMode.isValid(self.m_gearboxAssist):
-            self.m_gearboxAssist = GearboxAssistMode(self.m_gearboxAssist)
-        if SessionLength.isValid(self.m_sessionLength):
-            self.m_sessionLength = SessionLength(self.m_sessionLength)
-        if GameMode.isValid(self.m_gameMode):
-            self.m_gameMode = GameMode(self.m_gameMode)
-        if RuleSet.isValid(self.m_ruleSet):
-            self.m_ruleSet = RuleSet(self.m_ruleSet)
+        self.m_gearboxAssist = GearboxAssistMode.safeCast(self.m_gearboxAssist)
+        self.m_sessionLength = SessionLength.safeCast(self.m_sessionLength)
+        self.m_gameMode = GameMode.safeCast(self.m_gameMode)
+        self.m_ruleSet = RuleSet.safeCast(self.m_ruleSet)
 
         self.m_weekendStructure = [0] * 12
         # Section 5 - F1 24 specific stuff
@@ -1129,40 +1118,22 @@ class PacketSessionData(F1PacketBase):
             self.m_sector3LapDistanceStart = 0.0
 
         # Convert into enum types if supported
-        if PacketSessionData.RecoveryMode.isValid(self.m_recoveryMode):
-            self.m_recoveryMode = PacketSessionData.RecoveryMode(self.m_recoveryMode)
-        if PacketSessionData.FlashbackLimit.isValid(self.m_flashbackLimit):
-            self.m_flashbackLimit = PacketSessionData.FlashbackLimit(self.m_flashbackLimit)
-        if PacketSessionData.SurfaceType.isValid(self.m_surfaceType):
-            self.m_surfaceType = PacketSessionData.SurfaceType(self.m_surfaceType)
-        if PacketSessionData.LowFuelMode.isValid(self.m_lowFuelMode):
-            self.m_lowFuelMode = PacketSessionData.LowFuelMode(self.m_lowFuelMode)
-        if PacketSessionData.RaceStartsMode.isValid(self.m_raceStarts):
-            self.m_raceStarts = PacketSessionData.RaceStartsMode(self.m_raceStarts)
-        if PacketSessionData.TyreTemperatureMode(self.m_tyreTemperatureMode):
-            self.m_tyreTemperatureMode = PacketSessionData.TyreTemperatureMode(
-                self.m_tyreTemperatureMode)
-        if PacketSessionData.CarDamageMode.isValid(self.m_carDamage):
-            self.m_carDamage = PacketSessionData.CarDamageMode(self.m_carDamage)
-        if PacketSessionData.CarDamageRate.isValid(self.m_carDamageRate):
-            self.m_carDamageRate = PacketSessionData.CarDamageRate(self.m_carDamageRate)
-        if PacketSessionData.CollisionsMode.isValid(self.m_collisions):
-            self.m_collisions = PacketSessionData.CollisionsMode(self.m_collisions)
-        if PacketSessionData.CornerCuttingStringency.isValid(self.m_cornerCuttingStringency):
-            self.m_cornerCuttingStringency = PacketSessionData.CornerCuttingStringency(
+        self.m_recoveryMode = PacketSessionData.RecoveryMode.safeCast(self.m_recoveryMode)
+        self.m_flashbackLimit = PacketSessionData.FlashbackLimit.safeCast(self.m_flashbackLimit)
+        self.m_surfaceType = PacketSessionData.SurfaceType.safeCast(self.m_surfaceType)
+        self.m_lowFuelMode = PacketSessionData.LowFuelMode.safeCast(self.m_lowFuelMode)
+        self.m_raceStarts = PacketSessionData.RaceStartsMode.safeCast(self.m_raceStarts)
+        self.m_tyreTemperatureMode = PacketSessionData.TyreTemperatureMode.safeCast(self.m_tyreTemperatureMode)
+        self.m_carDamage = PacketSessionData.CarDamageMode.safeCast(self.m_carDamage)
+        self.m_carDamageRate = PacketSessionData.CarDamageRate.safeCast(self.m_carDamageRate)
+        self.m_collisions = PacketSessionData.CollisionsMode.safeCast(self.m_collisions)
+        self.m_cornerCuttingStringency = PacketSessionData.CornerCuttingStringency.safeCast(
                 self.m_cornerCuttingStringency)
-        if PacketSessionData.PitStopExperience.isValid(self.m_pitStopExperience):
-            self.m_pitStopExperience = PacketSessionData.PitStopExperience(self.m_pitStopExperience)
-        if PacketSessionData.SafetyCarSetting.isValid(self.m_safetyCar):
-            self.m_safetyCar = PacketSessionData.SafetyCarSetting(self.m_safetyCar)
-        if PacketSessionData.SafetyCarExperience.isValid(self.m_safetyCarExperience):
-            self.m_safetyCarExperience = PacketSessionData.SafetyCarExperience(
-                self.m_safetyCarExperience)
-        if PacketSessionData.FormationLapExperience.isValid(self.m_formationLapExperience):
-            self.m_formationLapExperience = PacketSessionData.FormationLapExperience(
-                self.m_formationLapExperience)
-        if PacketSessionData.RedFlagsSetting.isValid(self.m_redFlags):
-            self.m_redFlags = PacketSessionData.RedFlagsSetting(self.m_redFlags)
+        self.m_pitStopExperience = PacketSessionData.PitStopExperience.safeCast(self.m_pitStopExperience)
+        self.m_safetyCar = PacketSessionData.SafetyCarSetting.safeCast(self.m_safetyCar)
+        self.m_safetyCarExperience = PacketSessionData.SafetyCarExperience.safeCast(self.m_safetyCarExperience)
+        self.m_formationLapExperience = PacketSessionData.FormationLapExperience.safeCast(self.m_formationLapExperience)
+        self.m_redFlags = PacketSessionData.RedFlagsSetting.safeCast(self.m_redFlags)
 
     def __str__(self) -> str:
         """

--- a/lib/f1_types/packet_2_lap_data.py
+++ b/lib/f1_types/packet_2_lap_data.py
@@ -178,6 +178,41 @@ class LapData(F1SubPacketBase):
     m_speedTrapFastestSpeed: float
     m_speedTrapFastestLap: int
 
+    __slots__ = (
+        "m_packetFormat",
+        "m_lastLapTimeInMS",
+        "m_currentLapTimeInMS",
+        "m_sector1TimeInMS",
+        "m_sector1TimeMinutes",
+        "m_sector2TimeInMS",
+        "m_sector2TimeMinutes",
+        "m_deltaToCarInFrontInMS",
+        "m_deltaToRaceLeaderInMS",
+        "m_lapDistance",
+        "m_totalDistance",
+        "m_safetyCarDelta",
+        "m_carPosition",
+        "m_currentLapNum",
+        "m_pitStatus",
+        "m_numPitStops",
+        "m_sector",
+        "m_currentLapInvalid",
+        "m_penalties",
+        "m_totalWarnings",
+        "m_cornerCuttingWarnings",
+        "m_numUnservedDriveThroughPens",
+        "m_numUnservedStopGoPens",
+        "m_gridPosition",
+        "m_driverStatus",
+        "m_resultStatus",
+        "m_pitLaneTimerActive",
+        "m_pitLaneTimeInLaneInMS",
+        "m_pitStopTimerInMS",
+        "m_pitStopShouldServePen",
+        "m_speedTrapFastestSpeed",
+        "m_speedTrapFastestLap",
+    )
+
     class DriverStatus(F1BaseEnum):
         """
         Enumeration representing the status of a driver during a racing session.
@@ -467,6 +502,12 @@ class PacketLapData(F1PacketBase):
     """
 
     MAX_CARS = 22
+
+    __slots__ = (
+        "m_lapData",
+        "m_timeTrialPBCarIdx",
+        "m_timeTrialRivalCarIdx",
+    )
 
     def __init__(self, header: PacketHeader, packet: bytes) -> None:
         """

--- a/lib/f1_types/packet_2_lap_data.py
+++ b/lib/f1_types/packet_2_lap_data.py
@@ -334,14 +334,10 @@ class LapData(F1SubPacketBase):
                 self.m_speedTrapFastestLap
             ) = self.COMPILED_PACKET_STRUCT_24.unpack(raw_data)
 
-        if LapData.DriverStatus.isValid(self.m_driverStatus):
-            self.m_driverStatus = LapData.DriverStatus(self.m_driverStatus)
-        if ResultStatus.isValid(self.m_resultStatus):
-            self.m_resultStatus = ResultStatus(self.m_resultStatus)
-        if LapData.PitStatus.isValid(self.m_pitStatus):
-            self.m_pitStatus = LapData.PitStatus(self.m_pitStatus)
-        if LapData.Sector.isValid(self.m_sector):
-            self.m_sector = LapData.Sector(self.m_sector)
+        self.m_driverStatus = LapData.DriverStatus.safeCast(self.m_driverStatus)
+        self.m_resultStatus = ResultStatus.safeCast(self.m_resultStatus)
+        self.m_pitStatus = LapData.PitStatus.safeCast(self.m_pitStatus)
+        self.m_sector = LapData.Sector.safeCast(self.m_sector)
         self.m_currentLapInvalid = bool(self.m_currentLapInvalid)
         self.m_pitLaneTimerActive = bool(self.m_pitLaneTimerActive)
 
@@ -411,9 +407,9 @@ class LapData(F1SubPacketBase):
             "safety-car-delta": self.m_safetyCarDelta,
             "car-position": self.m_carPosition,
             "current-lap-num": self.m_currentLapNum,
-            "pit-status": str(self.m_pitStatus) if LapData.PitStatus.isValid(self.m_pitStatus) else self.m_pitStatus,
+            "pit-status": str(self.m_pitStatus),
             "num-pit-stops": self.m_numPitStops,
-            "sector": str(self.m_sector.value) if LapData.Sector.isValid(self.m_sector) else self.m_sector,
+            "sector": str(self.m_sector.value),
             "current-lap-invalid": self.m_currentLapInvalid,
             "penalties": self.m_penalties,
             "total-warnings": self.m_totalWarnings,

--- a/lib/f1_types/packet_3_event_data.py
+++ b/lib/f1_types/packet_3_event_data.py
@@ -131,6 +131,11 @@ class PacketEventData(F1PacketBase):
         COMPILED_PACKET_STRUCT = struct.Struct("<Bf")
         PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
+        __slots__ = (
+            "vehicleIdx",
+            "lapTime",
+        )
+
         def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes a FastestLap object by unpacking the provided binary data.
@@ -142,11 +147,10 @@ class PacketEventData(F1PacketBase):
             Raises:
                 struct.error: If the binary data does not match the expected format.
             """
-            unpacked_data = self.COMPILED_PACKET_STRUCT.unpack(data[:self.PACKET_LEN])
             (
                 self.vehicleIdx,
                 self.lapTime
-            ) = unpacked_data
+            ) = self.COMPILED_PACKET_STRUCT.unpack(data[:self.PACKET_LEN])
 
         def __str__(self) -> str:
             """
@@ -205,6 +209,11 @@ class PacketEventData(F1PacketBase):
 
         COMPILED_PACKET_STRUCT_23_24 = struct.Struct("<B")
         PACKET_LEN_23_24 = COMPILED_PACKET_STRUCT_23_24.size
+
+        __slots__ = (
+            "vehicleIdx",
+            "m_reason",
+        )
 
         class Reason(F1BaseEnum):
             INVALID = 0
@@ -292,6 +301,10 @@ class PacketEventData(F1PacketBase):
         COMPILED_PACKET_STRUCT_25 = struct.Struct("<B")
         PACKET_LEN_25 = COMPILED_PACKET_STRUCT_25.size
 
+        __slots__ = (
+            "m_reason",
+        )
+
         class Reason(F1BaseEnum):
             WET_TRACK = 0
             SAFETY_CAR_DEPLOYED = 1
@@ -337,6 +350,11 @@ class PacketEventData(F1PacketBase):
         """
         COMPILED_PACKET_STRUCT = struct.Struct("<B")
         PACKET_LEN = COMPILED_PACKET_STRUCT.size
+
+        __slots__ = (
+            "vehicleIdx",
+        )
+
         def __init__(self, data: bytes, _packet_format: int):
             """
             Initializes a TeamMateInPits object by unpacking the provided binary data.
@@ -396,6 +414,11 @@ class PacketEventData(F1PacketBase):
         """
         COMPILED_PACKET_STRUCT = struct.Struct("<B")
         PACKET_LEN = COMPILED_PACKET_STRUCT.size
+
+        __slots__ = (
+            "vehicleIdx",
+        )
+
         def __init__(self, data: bytes, _packet_format: int):
             """
             Initializes a RaceWinner object by unpacking the provided binary data.
@@ -462,6 +485,16 @@ class PacketEventData(F1PacketBase):
 
         COMPILED_PACKET_STRUCT = struct.Struct("<BBBBBBB")
         PACKET_LEN = COMPILED_PACKET_STRUCT.size
+
+        __slots__ = (
+            "penaltyType",
+            "infringementType",
+            "vehicleIdx",
+            "otherVehicleIndex",
+            "time",
+            "lapNum",
+            "placesGained",
+        )
 
         class PenaltyType(F1BaseEnum):
             """Enum class representing different penalties in motorsports."""
@@ -560,7 +593,6 @@ class PacketEventData(F1PacketBase):
                 _packet_format (int): The packet format
             """
 
-            unpacked_data = self.COMPILED_PACKET_STRUCT.unpack(data[:self.PACKET_LEN])
             (
                 self.penaltyType,
                 self.infringementType,
@@ -569,7 +601,7 @@ class PacketEventData(F1PacketBase):
                 self.time,
                 self.lapNum,
                 self.placesGained
-            ) = unpacked_data
+            ) = self.COMPILED_PACKET_STRUCT.unpack(data[:self.PACKET_LEN])
 
             if PacketEventData.Penalty.PenaltyType.isValid(self.penaltyType):
                 self.penaltyType = PacketEventData.Penalty.PenaltyType(self.penaltyType)
@@ -645,6 +677,15 @@ class PacketEventData(F1PacketBase):
         COMPILED_PACKET_STRUCT = struct.Struct("<BfBBBf")
         PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
+        __slots__ = (
+            "vehicleIdx",
+            "speed",
+            "isOverallFastestInSession",
+            "isDriverFastestInSession",
+            "fastestVehicleIdxInSession",
+            "fastestSpeedInSession"
+        )
+
         def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes a SpeedTrap object by unpacking the provided binary data.
@@ -656,7 +697,6 @@ class PacketEventData(F1PacketBase):
             Raises:
                 struct.error: If the binary data does not match the expected format.
             """
-            unpacked_data = self.COMPILED_PACKET_STRUCT.unpack(data[:self.PACKET_LEN])
             (
                 self.vehicleIdx,
                 self.speed,
@@ -664,7 +704,7 @@ class PacketEventData(F1PacketBase):
                 self.isDriverFastestInSession,
                 self.fastestVehicleIdxInSession,
                 self.fastestSpeedInSession
-            ) = unpacked_data
+            ) = self.COMPILED_PACKET_STRUCT.unpack(data[:self.PACKET_LEN])
             self.isOverallFastestInSession = bool(self.isOverallFastestInSession)
             self.isDriverFastestInSession = bool(self.isDriverFastestInSession)
 
@@ -744,6 +784,10 @@ class PacketEventData(F1PacketBase):
         COMPILED_PACKET_STRUCT = struct.Struct("<B")
         PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
+        __slots__ = (
+            "numLights",
+        )
+
         def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes a StartLights object by unpacking the provided binary data.
@@ -802,6 +846,10 @@ class PacketEventData(F1PacketBase):
 
         COMPILED_PACKET_STRUCT = struct.Struct("<B")
         PACKET_LEN = COMPILED_PACKET_STRUCT.size
+
+        __slots__ = (
+            "vehicleIdx",
+        )
 
         def __init__(self, data: bytes, _packet_format: int) -> None:
             """
@@ -877,6 +925,11 @@ class PacketEventData(F1PacketBase):
 
         COMPILED_PACKET_STRUCT_25 = struct.Struct("<Bf")
         PACKET_LEN_25 = COMPILED_PACKET_STRUCT_25.size
+
+        __slots__ = (
+            "vehicleIdx",
+            "stopTime",
+        )
 
         def __init__(self, data: bytes, packet_format: int) -> None:
             """
@@ -954,6 +1007,11 @@ class PacketEventData(F1PacketBase):
 
         COMPILED_PACKET_STRUCT = struct.Struct("<If")
         PACKET_LEN = COMPILED_PACKET_STRUCT.size
+
+        __slots__ = (
+            "flashbackFrameIdentifier",
+            "flashbackSessionTime",
+        )
 
         def __init__(self, data: bytes, _packet_format: int) -> None:
             """
@@ -1060,6 +1118,10 @@ class PacketEventData(F1PacketBase):
         UDP_ACTION_10 = 0x20000000
         UDP_ACTION_11 = 0x40000000
         UDP_ACTION_12 = 0x80000000
+
+        __slots__ = (
+            "buttonStatus",
+        )
 
         def __init__(self, data: bytes, _packet_format: int) -> None:
             """
@@ -1176,6 +1238,11 @@ class PacketEventData(F1PacketBase):
         COMPILED_PACKET_STRUCT = struct.Struct("<BB")
         PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
+        __slots__ = (
+            "overtakingVehicleIdx",
+            "beingOvertakenVehicleIdx",
+        )
+
         def __init__(self, data: bytes, _packet_format: int) -> None:
             """
             Initializes an Overtake object by unpacking the provided binary data.
@@ -1251,6 +1318,11 @@ class PacketEventData(F1PacketBase):
 
         COMPILED_PACKET_STRUCT = struct.Struct("<BB")
         PACKET_LEN = COMPILED_PACKET_STRUCT.size
+
+        __slots__ = (
+            "m_safety_car_type",
+            "m_event_type",
+        )
 
         def __init__(self, data: bytes, _packet_format: int) -> None:
             """
@@ -1330,6 +1402,11 @@ class PacketEventData(F1PacketBase):
 
         COMPILED_PACKET_STRUCT = struct.Struct("<BB")
         PACKET_LEN = COMPILED_PACKET_STRUCT.size
+
+        __slots__ = (
+            "m_vehicle_1_index",
+            "m_vehicle_2_index",
+        )
 
         def __init__(self, data: bytes, _packet_format: int) -> None:
             """
@@ -1420,6 +1497,12 @@ class PacketEventData(F1PacketBase):
 
     COMPILED_PACKET_STRUCT = struct.Struct("4s")
     PACKET_LEN = COMPILED_PACKET_STRUCT.size
+
+    __slots__ = (
+        'm_eventStringCode',
+        'm_eventCode',
+        'mEventDetails',
+    )
 
     def __init__(self, header: PacketHeader, packet: bytes) -> None:
         """Construct the PacketEventData object from the incoming raw packet

--- a/lib/f1_types/packet_3_event_data.py
+++ b/lib/f1_types/packet_3_event_data.py
@@ -329,8 +329,7 @@ class PacketEventData(F1PacketBase):
                 self.m_reason = None
                 return
             self.m_reason = self.COMPILED_PACKET_STRUCT_25.unpack(data[:self.PACKET_LEN_25])[0]
-            if PacketEventData.DrsDisabled.Reason.isValid(self.m_reason):
-                self.m_reason = PacketEventData.DrsDisabled.Reason(self.m_reason)
+            self.m_reason = PacketEventData.DrsDisabled.Reason.safeCast(self.m_reason)
 
         def __str__(self):
             return f"DrsDisabled(reason={self.m_reason})"
@@ -603,10 +602,8 @@ class PacketEventData(F1PacketBase):
                 self.placesGained
             ) = self.COMPILED_PACKET_STRUCT.unpack(data[:self.PACKET_LEN])
 
-            if PacketEventData.Penalty.PenaltyType.isValid(self.penaltyType):
-                self.penaltyType = PacketEventData.Penalty.PenaltyType(self.penaltyType)
-            if PacketEventData.Penalty.InfringementType.isValid(self.infringementType):
-                self.infringementType = PacketEventData.Penalty.InfringementType(self.infringementType)
+            self.penaltyType = PacketEventData.Penalty.PenaltyType.safeCast(self.penaltyType)
+            self.infringementType = PacketEventData.Penalty.InfringementType.safeCast(self.infringementType)
 
         def __str__(self):
             return f"Penalty(penaltyType={self.penaltyType}, infringementType={self.infringementType}, " \
@@ -1336,10 +1333,8 @@ class PacketEventData(F1PacketBase):
                 struct.error: If the binary data does not match the expected format.
             """
             self.m_safety_car_type, self.m_event_type = self.COMPILED_PACKET_STRUCT.unpack(data[:self.PACKET_LEN])
-            if SafetyCarType.isValid(self.m_safety_car_type):
-                self.m_safety_car_type = SafetyCarType(self.m_safety_car_type)
-            if SafetyCarEventType.isValid(self.m_event_type):
-                self.m_event_type = SafetyCarEventType(self.m_event_type)
+            self.m_safety_car_type = SafetyCarType.safeCast(self.m_safety_car_type)
+            self.m_event_type = SafetyCarEventType.safeCast(self.m_event_type)
 
         def __str__(self) -> str:
             """

--- a/lib/f1_types/packet_4_participants_data.py
+++ b/lib/f1_types/packet_4_participants_data.py
@@ -266,18 +266,15 @@ class ParticipantData(F1SubPacketBase):
             )
 
         self.m_name = self.m_name.decode('utf-8', errors='replace').rstrip('\x00')
-        if Platform.isValid(self.m_platform):
-            self.m_platform = Platform(self.m_platform)
-        if packet_format == 2023 and TeamID23.isValid(self.m_teamId):
-            self.m_teamId = TeamID23(self.m_teamId)
-        elif packet_format == 2024 and TeamID24.isValid(self.m_teamId):
-            self.m_teamId = TeamID24(self.m_teamId)
-        elif packet_format == 2025 and TeamID25.isValid(self.m_teamId):
-            self.m_teamId = TeamID25(self.m_teamId)
-        if TelemetrySetting.isValid(self.m_yourTelemetry):
-            self.m_yourTelemetry = TelemetrySetting(self.m_yourTelemetry)
-        if Nationality.isValid(self.m_nationality):
-            self.m_nationality = Nationality(self.m_nationality)
+        self.m_platform = Platform.safeCast(self.m_platform)
+        if packet_format == 2023:
+            self.m_teamId = TeamID23.safeCast(self.m_teamId)
+        elif packet_format == 2024:
+            self.m_teamId = TeamID24.safeCast(self.m_teamId)
+        elif packet_format == 2025:
+            self.m_teamId = TeamID25.safeCast(self.m_teamId)
+        self.m_yourTelemetry = TelemetrySetting.safeCast(self.m_yourTelemetry)
+        self.m_nationality = Nationality.safeCast(self.m_nationality)
         self.m_showOnlineNames = bool(self.m_showOnlineNames)
         self.m_myTeam = bool(self.m_myTeam)
         self.m_aiControlled = bool(self.m_aiControlled)

--- a/lib/f1_types/packet_4_participants_data.py
+++ b/lib/f1_types/packet_4_participants_data.py
@@ -48,6 +48,12 @@ class LiveryColour(F1SubPacketBase):
     )
     PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
+    __slots__ = (
+        "m_red",
+        "m_green",
+        "m_blue",
+    )
+
     def __init__(self, data: bytes) -> None:
         """Initializes a LiveryColour object with the given raw data."""
         self.m_red: int
@@ -170,6 +176,24 @@ class ParticipantData(F1SubPacketBase):
     PACKET_LEN_25_BASE = COMPILED_PACKET_STRUCT_25_BASE.size
     PACKET_LEN_25 = PACKET_LEN_25_BASE + (LiveryColour.PACKET_LEN * MAX_LIVERY_COLOURS)
 
+    __slots__ = (
+        "m_packetFormat",
+        "m_aiControlled",
+        "m_driverId",
+        "networkId",
+        "m_teamId",
+        "m_myTeam",
+        "m_raceNumber",
+        "m_nationality",
+        "m_name",
+        "m_yourTelemetry",
+        "m_showOnlineNames",
+        "m_platform",
+        "m_techLevel",
+        "m_numColours",
+        "m_liveryColours",
+    )
+
     def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initializes a ParticipantData object by unpacking the provided binary data.
@@ -185,7 +209,6 @@ class ParticipantData(F1SubPacketBase):
         self.m_numColours: int = 0
         self.m_liveryColours: List[LiveryColour]
         if packet_format == 2023:
-            unpacked_data = self.COMPILED_PACKET_STRUCT_23.unpack(data)
             (
                 self.m_aiControlled,
                 self.m_driverId,
@@ -198,10 +221,9 @@ class ParticipantData(F1SubPacketBase):
                 self.m_yourTelemetry,
                 self.m_showOnlineNames,
                 self.m_platform
-            ) = unpacked_data
+            ) = self.COMPILED_PACKET_STRUCT_23.unpack(data)
             self.m_techLevel = 0
         elif packet_format == 2024:
-            unpacked_data = self.COMPILED_PACKET_STRUCT_24.unpack(data)
             (
                 self.m_aiControlled,
                 self.m_driverId,
@@ -215,10 +237,9 @@ class ParticipantData(F1SubPacketBase):
                 self.m_showOnlineNames,
                 self.m_techLevel,
                 self.m_platform
-            ) = unpacked_data
+            ) = self.COMPILED_PACKET_STRUCT_24.unpack(data)
         else:
 
-            unpacked_data = self.COMPILED_PACKET_STRUCT_25_BASE.unpack(data[:self.PACKET_LEN_25_BASE])
             (
                 self.m_aiControlled,
                 self.m_driverId,
@@ -233,7 +254,7 @@ class ParticipantData(F1SubPacketBase):
                 self.m_techLevel,
                 self.m_platform,
                 self.m_numColours
-            ) = unpacked_data
+            ) = self.COMPILED_PACKET_STRUCT_25_BASE.unpack(data[:self.PACKET_LEN_25_BASE])
 
             self.m_liveryColours, _ = _validate_parse_fixed_segments(
                 data=data,
@@ -544,6 +565,12 @@ class PacketParticipantsData(F1PacketBase):
     """
 
     MAX_PARTICIPANTS = 22
+
+    __slots__ = (
+        "m_numActiveCars",
+        "m_participants",
+    )
+
     def __init__(self, header: PacketHeader, packet: bytes) -> None:
         """
         Initializes a PacketParticipantsData object by unpacking the provided binary data.

--- a/lib/f1_types/packet_5_car_setups_data.py
+++ b/lib/f1_types/packet_5_car_setups_data.py
@@ -111,6 +111,32 @@ class CarSetupData(F1SubPacketBase):
     )
     PACKET_LEN_24 = COMPILED_PACKET_STRUCT_24.size
 
+    __slots__ = (
+        "m_frontWing",
+        "m_rearWing",
+        "m_onThrottle",
+        "m_offThrottle",
+        "m_frontCamber",
+        "m_rearCamber",
+        "m_frontToe",
+        "m_rearToe",
+        "m_frontSuspension",
+        "m_rearSuspension",
+        "m_frontAntiRollBar",
+        "m_rearAntiRollBar",
+        "m_frontSuspensionHeight",
+        "m_rearSuspensionHeight",
+        "m_brakePressure",
+        "m_brakeBias",
+        "m_engineBraking",
+        "m_rearLeftTyrePressure",
+        "m_rearRightTyrePressure",
+        "m_frontLeftTyrePressure",
+        "m_frontRightTyrePressure",
+        "m_ballast",
+        "m_fuelLoad",
+    )
+
     def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initializes a CarSetupData object by unpacking the provided binary data.
@@ -125,7 +151,6 @@ class CarSetupData(F1SubPacketBase):
 
         self.m_packetFormat = packet_format
         if packet_format == 2023:
-            unpacked_data = self.COMPILED_PACKET_STRUCT_23.unpack(data)
             (
                 self.m_frontWing,
                 self.m_rearWing,
@@ -149,10 +174,9 @@ class CarSetupData(F1SubPacketBase):
                 self.m_frontRightTyrePressure,
                 self.m_ballast,
                 self.m_fuelLoad,
-            ) = unpacked_data
+            ) = self.COMPILED_PACKET_STRUCT_23.unpack(data)
             self.m_engineBraking = 0
         else:
-            unpacked_data = self.COMPILED_PACKET_STRUCT_24.unpack(data)
             (
                 self.m_frontWing,
                 self.m_rearWing,
@@ -177,7 +201,7 @@ class CarSetupData(F1SubPacketBase):
                 self.m_frontRightTyrePressure,
                 self.m_ballast,
                 self.m_fuelLoad,
-            ) = unpacked_data
+            ) = self.COMPILED_PACKET_STRUCT_24.unpack(data)
 
     def isValid(self) -> bool:
         """
@@ -500,6 +524,11 @@ class PacketCarSetupData(F1PacketBase):
 
     MAX_CARS = 22
     COMPILED_PACKET_STRUCT_EXTRA = struct.Struct("<f")
+
+    __slots__ = (
+        "m_carSetups",
+        "m_nextFrontWingValue",
+    )
 
     def __init__(self, header: PacketHeader, packet: bytes) -> None:
         """

--- a/lib/f1_types/packet_6_car_telemetry_data.py
+++ b/lib/f1_types/packet_6_car_telemetry_data.py
@@ -92,7 +92,6 @@ class CarTelemetryData(F1SubPacketBase):
         "m_engineTemperature",
         "m_tyresPressure",
         "m_surfaceType",
-        "m_drs",
     )
 
     def __init__(self, data) -> None:

--- a/lib/f1_types/packet_6_car_telemetry_data.py
+++ b/lib/f1_types/packet_6_car_telemetry_data.py
@@ -75,6 +75,26 @@ class CarTelemetryData(F1SubPacketBase):
     )
     PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
+    __slots__ = (
+        "m_speed",
+        "m_throttle",
+        "m_steer",
+        "m_brake",
+        "m_clutch",
+        "m_gear",
+        "m_engineRPM",
+        "m_drs",
+        "m_revLightsPercent",
+        "m_revLightsBitValue",
+        "m_brakesTemperature",
+        "m_tyresSurfaceTemperature",
+        "m_tyresInnerTemperature",
+        "m_engineTemperature",
+        "m_tyresPressure",
+        "m_surfaceType",
+        "m_drs",
+    )
+
     def __init__(self, data) -> None:
         """
         Initializes a CarTelemetryData object by unpacking the provided binary data.
@@ -361,6 +381,13 @@ class PacketCarTelemetryData(F1PacketBase):
     MAX_CARS = 22
     COMPILED_PACKET_FORMAT_EXTRA = struct.Struct("<BBb")
     PACKET_LEN_EXTRA = COMPILED_PACKET_FORMAT_EXTRA.size
+
+    __slots__ = (
+        "m_carTelemetryData",
+        "m_mfdPanelIndex",
+        "m_mfdPanelIndexSecondaryPlayer",
+        "m_suggestedGear"
+    )
 
     def __init__(self, header:PacketHeader, packet: bytes) -> None:
         """

--- a/lib/f1_types/packet_7_car_status_data.py
+++ b/lib/f1_types/packet_7_car_status_data.py
@@ -296,19 +296,12 @@ class CarStatusData(F1SubPacketBase):
         self.m_pitLimiterStatus = bool(self.m_pitLimiterStatus)
         self.m_networkPaused = bool(self.m_networkPaused)
 
-        if ActualTyreCompound.isValid(self.m_actualTyreCompound):
-            self.m_actualTyreCompound = ActualTyreCompound(self.m_actualTyreCompound)
-        if VisualTyreCompound.isValid(self.m_visualTyreCompound):
-            self.m_visualTyreCompound = VisualTyreCompound(self.m_visualTyreCompound)
-        if CarStatusData.VehicleFIAFlags.isValid(self.m_vehicleFiaFlags):
-            self.m_vehicleFiaFlags = CarStatusData.VehicleFIAFlags(self.m_vehicleFiaFlags)
-        if CarStatusData.ERSDeployMode.isValid(self.m_ersDeployMode):
-            self.m_ersDeployMode = CarStatusData.ERSDeployMode(self.m_ersDeployMode)
-        if TractionControlAssistMode.isValid(self.m_tractionControl):
-            self.m_tractionControl = TractionControlAssistMode(self.m_tractionControl)
-        if CarStatusData.FuelMix.isValid(self.m_fuelMix):
-            self.m_fuelMix = CarStatusData.FuelMix(self.m_fuelMix)
-
+        self.m_actualTyreCompound = ActualTyreCompound.safeCast(self.m_actualTyreCompound)
+        self.m_visualTyreCompound = VisualTyreCompound.safeCast(self.m_visualTyreCompound)
+        self.m_vehicleFiaFlags = CarStatusData.VehicleFIAFlags.safeCast(self.m_vehicleFiaFlags)
+        self.m_ersDeployMode = CarStatusData.ERSDeployMode.safeCast(self.m_ersDeployMode)
+        self.m_tractionControl = TractionControlAssistMode.safeCast(self.m_tractionControl)
+        self.m_fuelMix = CarStatusData.FuelMix.safeCast(self.m_fuelMix)
 
     def __str__(self):
         """

--- a/lib/f1_types/packet_7_car_status_data.py
+++ b/lib/f1_types/packet_7_car_status_data.py
@@ -136,6 +136,34 @@ class CarStatusData(F1SubPacketBase):
     m_ersDeployedThisLap: float
     m_networkPaused: bool
 
+    __slots__ = (
+        "m_tractionControl",
+        "m_antiLockBrakes",
+        "m_fuelMix",
+        "m_frontBrakeBias",
+        "m_pitLimiterStatus",
+        "m_fuelInTank",
+        "m_fuelCapacity",
+        "m_fuelRemainingLaps",
+        "m_maxRPM",
+        "m_idleRPM",
+        "m_maxGears",
+        "m_drsAllowed",
+        "m_drsActivationDistance",
+        "m_actualTyreCompound",
+        "m_visualTyreCompound",
+        "m_tyresAgeLaps",
+        "m_vehicleFiaFlags",
+        "m_enginePowerICE",
+        "m_enginePowerMGUK",
+        "m_ersStoreEnergy",
+        "m_ersDeployMode",
+        "m_ersHarvestedThisLapMGUK",
+        "m_ersHarvestedThisLapMGUH",
+        "m_ersDeployedThisLap",
+        "m_networkPaused",
+    )
+
     class VehicleFIAFlags(F1BaseEnum):
         """
         Enumeration representing different FIA flags related to vehicles.
@@ -235,42 +263,52 @@ class CarStatusData(F1SubPacketBase):
             data (bytes): Raw data representing car status.
         """
 
-        # Unpack data in a single step
-        unpacked = self.COMPILED_PACKET_STRUCT.unpack(data)
-
-        # Set attributes using __dict__.update() to reduce overhead
-        self.__dict__.update(zip([
-            "m_tractionControl", "m_antiLockBrakes", "m_fuelMix", "m_frontBrakeBias",
-            "m_pitLimiterStatus", "m_fuelInTank", "m_fuelCapacity", "m_fuelRemainingLaps",
-            "m_maxRPM", "m_idleRPM", "m_maxGears", "m_drsAllowed", "m_drsActivationDistance",
-            "m_actualTyreCompound", "m_visualTyreCompound", "m_tyresAgeLaps", "m_vehicleFiaFlags",
-            "m_enginePowerICE", "m_enginePowerMGUK", "m_ersStoreEnergy", "m_ersDeployMode",
-            "m_ersHarvestedThisLapMGUK", "m_ersHarvestedThisLapMGUH", "m_ersDeployedThisLap",
-            "m_networkPaused"
-        ], unpacked))
+        (
+            self.m_tractionControl,
+            self.m_antiLockBrakes,
+            self.m_fuelMix,
+            self.m_frontBrakeBias,
+            self.m_pitLimiterStatus,
+            self.m_fuelInTank,
+            self.m_fuelCapacity,
+            self.m_fuelRemainingLaps,
+            self.m_maxRPM,
+            self.m_idleRPM,
+            self.m_maxGears,
+            self.m_drsAllowed,
+            self.m_drsActivationDistance,
+            self.m_actualTyreCompound,
+            self.m_visualTyreCompound,
+            self.m_tyresAgeLaps,
+            self.m_vehicleFiaFlags,
+            self.m_enginePowerICE,
+            self.m_enginePowerMGUK,
+            self.m_ersStoreEnergy,
+            self.m_ersDeployMode,
+            self.m_ersHarvestedThisLapMGUK,
+            self.m_ersHarvestedThisLapMGUH,
+            self.m_ersDeployedThisLap,
+            self.m_networkPaused
+        ) = self.COMPILED_PACKET_STRUCT.unpack(data)
 
         # Convert boolean fields using bitwise AND
-        self.m_antiLockBrakes = unpacked[1] & 1
-        self.m_pitLimiterStatus = unpacked[4] & 1
-        self.m_networkPaused = unpacked[24] & 1
-
-        # Convert Enums with error handling
-        def try_enum(enum_class, value):
-            try:
-                return enum_class(value)
-            except ValueError:
-                return value  # Store raw value if conversion fails
-
-        self.m_actualTyreCompound = try_enum(ActualTyreCompound, unpacked[13])
-        self.m_visualTyreCompound = try_enum(VisualTyreCompound, unpacked[14])
-        self.m_vehicleFiaFlags = try_enum(CarStatusData.VehicleFIAFlags, unpacked[16])
-        self.m_ersDeployMode = try_enum(CarStatusData.ERSDeployMode, unpacked[20])
-        self.m_tractionControl = try_enum(TractionControlAssistMode, unpacked[0])
-        self.m_fuelMix = try_enum(CarStatusData.FuelMix, unpacked[2])
-
         self.m_antiLockBrakes = bool(self.m_antiLockBrakes)
         self.m_pitLimiterStatus = bool(self.m_pitLimiterStatus)
         self.m_networkPaused = bool(self.m_networkPaused)
+
+        if ActualTyreCompound.isValid(self.m_actualTyreCompound):
+            self.m_actualTyreCompound = ActualTyreCompound(self.m_actualTyreCompound)
+        if VisualTyreCompound.isValid(self.m_visualTyreCompound):
+            self.m_visualTyreCompound = VisualTyreCompound(self.m_visualTyreCompound)
+        if CarStatusData.VehicleFIAFlags.isValid(self.m_vehicleFiaFlags):
+            self.m_vehicleFiaFlags = CarStatusData.VehicleFIAFlags(self.m_vehicleFiaFlags)
+        if CarStatusData.ERSDeployMode.isValid(self.m_ersDeployMode):
+            self.m_ersDeployMode = CarStatusData.ERSDeployMode(self.m_ersDeployMode)
+        if TractionControlAssistMode.isValid(self.m_tractionControl):
+            self.m_tractionControl = TractionControlAssistMode(self.m_tractionControl)
+        if CarStatusData.FuelMix.isValid(self.m_fuelMix):
+            self.m_fuelMix = CarStatusData.FuelMix(self.m_fuelMix)
+
 
     def __str__(self):
         """
@@ -507,6 +545,10 @@ class PacketCarStatusData(F1PacketBase):
     """
 
     MAX_CARS = 22
+
+    __slots__ = (
+        "m_carStatusData",
+    )
 
     def __init__(self, header: PacketHeader, packet: bytes) -> None:
         """Initialize the object from raw bytes.

--- a/lib/f1_types/packet_8_final_classification_data.py
+++ b/lib/f1_types/packet_8_final_classification_data.py
@@ -100,6 +100,24 @@ class FinalClassificationData(F1SubPacketBase):
     )
     PACKET_LEN_25 = COMPILED_PACKET_STRUCT_25.size
 
+    __slots__ = (
+        "m_position",
+        "m_numLaps",
+        "m_gridPosition",
+        "m_points",
+        "m_numPitStops",
+        "m_resultStatus",
+        "m_resultReason",
+        "m_bestLapTimeInMS",
+        "m_totalRaceTime",
+        "m_penaltiesTime",
+        "m_numPenalties",
+        "m_numTyreStints",
+        "m_tyreStintsActual",
+        "m_tyreStintsVisual",
+        "m_tyreStintsEndLaps",
+    )
+
     def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initializes FinalClassificationData with raw data.
@@ -576,6 +594,11 @@ class PacketFinalClassificationData(F1PacketBase):
     """
 
     MAX_CARS = 22
+
+    __slots__ = (
+        "m_numCars",
+        "m_classificationData",
+    )
 
     def __init__(self, header: PacketHeader, packet: bytes) -> None:
         """

--- a/lib/f1_types/packet_8_final_classification_data.py
+++ b/lib/f1_types/packet_8_final_classification_data.py
@@ -216,10 +216,8 @@ class FinalClassificationData(F1SubPacketBase):
                 self.m_tyreStintsEndLaps[7]
             ) = self.COMPILED_PACKET_STRUCT_25.unpack(data)
 
-        if ResultStatus.isValid(self.m_resultStatus):
-            self.m_resultStatus = ResultStatus(self.m_resultStatus)
-        if ResultReason.isValid(self.m_resultReason):
-            self.m_resultReason = ResultReason(self.m_resultReason)
+        self.m_resultStatus = ResultStatus.safeCast(self.m_resultStatus)
+        self.m_resultReason = ResultReason.safeCast(self.m_resultReason)
 
         # Trim the tyre stints info
         self.m_tyreStintsActual     = self.m_tyreStintsActual[:self.m_numTyreStints]
@@ -227,13 +225,8 @@ class FinalClassificationData(F1SubPacketBase):
         self.m_tyreStintsEndLaps    = self.m_tyreStintsEndLaps[:self.m_numTyreStints]
 
         # Make tyre stint values as enum
-        self.m_tyreStintsActual = [ActualTyreCompound(compound) \
-                                    if ActualTyreCompound.isValid(compound) \
-                                        else compound for compound in self.m_tyreStintsActual]
-
-        self.m_tyreStintsVisual = [VisualTyreCompound(compound) \
-                                    if VisualTyreCompound.isValid(compound) \
-                                        else compound for compound in self.m_tyreStintsVisual]
+        self.m_tyreStintsActual = [ActualTyreCompound.safeCast(compound) for compound in self.m_tyreStintsActual]
+        self.m_tyreStintsVisual = [VisualTyreCompound.safeCast(compound) for compound in self.m_tyreStintsVisual]
 
     def __str__(self):
         """

--- a/lib/f1_types/packet_9_lobby_info_data.py
+++ b/lib/f1_types/packet_9_lobby_info_data.py
@@ -91,6 +91,18 @@ class LobbyInfoData(F1SubPacketBase):
     )
     PACKET_LEN_25 = COMPILED_PACKET_STRUCT_25.size
 
+    __slots__ = (
+        "m_aiControlled",
+        "m_teamId",
+        "m_nationality",
+        "m_platform",
+        "m_name",
+        "m_carNumber",
+        "m_yourTelemetry",
+        "m_showOnlineNames",
+        "m_techLevel",
+        "m_readyStatus",
+    )
     class ReadyStatus(F1BaseEnum):
         """
         ENUM class for the marshal zone flag status
@@ -351,6 +363,12 @@ class PacketLobbyInfoData(F1PacketBase):
     """
 
     MAX_PLAYERS: int = 22
+
+    __slots__ = (
+        "m_numPlayers",
+        "m_lobbyPlayers",
+    )
+
     def __init__(self, header: PacketHeader, packet: bytes) -> None:
         """
         Initializes PacketLobbyInfoData with raw data.

--- a/lib/f1_types/packet_9_lobby_info_data.py
+++ b/lib/f1_types/packet_9_lobby_info_data.py
@@ -153,24 +153,20 @@ class LobbyInfoData(F1SubPacketBase):
                 self.m_techLevel,
                 self.m_readyStatus,
             ) = _struct.unpack(data)
-            if TelemetrySetting.isValid(self.m_yourTelemetry):
-                self.m_yourTelemetry = TelemetrySetting(self.m_yourTelemetry)
+            self.m_yourTelemetry = TelemetrySetting.safeCast(self.m_yourTelemetry)
 
         self.m_name = self.m_name.decode('utf-8', errors='replace').rstrip('\x00')
 
-        if self.packet_format == 2023 and TeamID23.isValid(self.m_teamId):
-            self.m_teamId = TeamID23(self.m_teamId)
-        elif self.packet_format == 2024 and TeamID24.isValid(self.m_teamId):
-            self.m_teamId = TeamID24(self.m_teamId)
-        elif self.packet_format == 2025 and TeamID25.isValid(self.m_teamId):
-            self.m_teamId = TeamID25(self.m_teamId)
+        if self.packet_format == 2023:
+            self.m_teamId = TeamID23.safeCast(self.m_teamId)
+        elif self.packet_format == 2024:
+            self.m_teamId = TeamID24.safeCast(self.m_teamId)
+        elif self.packet_format == 2025:
+            self.m_teamId = TeamID25.safeCast(self.m_teamId)
 
-        if Nationality.isValid(self.m_nationality):
-            self.m_nationality = Nationality(self.m_nationality)
-        if Platform.isValid(self.m_platform):
-            self.m_platform = Platform(self.m_platform)
-        if LobbyInfoData.ReadyStatus.isValid(self.m_readyStatus):
-            self.m_readyStatus = LobbyInfoData.ReadyStatus(self.m_readyStatus)
+        self.m_nationality = Nationality.safeCast(self.m_nationality)
+        self.m_platform = Platform.safeCast(self.m_platform)
+        self.m_readyStatus = LobbyInfoData.ReadyStatus.safeCast(self.m_readyStatus)
         self.m_aiControlled = bool(self.m_aiControlled)
 
     def toJSON(self) -> Dict[str, Any]:

--- a/tests/f1_types/tests_packet_0_car_motion_data.py
+++ b/tests/f1_types/tests_packet_0_car_motion_data.py
@@ -815,6 +815,7 @@ class TestPacketCarMotionData(F1TypesTest):
         parsed_obj = PacketMotionData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_24_random(self):
         """
@@ -838,6 +839,7 @@ class TestPacketCarMotionData(F1TypesTest):
         parsed_obj = PacketMotionData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_25_random(self):
         """
@@ -861,6 +863,7 @@ class TestPacketCarMotionData(F1TypesTest):
         parsed_obj = PacketMotionData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_23_actual(self):
         """
@@ -870,6 +873,7 @@ class TestPacketCarMotionData(F1TypesTest):
         parsed_packet = PacketMotionData(self.m_header_23, self.m_packet_23_24_25)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(self.m_expected_json_23_24_25, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_24_actual(self):
         """
@@ -879,6 +883,7 @@ class TestPacketCarMotionData(F1TypesTest):
         parsed_packet = PacketMotionData(self.m_header_24, self.m_packet_23_24_25)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(self.m_expected_json_23_24_25, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual(self):
         """
@@ -888,6 +893,7 @@ class TestPacketCarMotionData(F1TypesTest):
         parsed_packet = PacketMotionData(self.m_header_25, self.m_packet_23_24_25)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(self.m_expected_json_23_24_25, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def _generateRandomCarMotionData(self) -> CarMotionData:
         """Generate a random CarMotionData object

--- a/tests/f1_types/tests_packet_10_car_damage_data.py
+++ b/tests/f1_types/tests_packet_10_car_damage_data.py
@@ -54,6 +54,7 @@ class TestPacketCarDamageData(F1TypesTest):
         parsed_obj = PacketCarDamageData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_24_random(self):
         """
@@ -72,6 +73,7 @@ class TestPacketCarDamageData(F1TypesTest):
         parsed_obj = PacketCarDamageData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_23_random(self):
         """
@@ -90,6 +92,7 @@ class TestPacketCarDamageData(F1TypesTest):
         parsed_obj = PacketCarDamageData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_23_actual(self):
         """
@@ -941,6 +944,7 @@ class TestPacketCarDamageData(F1TypesTest):
         parsed_packet = PacketCarDamageData(self.m_header_23, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_24_actual(self):
         """
@@ -1801,6 +1805,7 @@ class TestPacketCarDamageData(F1TypesTest):
         parsed_packet = PacketCarDamageData(self.m_header_25, raw_payload)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def _generateRandomCarDamageData(self, packet_format: int) -> CarDamageData:
         """

--- a/tests/f1_types/tests_packet_11_session_history_data.py
+++ b/tests/f1_types/tests_packet_11_session_history_data.py
@@ -78,6 +78,7 @@ class TestPacketSessionHistoryData(F1TypesTest):
         parsed_packet = PacketSessionHistoryData(self.m_header_23, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_24_actual(self):
         """
@@ -121,6 +122,7 @@ class TestPacketSessionHistoryData(F1TypesTest):
         parsed_packet = PacketSessionHistoryData(self.m_header_24, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual(self):
 
@@ -130,6 +132,7 @@ class TestPacketSessionHistoryData(F1TypesTest):
         parsed_packet = PacketSessionHistoryData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual_invalid_count(self):
 

--- a/tests/f1_types/tests_packet_12_tyre_sets_data.py
+++ b/tests/f1_types/tests_packet_12_tyre_sets_data.py
@@ -52,6 +52,7 @@ class TestPacketTyreSetsData(F1TypesTest):
         parsed_obj = PacketTyreSetsData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_24_random(self):
         """
@@ -67,6 +68,7 @@ class TestPacketTyreSetsData(F1TypesTest):
         parsed_obj = PacketTyreSetsData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_23_actual(self):
         """
@@ -304,6 +306,7 @@ class TestPacketTyreSetsData(F1TypesTest):
         parsed_packet = PacketTyreSetsData(self.m_header_23, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_24_actual(self):
         """
@@ -541,6 +544,7 @@ class TestPacketTyreSetsData(F1TypesTest):
         parsed_packet = PacketTyreSetsData(self.m_header_24, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual(self):
 
@@ -550,6 +554,7 @@ class TestPacketTyreSetsData(F1TypesTest):
         parsed_packet = PacketTyreSetsData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def _generateRandomTyreSetData(self, header: PacketHeader) -> TyreSetData:
         """

--- a/tests/f1_types/tests_packet_13_motion_ex_data.py
+++ b/tests/f1_types/tests_packet_13_motion_ex_data.py
@@ -137,6 +137,7 @@ class TestPacketMotionExData(F1TypesTest):
         parsed_packet = PacketMotionExData(self.m_header_23, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_24_actual(self):
         """
@@ -239,6 +240,7 @@ class TestPacketMotionExData(F1TypesTest):
         parsed_packet = PacketMotionExData(self.m_header_24, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual(self):
         """
@@ -251,3 +253,4 @@ class TestPacketMotionExData(F1TypesTest):
         parsed_packet = PacketMotionExData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))

--- a/tests/f1_types/tests_packet_14_time_trial_data.py
+++ b/tests/f1_types/tests_packet_14_time_trial_data.py
@@ -107,6 +107,7 @@ class TestPacketTimeTrialData(F1TypesTest):
         parsed_packet = PacketTimeTrialData(self.m_header_24, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual(self):
 
@@ -116,6 +117,7 @@ class TestPacketTimeTrialData(F1TypesTest):
         parsed_packet = PacketTimeTrialData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_24_random(self):
         """
@@ -131,6 +133,7 @@ class TestPacketTimeTrialData(F1TypesTest):
         parsed_obj = PacketTimeTrialData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_25_random(self):
         """
@@ -146,6 +149,7 @@ class TestPacketTimeTrialData(F1TypesTest):
         parsed_obj = PacketTimeTrialData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def _generateRandomTimeTrialDataSet(self, index: int, packet_format: int) -> TimeTrialDataSet:
         """

--- a/tests/f1_types/tests_packet_15_lap_positions_data.py
+++ b/tests/f1_types/tests_packet_15_lap_positions_data.py
@@ -46,6 +46,7 @@ class TestPacketLapPositionsData(F1TypesTest):
         parsed_packet = PacketLapPositionsData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual_segmented(self):
         """
@@ -59,3 +60,4 @@ class TestPacketLapPositionsData(F1TypesTest):
         parsed_packet = PacketLapPositionsData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))

--- a/tests/f1_types/tests_packet_1_session_data.py
+++ b/tests/f1_types/tests_packet_1_session_data.py
@@ -270,6 +270,7 @@ class TestPacketSessionData(F1TypesTest):
         parsed_packet = PacketSessionData(random_header, packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_24(self):
         """
@@ -424,6 +425,7 @@ class TestPacketSessionData(F1TypesTest):
         parsed_packet = PacketSessionData(random_header, packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25(self):
 
@@ -434,3 +436,4 @@ class TestPacketSessionData(F1TypesTest):
         parsed_packet = PacketSessionData(random_header, packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))

--- a/tests/f1_types/tests_packet_2_lap_data.py
+++ b/tests/f1_types/tests_packet_2_lap_data.py
@@ -908,6 +908,7 @@ class TestPacketLapData(F1TypesTest):
         parsed_packet = PacketLapData(random_header, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_24_actual(self):
         """
@@ -1741,6 +1742,7 @@ class TestPacketLapData(F1TypesTest):
         parsed_packet = PacketLapData(random_header, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual(self):
         """
@@ -1755,3 +1757,4 @@ class TestPacketLapData(F1TypesTest):
         parsed_packet = PacketLapData(random_header, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))

--- a/tests/f1_types/tests_packet_3_event_data.py
+++ b/tests/f1_types/tests_packet_3_event_data.py
@@ -49,6 +49,7 @@ class TestPacketEventData(F1TypesTest):
         parsed_packet = PacketEventData(random_header, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_24_fastest_lap(self):
         """
@@ -68,6 +69,7 @@ class TestPacketEventData(F1TypesTest):
         parsed_packet = PacketEventData(random_header, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_fastest_lap(self):
         """
@@ -81,4 +83,5 @@ class TestPacketEventData(F1TypesTest):
         parsed_packet = PacketEventData(random_header, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 

--- a/tests/f1_types/tests_packet_4_participants_data.py
+++ b/tests/f1_types/tests_packet_4_participants_data.py
@@ -62,6 +62,7 @@ class TestPacketParticipantsData(F1TypesTest):
         parsed_obj = PacketParticipantsData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_24_random(self):
         """
@@ -80,6 +81,7 @@ class TestPacketParticipantsData(F1TypesTest):
         parsed_obj = PacketParticipantsData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_23_random(self):
         """
@@ -98,6 +100,7 @@ class TestPacketParticipantsData(F1TypesTest):
         parsed_obj = PacketParticipantsData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_24_actual(self):
         """
@@ -110,6 +113,7 @@ class TestPacketParticipantsData(F1TypesTest):
         parsed_packet = PacketParticipantsData(self.m_header_24, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_23_actual(self):
         """
@@ -122,6 +126,7 @@ class TestPacketParticipantsData(F1TypesTest):
         parsed_packet = PacketParticipantsData(self.m_header_23, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual(self):
         """
@@ -134,6 +139,7 @@ class TestPacketParticipantsData(F1TypesTest):
         parsed_packet = PacketParticipantsData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def _getRandomParticipantData(self, header: PacketHeader, max_length: Optional[int] = 31) -> ParticipantData:
         """

--- a/tests/f1_types/tests_packet_5_car_setups_data.py
+++ b/tests/f1_types/tests_packet_5_car_setups_data.py
@@ -54,6 +54,7 @@ class TestPacketCarSetupData(F1TypesTest):
         parsed_obj = PacketCarSetupData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_23_random(self):
         """
@@ -71,6 +72,7 @@ class TestPacketCarSetupData(F1TypesTest):
         parsed_obj = PacketCarSetupData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_24_actual(self):
         """
@@ -658,6 +660,7 @@ class TestPacketCarSetupData(F1TypesTest):
         parsed_packet = PacketCarSetupData(self.m_header_24, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_23_actual(self):
         """
@@ -1245,6 +1248,7 @@ class TestPacketCarSetupData(F1TypesTest):
         parsed_packet = PacketCarSetupData(self.m_header_23, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual(self):
         """
@@ -1257,6 +1261,7 @@ class TestPacketCarSetupData(F1TypesTest):
         parsed_packet = PacketCarSetupData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def _getRandomCarSetupData(self, header: PacketHeader) -> CarSetupData:
         """

--- a/tests/f1_types/tests_packet_6_car_telemetry_data.py
+++ b/tests/f1_types/tests_packet_6_car_telemetry_data.py
@@ -57,6 +57,7 @@ class TestPacketCarTelemetryData(F1TypesTest):
         parsed_obj = PacketCarTelemetryData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_23_random(self):
         """
@@ -78,6 +79,7 @@ class TestPacketCarTelemetryData(F1TypesTest):
         parsed_obj = PacketCarTelemetryData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_23_actual(self):
         """
@@ -1020,6 +1022,7 @@ class TestPacketCarTelemetryData(F1TypesTest):
         parsed_packet = PacketCarTelemetryData(self.m_header_23, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_24_actual(self):
         """
@@ -1962,6 +1965,7 @@ class TestPacketCarTelemetryData(F1TypesTest):
         parsed_packet = PacketCarTelemetryData(self.m_header_24, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual(self):
         """
@@ -1974,6 +1978,7 @@ class TestPacketCarTelemetryData(F1TypesTest):
         parsed_packet = PacketCarTelemetryData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def _generateRandomCarTelemetryData(self) -> CarTelemetryData:
         """

--- a/tests/f1_types/tests_packet_7_status_data.py
+++ b/tests/f1_types/tests_packet_7_status_data.py
@@ -55,6 +55,7 @@ class TestPacketCarStatusData(F1TypesTest):
         parsed_obj = PacketCarStatusData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_23_random(self):
         """
@@ -73,6 +74,7 @@ class TestPacketCarStatusData(F1TypesTest):
         parsed_obj = PacketCarStatusData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_24_actual(self):
         """
@@ -705,6 +707,7 @@ class TestPacketCarStatusData(F1TypesTest):
         parsed_packet = PacketCarStatusData(self.m_header_24, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_23_actual(self):
         """
@@ -1336,6 +1339,7 @@ class TestPacketCarStatusData(F1TypesTest):
         parsed_packet = PacketCarStatusData(self.m_header_23, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual(self):
         """
@@ -1348,6 +1352,7 @@ class TestPacketCarStatusData(F1TypesTest):
         parsed_packet = PacketCarStatusData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def _generateRandomCarStatusData(self) -> CarStatusData:
         """

--- a/tests/f1_types/tests_packet_8_final_classification.py
+++ b/tests/f1_types/tests_packet_8_final_classification.py
@@ -61,6 +61,8 @@ class TestPacketFinalClassificationData(F1TypesTest):
         parsed_obj = PacketFinalClassificationData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
+
 
     def test_f1_25_empty(self):
         """
@@ -76,6 +78,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         self.assertEqual(generated_test_obj.m_numCars, 0)
         self.assertEqual(generated_test_obj.m_header, self.m_header_25)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), {'num-cars': 0, 'classification-data': []})
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_25_empty_no_header(self):
         """
@@ -91,6 +94,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         self.assertEqual(generated_test_obj.m_numCars, 0)
         self.assertEqual(generated_test_obj.m_header, None)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), {'num-cars': 0, 'classification-data': []})
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_24_random(self):
         """
@@ -110,6 +114,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         parsed_obj = PacketFinalClassificationData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_24_empty(self):
         """
@@ -125,6 +130,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         self.assertEqual(generated_test_obj.m_numCars, 0)
         self.assertEqual(generated_test_obj.m_header, self.m_header_24)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), {'num-cars': 0, 'classification-data': []})
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_24_empty_no_header(self):
         """
@@ -140,6 +146,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         self.assertEqual(generated_test_obj.m_numCars, 0)
         self.assertEqual(generated_test_obj.m_header, None)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), {'num-cars': 0, 'classification-data': []})
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_23_random(self):
         """
@@ -159,6 +166,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         parsed_obj = PacketFinalClassificationData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(parsed_obj, '__dict__'))
 
     def test_f1_23_empty(self):
         """
@@ -174,6 +182,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         self.assertEqual(generated_test_obj.m_numCars, 0)
         self.assertEqual(generated_test_obj.m_header, self.m_header_23)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), {'num-cars': 0, 'classification-data': []})
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_23_empty_no_header(self):
         """
@@ -189,6 +198,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         self.assertEqual(generated_test_obj.m_numCars, 0)
         self.assertEqual(generated_test_obj.m_header, None)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), {'num-cars': 0, 'classification-data': []})
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_23_actual(self):
         """
@@ -685,6 +695,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         parsed_packet = PacketFinalClassificationData(self.m_header_23, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def test_f1_25_actual(self):
         """
@@ -697,6 +708,7 @@ class TestPacketFinalClassificationData(F1TypesTest):
         parsed_packet = PacketFinalClassificationData(self.m_header_25, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def _generateRandomFinalClassificationData(self, packet_format: int) -> FinalClassificationData:
         """

--- a/tests/f1_types/tests_packet_9_lobby_info_data.py
+++ b/tests/f1_types/tests_packet_9_lobby_info_data.py
@@ -61,6 +61,7 @@ class TestPacketLobbyInfoData(F1TypesTest):
         parsed_obj = PacketLobbyInfoData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_24_random(self):
         """
@@ -81,6 +82,7 @@ class TestPacketLobbyInfoData(F1TypesTest):
         parsed_obj = PacketLobbyInfoData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_23_random(self):
         """
@@ -100,6 +102,7 @@ class TestPacketLobbyInfoData(F1TypesTest):
         parsed_obj = PacketLobbyInfoData(parsed_header, payload_bytes)
         self.assertEqual(generated_test_obj, parsed_obj)
         self.jsonComparisionUtil(generated_test_obj.toJSON(), parsed_obj.toJSON())
+        self.assertFalse(hasattr(generated_test_obj, '__dict__'))
 
     def test_f1_23_actual(self):
         """
@@ -356,6 +359,7 @@ class TestPacketLobbyInfoData(F1TypesTest):
         parsed_packet = PacketLobbyInfoData(self.m_header_23, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
 
     def test_f1_24_actual(self):
@@ -481,6 +485,7 @@ class TestPacketLobbyInfoData(F1TypesTest):
         parsed_packet = PacketLobbyInfoData(self.m_header_24, raw_packet)
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
+        self.assertFalse(hasattr(parsed_packet, '__dict__'))
 
     def _generateRandomLobbyInfoData(self, header: PacketHeader) -> LobbyInfoData:
         """

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -44,45 +44,45 @@ from f1_types import (TestF1BaseEnum, TestF1PacketBase, TestF1SubPacketBase,
 # pylint: disable=unused-import wrong-import-position
 # sourcery skip: dont-import-test-modules
 from tests_base import CustomTestResult, F1TelemetryUnitTestsBase
-# from tests_collision_analyzer import (TestCollisionAnalyzer,
-#                                       TestCollisionPairKey,
-#                                       TestCollisionRecord)
-# from tests_config import (TestCaptureSettings, TestConfigIO,
-#                           TestDisplaySettings, TestEdgeCases, TestFilePathStr,
-#                           TestForwardingSettings, TestHttpsSettings,
-#                           TestLoadConfigFromIni, TestLoggingSettings,
-#                           TestMissingSectionsAndKeys, TestNetworkSettings,
-#                           TestPngSettings, TestPrivacySettings,
-#                           TestSampleSettingsFixture, TestStreamOverlaySettings)
-# from tests_custom_markers import (TestCustomMarkerEntry,
-#                                   TestCustomMarkersHistory)
-# from tests_data_per_driver import (TestTyreSetHistoryEntry,
-#                                    TestTyreSetHistoryManager, TestTyreSetInfo)
-# from tests_debouncer import TestMultiButtonDebouncer
-# from tests_fuel_recommender import (TestFuelRateRecommenderMisc,
-#                                     TestFuelRateRecommenderRemove,
-#                                     TestFuelRemainingPerLap)
-# from tests_ipc import TestIPC
-# from tests_itc import TestAsyncInterTaskCommunicator
-# from tests_overtake_analyzer import (TestOvertakeAnalyzerEmptyInput,
-#                                      TestOvertakeAnalyzerFileCsv,
-#                                      TestOvertakeAnalyzerInvalidData,
-#                                      TestOvertakeAnalyzerListCsv,
-#                                      TestOvertakeAnalyzerListObj)
-# from tests_pcap import (FullPCapTests, TestF1PacketCaptureCompression,
-#                         TestF1PacketCaptureHeader)
-# from tests_race_analyzer import TestGetFastestTimesJson
-# from tests_save_to_disk import TestSaveRaceInfo
-# from tests_tyre_wear_extrapolator import (
-#     TestSimpleLinearRegression, TestTyreWearExtrapolator,
-#     TestTyreWearExtrapolatorWithMissingLaps,
-#     TestTyreWearExtrapolatorWithNonRacingLaps)
-# from tests_udp_forwarder import TestAsyncUDPForwarder
-# from tests_version import TestGetVersion, TestIsUpdateAvailable
+from tests_collision_analyzer import (TestCollisionAnalyzer,
+                                      TestCollisionPairKey,
+                                      TestCollisionRecord)
+from tests_config import (TestCaptureSettings, TestConfigIO,
+                          TestDisplaySettings, TestEdgeCases, TestFilePathStr,
+                          TestForwardingSettings, TestHttpsSettings,
+                          TestLoadConfigFromIni, TestLoggingSettings,
+                          TestMissingSectionsAndKeys, TestNetworkSettings,
+                          TestPngSettings, TestPrivacySettings,
+                          TestSampleSettingsFixture, TestStreamOverlaySettings)
+from tests_custom_markers import (TestCustomMarkerEntry,
+                                  TestCustomMarkersHistory)
+from tests_data_per_driver import (TestTyreSetHistoryEntry,
+                                   TestTyreSetHistoryManager, TestTyreSetInfo)
+from tests_debouncer import TestMultiButtonDebouncer
+from tests_fuel_recommender import (TestFuelRateRecommenderMisc,
+                                    TestFuelRateRecommenderRemove,
+                                    TestFuelRemainingPerLap)
+from tests_ipc import TestIPC
+from tests_itc import TestAsyncInterTaskCommunicator
+from tests_overtake_analyzer import (TestOvertakeAnalyzerEmptyInput,
+                                     TestOvertakeAnalyzerFileCsv,
+                                     TestOvertakeAnalyzerInvalidData,
+                                     TestOvertakeAnalyzerListCsv,
+                                     TestOvertakeAnalyzerListObj)
+from tests_pcap import (FullPCapTests, TestF1PacketCaptureCompression,
+                        TestF1PacketCaptureHeader)
+from tests_race_analyzer import TestGetFastestTimesJson
+from tests_save_to_disk import TestSaveRaceInfo
+from tests_tyre_wear_extrapolator import (
+    TestSimpleLinearRegression, TestTyreWearExtrapolator,
+    TestTyreWearExtrapolatorWithMissingLaps,
+    TestTyreWearExtrapolatorWithNonRacingLaps)
+from tests_udp_forwarder import TestAsyncUDPForwarder
+from tests_version import TestGetVersion, TestIsUpdateAvailable
 
-# from tests.tests_child_proc_mgmt import TestIsInitComplete, TestPidReport
-# from tests.tests_port_check import TestPortAvailability
-# from tests.tests_wdt import TestWatchDogTimer
+from tests.tests_child_proc_mgmt import TestIsInitComplete, TestPidReport
+from tests.tests_port_check import TestPortAvailability
+from tests.tests_wdt import TestWatchDogTimer
 
 # Initialize colorama
 init(autoreset=True)

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -44,45 +44,45 @@ from f1_types import (TestF1BaseEnum, TestF1PacketBase, TestF1SubPacketBase,
 # pylint: disable=unused-import wrong-import-position
 # sourcery skip: dont-import-test-modules
 from tests_base import CustomTestResult, F1TelemetryUnitTestsBase
-from tests_collision_analyzer import (TestCollisionAnalyzer,
-                                      TestCollisionPairKey,
-                                      TestCollisionRecord)
-from tests_config import (TestCaptureSettings, TestConfigIO,
-                          TestDisplaySettings, TestEdgeCases, TestFilePathStr,
-                          TestForwardingSettings, TestHttpsSettings,
-                          TestLoadConfigFromIni, TestLoggingSettings,
-                          TestMissingSectionsAndKeys, TestNetworkSettings,
-                          TestPngSettings, TestPrivacySettings,
-                          TestSampleSettingsFixture, TestStreamOverlaySettings)
-from tests_custom_markers import (TestCustomMarkerEntry,
-                                  TestCustomMarkersHistory)
-from tests_data_per_driver import (TestTyreSetHistoryEntry,
-                                   TestTyreSetHistoryManager, TestTyreSetInfo)
-from tests_debouncer import TestMultiButtonDebouncer
-from tests_fuel_recommender import (TestFuelRateRecommenderMisc,
-                                    TestFuelRateRecommenderRemove,
-                                    TestFuelRemainingPerLap)
-from tests_ipc import TestIPC
-from tests_itc import TestAsyncInterTaskCommunicator
-from tests_overtake_analyzer import (TestOvertakeAnalyzerEmptyInput,
-                                     TestOvertakeAnalyzerFileCsv,
-                                     TestOvertakeAnalyzerInvalidData,
-                                     TestOvertakeAnalyzerListCsv,
-                                     TestOvertakeAnalyzerListObj)
-from tests_pcap import (FullPCapTests, TestF1PacketCaptureCompression,
-                        TestF1PacketCaptureHeader)
-from tests_race_analyzer import TestGetFastestTimesJson
-from tests_save_to_disk import TestSaveRaceInfo
-from tests_tyre_wear_extrapolator import (
-    TestSimpleLinearRegression, TestTyreWearExtrapolator,
-    TestTyreWearExtrapolatorWithMissingLaps,
-    TestTyreWearExtrapolatorWithNonRacingLaps)
-from tests_udp_forwarder import TestAsyncUDPForwarder
-from tests_version import TestGetVersion, TestIsUpdateAvailable
+# from tests_collision_analyzer import (TestCollisionAnalyzer,
+#                                       TestCollisionPairKey,
+#                                       TestCollisionRecord)
+# from tests_config import (TestCaptureSettings, TestConfigIO,
+#                           TestDisplaySettings, TestEdgeCases, TestFilePathStr,
+#                           TestForwardingSettings, TestHttpsSettings,
+#                           TestLoadConfigFromIni, TestLoggingSettings,
+#                           TestMissingSectionsAndKeys, TestNetworkSettings,
+#                           TestPngSettings, TestPrivacySettings,
+#                           TestSampleSettingsFixture, TestStreamOverlaySettings)
+# from tests_custom_markers import (TestCustomMarkerEntry,
+#                                   TestCustomMarkersHistory)
+# from tests_data_per_driver import (TestTyreSetHistoryEntry,
+#                                    TestTyreSetHistoryManager, TestTyreSetInfo)
+# from tests_debouncer import TestMultiButtonDebouncer
+# from tests_fuel_recommender import (TestFuelRateRecommenderMisc,
+#                                     TestFuelRateRecommenderRemove,
+#                                     TestFuelRemainingPerLap)
+# from tests_ipc import TestIPC
+# from tests_itc import TestAsyncInterTaskCommunicator
+# from tests_overtake_analyzer import (TestOvertakeAnalyzerEmptyInput,
+#                                      TestOvertakeAnalyzerFileCsv,
+#                                      TestOvertakeAnalyzerInvalidData,
+#                                      TestOvertakeAnalyzerListCsv,
+#                                      TestOvertakeAnalyzerListObj)
+# from tests_pcap import (FullPCapTests, TestF1PacketCaptureCompression,
+#                         TestF1PacketCaptureHeader)
+# from tests_race_analyzer import TestGetFastestTimesJson
+# from tests_save_to_disk import TestSaveRaceInfo
+# from tests_tyre_wear_extrapolator import (
+#     TestSimpleLinearRegression, TestTyreWearExtrapolator,
+#     TestTyreWearExtrapolatorWithMissingLaps,
+#     TestTyreWearExtrapolatorWithNonRacingLaps)
+# from tests_udp_forwarder import TestAsyncUDPForwarder
+# from tests_version import TestGetVersion, TestIsUpdateAvailable
 
-from tests.tests_child_proc_mgmt import TestIsInitComplete, TestPidReport
-from tests.tests_port_check import TestPortAvailability
-from tests.tests_wdt import TestWatchDogTimer
+# from tests.tests_child_proc_mgmt import TestIsInitComplete, TestPidReport
+# from tests.tests_port_check import TestPortAvailability
+# from tests.tests_wdt import TestWatchDogTimer
 
 # Initialize colorama
 init(autoreset=True)


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

made all telemetry objects slotted
made a safeCast method in base packet type to check validity and then construct
refactored car status to have same structure as rest of codebase

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [ ] New feature 🚀
- [x] Refactor 🔨
- [ ] Documentation 📚
- [x] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Unit Tests

- [x] All unit tests pass
- Attach test command/output:

```
----------------------------------------------------------------------
Ran 327 tests in 15.596s

OK
```

To run the unit test suite
```bash
poetry run python tests/unit_tests.py
```

### ✅ Integration Tests

* [x] All integration tests pass
* Attach test command/output:

```
Passed: 27/27

PASS: f1_23_sp_austria.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_mp_fp_austria_full_spec.f1pcap
PASS: f1_25_mp_fp_jeddah.f1pcap
PASS: f1_25_mp_fp_jeddah_player.f1pcap
PASS: f1_25_mp_fp_jeddah_player_2.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_mp_quali_sprint_austria_spec.f1pcap
PASS: f1_25_mp_race_japan_spec.f1pcap
PASS: f1_25_mp_race_jeddah.f1pcap
PASS: f1_25_mp_solo_afk_fp_aus.f1pcap
PASS: f1_25_sp_aus_5lap_1stop.f1pcap
PASS: f1_25_sp_aus_5lap_1stop_flashback.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_sp_baku_mid_session_save_load.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_sp_imola_5lap_1stop.f1pcap
PASS: f1_25_sp_qatar_flashback_1stop.f1pcap
PASS: f1_25_sp_qatar_partial.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
Total time: 734.591 seconds
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

### ✅ Pylint

* [x] Code passes `pylint`
* Paste summary report:

```
$ pylint --rcfile scripts/.pylintrc apps lib

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

To run pylint
```bash
pylint --rcfile scripts/.pylintrc lib apps
```

---

## 🧱 `lib/` Directory Changes

* [x] This PR modifies or adds files under `lib/`
* [x] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Added assertion to check if obj is truly slotted in every parser test case
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Refactor telemetry packet parsing to improve performance and consistency by adding __slots__ to all packet and sub-packet classes, introducing a safeCast method on F1BaseEnum for uniform enum conversions, standardizing enum casting in parsing logic, and restructuring CarStatusData to explicit unpacking and safeCast usage.

Enhancements:
- Add __slots__ to all packet and sub-packet classes to reduce memory overhead
- Introduce F1BaseEnum.safeCast for uniform and safe enum value conversions
- Replace manual isValid checks with safeCast calls across packet parsing logic
- Refactor CarStatusData parsing to use explicit tuple unpacking and safeCast for consistency