### PR TITLE
Revamp Eng View race table with Tabulator

### DIFF
--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -62,8 +62,6 @@ class SessionInfo:
          - m_track (Optional[TrackID]): The current track
          - m_track_len (Optional[int]): The length of the track in meters
          - m_session_type (Optional[SessionType): The type of the session, will be an enum specific to game year
-         - m_session_uid (Optional[int]): The unique identifier of the session
-         - m_game_mode (Optional[GameMode]): The current game mode
          - m_track_temp (Optional[int]): The current track temperature in degrees Celsius
          - m_air_temp (Optional[int]): The current air temperature in degrees Celsius
          - m_total_laps (Optional[int]): The total number of laps in the current event
@@ -86,7 +84,6 @@ class SessionInfo:
         self.m_track : Optional[TrackID] = None
         self.m_track_len: Optional[int] = None
         self.m_session_type : Optional[SessionType] = None
-        self.m_session_uid : Optional[int] = None
         self.m_game_mode: Optional[GameMode] = None
         self.m_track_temp : Optional[int] = None
         self.m_air_temp : Optional[int] = None
@@ -131,7 +128,6 @@ class SessionInfo:
         self.m_track = None
         self.m_track_len = None
         self.m_session_type = None
-        self.m_session_uid = None
         self.m_game_mode = None
         self.m_track_temp = None
         self.m_air_temp = None
@@ -182,7 +178,6 @@ class SessionInfo:
         self.m_track_temp = packet.m_trackTemperature
         self.m_air_temp = packet.m_airTemperature
         self.m_session_type = packet.m_sessionType
-        self.m_session_uid = packet.m_header.m_sessionUID
         self.m_game_mode = packet.m_gameMode
         self.m_weather_forecast_samples = packet.m_weatherForecastSamples
         self.m_pit_speed_limit = packet.m_pitSpeedLimit

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -62,6 +62,8 @@ class SessionInfo:
          - m_track (Optional[TrackID]): The current track
          - m_track_len (Optional[int]): The length of the track in meters
          - m_session_type (Optional[SessionType): The type of the session, will be an enum specific to game year
+         - m_session_uid (Optional[int]): The unique identifier of the session
+         - m_game_mode (Optional[GameMode]): The current game mode
          - m_track_temp (Optional[int]): The current track temperature in degrees Celsius
          - m_air_temp (Optional[int]): The current air temperature in degrees Celsius
          - m_total_laps (Optional[int]): The total number of laps in the current event
@@ -76,6 +78,26 @@ class SessionInfo:
          - m_packet_format (Optional[int]): The current packet format
     """
 
+    __slots__ = (
+        "m_track",
+        "m_track_len",
+        "m_session_type",
+        "m_session_uid",
+        "m_game_mode",
+        "m_track_temp",
+        "m_air_temp",
+        "m_total_laps",
+        "m_safety_car_status",
+        "m_is_spectating",
+        "m_spectator_car_index",
+        "m_weather_forecast_samples",
+        "m_pit_speed_limit",
+        "m_packet_session",
+        "m_packet_final_classification",
+        "m_game_year",
+        "m_packet_format",
+    )
+
     def __init__(self):
         """
         Init the SessionInfo object fields to None
@@ -84,6 +106,7 @@ class SessionInfo:
         self.m_track : Optional[TrackID] = None
         self.m_track_len: Optional[int] = None
         self.m_session_type : Optional[SessionType] = None
+        self.m_session_uid: Optional[int] = None
         self.m_game_mode: Optional[GameMode] = None
         self.m_track_temp : Optional[int] = None
         self.m_air_temp : Optional[int] = None
@@ -108,6 +131,7 @@ class SessionInfo:
             f"SessionInfo(m_track={str(self.m_track)}, "
             f"m_track_len={self.m_track_len}, "
             f"m_event_type={str(self.m_session_type)}, "
+            f"m_session_uid={self.m_session_uid}, "
             f"m_game_mode={str(self.m_game_mode)}, "
             f"m_track_temp={self.m_track_temp}, "
             f"m_air_temp={self.m_air_temp}, "
@@ -128,6 +152,7 @@ class SessionInfo:
         self.m_track = None
         self.m_track_len = None
         self.m_session_type = None
+        self.m_session_uid = None
         self.m_game_mode = None
         self.m_track_temp = None
         self.m_air_temp = None
@@ -178,6 +203,7 @@ class SessionInfo:
         self.m_track_temp = packet.m_trackTemperature
         self.m_air_temp = packet.m_airTemperature
         self.m_session_type = packet.m_sessionType
+        self.m_session_uid = packet.m_header.m_sessionUID
         self.m_game_mode = packet.m_gameMode
         self.m_weather_forecast_samples = packet.m_weatherForecastSamples
         self.m_pit_speed_limit = packet.m_pitSpeedLimit

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -62,6 +62,8 @@ class SessionInfo:
          - m_track (Optional[TrackID]): The current track
          - m_track_len (Optional[int]): The length of the track in meters
          - m_session_type (Optional[SessionType): The type of the session, will be an enum specific to game year
+         - m_session_uid (Optional[int]): The unique identifier of the session
+         - m_game_mode (Optional[GameMode]): The current game mode
          - m_track_temp (Optional[int]): The current track temperature in degrees Celsius
          - m_air_temp (Optional[int]): The current air temperature in degrees Celsius
          - m_total_laps (Optional[int]): The total number of laps in the current event
@@ -84,6 +86,7 @@ class SessionInfo:
         self.m_track : Optional[TrackID] = None
         self.m_track_len: Optional[int] = None
         self.m_session_type : Optional[SessionType] = None
+        self.m_session_uid : Optional[int] = None
         self.m_game_mode: Optional[GameMode] = None
         self.m_track_temp : Optional[int] = None
         self.m_air_temp : Optional[int] = None
@@ -128,6 +131,7 @@ class SessionInfo:
         self.m_track = None
         self.m_track_len = None
         self.m_session_type = None
+        self.m_session_uid = None
         self.m_game_mode = None
         self.m_track_temp = None
         self.m_air_temp = None
@@ -178,6 +182,7 @@ class SessionInfo:
         self.m_track_temp = packet.m_trackTemperature
         self.m_air_temp = packet.m_airTemperature
         self.m_session_type = packet.m_sessionType
+        self.m_session_uid = packet.m_header.m_sessionUID
         self.m_game_mode = packet.m_gameMode
         self.m_weather_forecast_samples = packet.m_weatherForecastSamples
         self.m_pit_speed_limit = packet.m_pitSpeedLimit

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -101,6 +101,7 @@ class RaceInfoUpdate:
             "track-temperature": _getValueOrDefaultValue(self.m_session_info.m_track_temp, default_value=0),
             "air-temperature": _getValueOrDefaultValue(self.m_session_info.m_air_temp, default_value=0),
             "event-type": _getValueOrDefaultValue(str(self.m_session_info.m_session_type)),
+            "session-uid" : _getValueOrDefaultValue(self.m_session_info.m_session_uid, None),
             "session-time-left" : _getValueOrDefaultValue(self.m_session_info.m_packet_session.m_sessionTimeLeft \
                                                           if self.m_session_info.m_packet_session else None, 0),
             "total-laps": _getValueOrDefaultValue(self.m_session_info.m_total_laps, default_value=None),

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -95,7 +95,6 @@ class RaceInfoUpdate:
         final_json = {
             # First, global fields
             "live-data" : True,
-            "session-uid" : _getValueOrDefaultValue(self.m_session_info.m_session_uid, None),
             "f1-game-year" : _getValueOrDefaultValue(self.m_session_info.m_game_year, None),
             "packet-format" : _getValueOrDefaultValue(self.m_session_info.m_packet_format, None),
             "circuit": str(self.m_session_info.m_track) if self.m_session_info.m_track is not None else "---",

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -95,6 +95,7 @@ class RaceInfoUpdate:
         final_json = {
             # First, global fields
             "live-data" : True,
+            "session-uid" : _getValueOrDefaultValue(self.m_session_info.m_session_uid, None),
             "f1-game-year" : _getValueOrDefaultValue(self.m_session_info.m_game_year, None),
             "packet-format" : _getValueOrDefaultValue(self.m_session_info.m_packet_format, None),
             "circuit": str(self.m_session_info.m_track) if self.m_session_info.m_track is not None else "---",

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -240,59 +240,52 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 
 .green-time {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: var(--bs-success); /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
+    display: inline-block;
+    color: var(--bs-success);
+    border: 2px solid currentColor;
+    border-radius: 4px;
 }
 
 .purple-time {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: #d825d8; /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
+    display: inline-block;
+    color: #d825d8;
+    border: 2px solid currentColor;
+    border-radius: 4px;
 }
 
 .red-time {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: var(--bs-danger); /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
+    display: inline-block;
+    color: var(--bs-danger);
+    border: 2px solid currentColor;
+    border-radius: 4px;
 }
 
 .drs-not-available {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: #2D2D33; /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
+    display: inline-block;
+    color: #2D2D33;
+    border: 2px solid currentColor;
+    border-radius: 4px;
 }
 
 .drs-available {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: #A1A1AA; /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
+    display: inline-block;
+    color: #A1A1AA;
+    border: 2px solid currentColor;
+    border-radius: 4px;
 }
 
 .drs-active {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: #10B981; /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
+    display: inline-block;
+    color: #10B981;
+    border: 2px solid currentColor;
+    border-radius: 4px;
 }
 
 .driver-pitting {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: #06B6D4; /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
+    display: inline-block;
+    color: #06B6D4;
+    border: 2px solid currentColor;
+    border-radius: 4px;
 }
 
 /* Tabulator custom styling */
@@ -354,62 +347,6 @@ input[type="number"]::-webkit-outer-spin-button {
 
 .tabulator-row.player-row .tabulator-cell:last-child {
     border-right: 2px solid #ffd700;
-}
-
-.green-time {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: var(--bs-success); /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
-}
-
-.purple-time {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: #d825d8; /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
-}
-
-.red-time {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: var(--bs-danger); /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
-}
-
-.drs-not-available {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: #2D2D33; /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
-}
-
-.drs-available {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: #A1A1AA; /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
-}
-
-.drs-active {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: #10B981; /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
-}
-
-.driver-pitting {
-    display: inline-block; /* Ensures the element wraps tightly around the text */
-    /* padding: 2px 4px; Adjusts the space between the text and the border */
-    color: #06B6D4; /* Sets the text color */
-    border: 2px solid currentColor; /* Sets the border color to match the text */
-    border-radius: 4px; /* Optional: rounds the corners of the border */
 }
 
 /* Settings Modal */

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -349,41 +349,45 @@ input[type="number"]::-webkit-outer-spin-button {
     border-right: 2px solid #ffd700;
 }
 
-/* Settings Modal */
-#settings-modal {
-    display: none;
+/* Column Visibility Pane */
+.column-visibility-pane {
     position: fixed;
-    z-index: 1050;
-    left: 0;
     top: 0;
-    width: 100%;
+    right: -300px; /* Start off-screen to the right */
+    width: 300px;
     height: 100%;
-    overflow: auto;
-    background-color: rgba(0,0,0,0.4);
-}
-
-#settings-modal .modal-content {
     background-color: var(--f1-dark);
-    margin: 15% auto;
-    padding: 20px;
-    border: 1px solid var(--f1-light-gray);
-    width: 80%;
-    max-width: 500px;
+    border-left: 1px solid var(--f1-light-gray);
+    box-shadow: -5px 0 15px rgba(0, 0, 0, 0.3);
+    z-index: 1050;
+    transition: right 0.3s ease-in-out;
+    display: flex;
+    flex-direction: column;
     color: var(--f1-text);
 }
 
-#settings-modal .close-btn {
-    color: var(--f1-text-secondary);
-    float: right;
-    font-size: 28px;
-    font-weight: bold;
+.column-visibility-pane.open {
+    right: 0; /* Slide in */
 }
 
-#settings-modal .close-btn:hover,
-#settings-modal .close-btn:focus {
-    color: var(--f1-text);
-    text-decoration: none;
-    cursor: pointer;
+.column-visibility-pane .pane-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem;
+    background-color: var(--f1-darker);
+    border-bottom: 1px solid var(--f1-light-gray);
+}
+
+.column-visibility-pane .pane-header h2 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.column-visibility-pane .pane-body {
+    padding: 1rem;
+    overflow-y: auto;
+    flex-grow: 1;
 }
 
 #column-visibility-container {
@@ -393,6 +397,12 @@ input[type="number"]::-webkit-outer-spin-button {
 
 #column-visibility-container label {
     margin-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+}
+
+#column-visibility-container input[type="checkbox"] {
+    margin-right: 0.5rem;
 }
 
 #column-visibility-container .sub-column {

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -211,6 +211,20 @@ input[type="number"]::-webkit-outer-spin-button {
     background: #222;
 }
 
+.settings-button {
+  background: none;
+  border: none;
+  color: var(--f1-text);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.5rem;
+  transition: color 0.2s;
+}
+
+.settings-button:hover {
+  color: var(--f1-red);
+}
+
 /* Player row highlight */
 .eng-view-table tbody tr.player-row td {
     border-top: 2px solid #ffd700 !important;

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -272,3 +272,56 @@ input[type="number"]::-webkit-outer-spin-button {
     border: 2px solid currentColor; /* Sets the border color to match the text */
     border-radius: 4px; /* Optional: rounds the corners of the border */
 }
+
+/* Tabulator custom styling */
+#eng-view-table {
+    font-size: 0.85rem;
+    background-color: var(--f1-dark);
+    border: 1px solid #333;
+}
+
+.tabulator-header {
+    background-color: var(--f1-darker) !important;
+    color: var(--f1-text) !important;
+    border-bottom: 1px solid #333;
+}
+
+.tabulator-col {
+    background-color: var(--f1-gray);
+    border-right: 1px solid #333;
+}
+
+.tabulator-col-content {
+    padding: 0.3rem;
+}
+
+.tabulator-row {
+    background-color: var(--f1-dark);
+    color: var(--f1-text);
+}
+
+.tabulator-row:nth-child(even) {
+    background-color: var(--f1-gray);
+}
+
+.tabulator-row:hover {
+    background-color: var(--f1-light-gray);
+}
+
+.tabulator-cell {
+    padding: 0.3rem;
+    border-right: 1px solid #333;
+}
+
+.tabulator-row.player-row .tabulator-cell {
+    border-top: 2px solid #ffd700;
+    border-bottom: 2px solid #ffd700;
+}
+
+.tabulator-row.player-row .tabulator-cell:first-child {
+    border-left: 2px solid #ffd700;
+}
+
+.tabulator-row.player-row .tabulator-cell:last-child {
+    border-right: 2px solid #ffd700;
+}

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -19,6 +19,7 @@ body {
     display: flex;
     flex-direction: column;
     padding: 0;
+    overflow: hidden;
 }
 
 .eng-view-global-data-section {
@@ -28,11 +29,11 @@ body {
 }
 
 .eng-view-race-table-section {
-    flex: 1;
-    overflow-y: scroll;
-    padding-bottom: 6rem;
-    padding-left: 1rem;
-    padding-right: 1rem;
+    flex: 1 1 auto;
+    overflow: hidden;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
 }
 
 .eng-view-table {

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -134,6 +134,7 @@ body {
 
 .eng-view-tyre-row-2 {
     color: var(--f1-text-secondary);
+    font-size: 0.7rem;
 }
 
 /* Icon and text row styling */

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -293,7 +293,7 @@ input[type="number"]::-webkit-outer-spin-button {
 
 .tabulator-col {
     background-color: var(--f1-gray);
-    border-right: 1px solid #333;
+    border-right: 1px solid #222;
 }
 
 .tabulator-col-content {
@@ -310,12 +310,16 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 
 .tabulator-row:hover {
-    background-color: var(--f1-light-gray);
+    background-color: var(--f1-dark) !important;
+}
+
+.tabulator-row:nth-child(even):hover {
+    background-color: var(--f1-gray) !important;
 }
 
 .tabulator-cell {
     padding: 0.3rem;
-    border-right: 1px solid #333;
+    border-right: 1px solid #222;
 }
 
 .tabulator-row.player-row .tabulator-cell {

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -70,6 +70,7 @@ body {
 
 .tabulator-col.eng-view-table-main-header .tabulator-col-content {
     color: var(--f1-text);
+    text-align: center;
     font-weight: 500;
 }
 

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -447,7 +447,7 @@ input[type="number"]::-webkit-outer-spin-button {
     margin-left: 20px;
 }
 
-.telemetry-restricted {
+.single-line-cell {
     display: flex;
     flex-direction: column;
     height: 100%;

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -396,3 +396,53 @@ input[type="number"]::-webkit-outer-spin-button {
     border: 2px solid currentColor; /* Sets the border color to match the text */
     border-radius: 4px; /* Optional: rounds the corners of the border */
 }
+
+/* Settings Modal */
+#settings-modal {
+    display: none;
+    position: fixed;
+    z-index: 1050;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.4);
+}
+
+#settings-modal .modal-content {
+    background-color: var(--f1-dark);
+    margin: 15% auto;
+    padding: 20px;
+    border: 1px solid var(--f1-light-gray);
+    width: 80%;
+    max-width: 500px;
+    color: var(--f1-text);
+}
+
+#settings-modal .close-btn {
+    color: var(--f1-text-secondary);
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+}
+
+#settings-modal .close-btn:hover,
+#settings-modal .close-btn:focus {
+    color: var(--f1-text);
+    text-decoration: none;
+    cursor: pointer;
+}
+
+#column-visibility-container {
+    display: flex;
+    flex-direction: column;
+}
+
+#column-visibility-container label {
+    margin-bottom: 0.5rem;
+}
+
+#column-visibility-container .sub-column {
+    margin-left: 20px;
+}

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -330,3 +330,59 @@ input[type="number"]::-webkit-outer-spin-button {
 .tabulator-row.player-row .tabulator-cell:last-child {
     border-right: 2px solid #ffd700;
 }
+
+.green-time {
+    display: inline-block; /* Ensures the element wraps tightly around the text */
+    /* padding: 2px 4px; Adjusts the space between the text and the border */
+    color: var(--bs-success); /* Sets the text color */
+    border: 2px solid currentColor; /* Sets the border color to match the text */
+    border-radius: 4px; /* Optional: rounds the corners of the border */
+}
+
+.purple-time {
+    display: inline-block; /* Ensures the element wraps tightly around the text */
+    /* padding: 2px 4px; Adjusts the space between the text and the border */
+    color: #d825d8; /* Sets the text color */
+    border: 2px solid currentColor; /* Sets the border color to match the text */
+    border-radius: 4px; /* Optional: rounds the corners of the border */
+}
+
+.red-time {
+    display: inline-block; /* Ensures the element wraps tightly around the text */
+    /* padding: 2px 4px; Adjusts the space between the text and the border */
+    color: var(--bs-danger); /* Sets the text color */
+    border: 2px solid currentColor; /* Sets the border color to match the text */
+    border-radius: 4px; /* Optional: rounds the corners of the border */
+}
+
+.drs-not-available {
+    display: inline-block; /* Ensures the element wraps tightly around the text */
+    /* padding: 2px 4px; Adjusts the space between the text and the border */
+    color: #2D2D33; /* Sets the text color */
+    border: 2px solid currentColor; /* Sets the border color to match the text */
+    border-radius: 4px; /* Optional: rounds the corners of the border */
+}
+
+.drs-available {
+    display: inline-block; /* Ensures the element wraps tightly around the text */
+    /* padding: 2px 4px; Adjusts the space between the text and the border */
+    color: #A1A1AA; /* Sets the text color */
+    border: 2px solid currentColor; /* Sets the border color to match the text */
+    border-radius: 4px; /* Optional: rounds the corners of the border */
+}
+
+.drs-active {
+    display: inline-block; /* Ensures the element wraps tightly around the text */
+    /* padding: 2px 4px; Adjusts the space between the text and the border */
+    color: #10B981; /* Sets the text color */
+    border: 2px solid currentColor; /* Sets the border color to match the text */
+    border-radius: 4px; /* Optional: rounds the corners of the border */
+}
+
+.driver-pitting {
+    display: inline-block; /* Ensures the element wraps tightly around the text */
+    /* padding: 2px 4px; Adjusts the space between the text and the border */
+    color: #06B6D4; /* Sets the text color */
+    border: 2px solid currentColor; /* Sets the border color to match the text */
+    border-radius: 4px; /* Optional: rounds the corners of the border */
+}

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -64,8 +64,13 @@ body {
     border-right: 2px solid #333 !important;
 }
 
-.eng-view-table-main-header th {
+.tabulator-col.eng-view-table-main-header {
+    background-color: var(--f1-dark) !important;
+}
+
+.tabulator-col.eng-view-table-main-header .tabulator-col-content {
     color: var(--f1-text);
+    font-weight: 500;
 }
 
 .eng-view-sub-header th {

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -446,3 +446,11 @@ input[type="number"]::-webkit-outer-spin-button {
 #column-visibility-container .sub-column {
     margin-left: 20px;
 }
+
+.telemetry-restricted {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    align-items: center;
+}

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -28,8 +28,8 @@ body {
 }
 
 .eng-view-race-table-section {
-    flex: 0 0 85%;
-    overflow-y: auto;
+    flex: 1;
+    overflow-y: scroll;
     padding-bottom: 6rem;
     padding-left: 1rem;
     padding-right: 1rem;
@@ -278,12 +278,16 @@ input[type="number"]::-webkit-outer-spin-button {
     font-size: 0.85rem;
     background-color: var(--f1-dark);
     border: 1px solid #333;
+    height: 100% !important;
 }
 
 .tabulator-header {
     background-color: var(--f1-darker) !important;
     color: var(--f1-text) !important;
     border-bottom: 1px solid #333;
+    position: sticky !important;
+    top: 0 !important;
+    z-index: 1 !important;
 }
 
 .tabulator-col {

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -7,6 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
     <link href="https://fonts.googleapis.com/css2?family=Exo+2:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/engView.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/modals.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreSetsCards.css') }}">
@@ -20,6 +21,7 @@
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@10"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tinycolor/1.4.2/tinycolor.min.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
 </head>
 <body>
     <div class="container-fluid">
@@ -104,66 +106,7 @@
 
         <!-- Race Table Section -->
         <div class="eng-view-race-table-section">
-            <div class="table-responsive">
-                <table class="table table-hover table-sm table-striped eng-view-table">
-                    <thead>
-                        <tr class="text-center eng-view-table-main-header">
-                            <th class="eng-view-col-border">Pos</th>
-                            <th class="eng-view-col-border">Name</th>
-                            <th class="eng-view-col-border">Delta</th>
-                            <th colspan="4" class="eng-view-col-border">Penalties</th>
-                            <th colspan="4" class="eng-view-col-border">Best Lap</th>
-                            <th colspan="4" class="eng-view-col-border">Last Lap</th>
-                            <th colspan="6" class="eng-view-col-border">Tyre Wear</th>
-                            <th colspan="3" class="eng-view-col-border">ERS</th>
-                            <th colspan="3" class="eng-view-col-border">Fuel</th>
-                            <th colspan="3">Damage</th>
-                        </tr>
-                        <tr class="eng-view-sub-header">
-                            <th class="eng-view-col-border"></th>
-                            <th class="eng-view-col-border"></th>
-                            <th class="eng-view-col-border"></th>
-                            <!-- Penalties -->
-                            <th>Track</th>
-                            <th>Time</th>
-                            <th>DT</th>
-                            <th class="eng-view-col-border">Serv</th>
-                            <!-- Last Lap -->
-                            <th>Lap</th>
-                            <th>S1</th>
-                            <th>S2</th>
-                            <th class="eng-view-col-border">S3</th>
-                            <!-- Best Lap -->
-                            <th>Lap</th>
-                            <th>S1</th>
-                            <th>S2</th>
-                            <th class="eng-view-col-border">S3</th>
-                            <!-- Tyre Wear -->
-                            <th>Comp</th>
-                            <th>Lap</th>
-                            <th>FL</th>
-                            <th>FR</th>
-                            <th>RL</th>
-                            <th class="eng-view-col-border">RR</th>
-                            <!-- ERS -->
-                            <th>Avail</th>
-                            <th>Deploy</th>
-                            <th class="eng-view-col-border">Mode</th>
-                            <!-- Fuel -->
-                            <th>Total</th>
-                            <th>Per Lap</th>
-                            <th class="eng-view-col-border">Est</th>
-                            <!-- Damage -->
-                            <th>FL</th>
-                            <th>FR</th>
-                            <th>RW</th>
-                        </tr>
-                    </thead>
-                    <tbody id="engViewRaceTableBody">
-                        <!-- Rows will be populated by JavaScript -->
-                    </tbody>
-                </table>
-            </div>
+            <div id="eng-view-table"></div>
         </div>
 
         <!-- Driver Details Modal -->

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -113,16 +113,18 @@
             <div id="eng-view-table"></div>
         </div>
 
-        <!-- Settings Modal -->
-        <div id="settings-modal" class="modal">
-            <div class="modal-content">
-                <span class="close-btn">&times;</span>
-                <div class="d-flex justify-content-between align-items-center">
-                    <h2>Column Visibility</h2>
-                    <button id="reset-visibility-btn" class="btn btn-sm btn-secondary">Reset</button>
+        <!-- Column Visibility Pane -->
+        <div id="column-visibility-pane" class="column-visibility-pane">
+            <div class="pane-header">
+                <h2>Column Visibility</h2>
+                <div>
+                    <button id="reset-visibility-btn" class="btn btn-sm btn-secondary me-2">Reset All</button>
+                    <button id="close-pane-btn" class="btn-close btn-close-white" aria-label="Close"></button>
                 </div>
-                <div id="column-visibility-container" class="mt-2">
-                    <!-- Checkboxes will be populated here -->
+            </div>
+            <div class="pane-body">
+                <div id="column-visibility-container">
+                    <!-- Toggle switches will be populated here -->
                 </div>
             </div>
         </div>

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -32,9 +32,12 @@
                     <div class="card border-secondary global-stats-section">
                         <div class="card-header border-secondary d-flex justify-content-between align-items-center global-stats-section-header">
                             <h5 class="mb-0" id="raceStatusHeader">Race Status</h5>
-                            <a href="/">
-                                <span style="font-size: 1.5rem;" data-bs-toggle="tooltip" data-bs-title="Switch to driver view">🏎️</span>
-                            </a>
+                            <div class="d-flex">
+                                <a href="/">
+                                    <span style="font-size: 1.5rem;" data-bs-toggle="tooltip" data-bs-title="Switch to driver view">🏎️</span>
+                                </a>
+                                <button id="settings-btn" class="btn btn-sm btn-secondary ms-2"><i class="bi bi-gear-fill"></i></button>
+                            </div>
                         </div>
                         <div class="card-body">
                             <div class="eng-view-global-stat">
@@ -107,6 +110,20 @@
         <!-- Race Table Section -->
         <div class="eng-view-race-table-section">
             <div id="eng-view-table"></div>
+        </div>
+
+        <!-- Settings Modal -->
+        <div id="settings-modal" class="modal">
+            <div class="modal-content">
+                <span class="close-btn">&times;</span>
+                <div class="d-flex justify-content-between align-items-center">
+                    <h2>Column Visibility</h2>
+                    <button id="reset-visibility-btn" class="btn btn-sm btn-secondary">Reset</button>
+                </div>
+                <div id="column-visibility-container" class="mt-2">
+                    <!-- Checkboxes will be populated here -->
+                </div>
+            </div>
         </div>
 
         <!-- Driver Details Modal -->

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -33,6 +33,7 @@
                         <div class="card-header border-secondary d-flex justify-content-between align-items-center global-stats-section-header">
                             <h5 class="mb-0" id="raceStatusHeader">Race Status</h5>
                             <div class="d-flex">
+                                <span style="font-size: 1.5rem;" data-bs-toggle="tooltip" data-bs-title="This symbol shows up when a driver has set their telemetry to restricted">⌀</span>
                                 <a href="/">
                                     <span style="font-size: 1.5rem;" data-bs-toggle="tooltip" data-bs-title="Switch to driver view">🏎️</span>
                                 </a>
@@ -154,9 +155,6 @@
                 </div>
             </div>
         </div>
-
-
-
     </div>
 
     <script src="{{ url_for('static', filename='js/preferences.js') }}"></script>

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -22,6 +22,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tinycolor/1.4.2/tinycolor.min.js"></script>
     <script type="text/javascript" src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
 </head>
 <body>
     <div class="container-fluid">

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -34,10 +34,10 @@
                             <h5 class="mb-0" id="raceStatusHeader">Race Status</h5>
                             <div class="d-flex">
                                 <span style="font-size: 1.5rem;" data-bs-toggle="tooltip" data-bs-title="This symbol shows up when a driver has set their telemetry to restricted">⌀</span>
-                                <a href="/">
-                                    <span style="font-size: 1.5rem;" data-bs-toggle="tooltip" data-bs-title="Switch to driver view">🏎️</span>
+                                <a id="driver-view-btn" class="btn settings-button" href="/" data-bs-toggle="tooltip" data-bs-title="Switch to driver view">
+                                    <i class="bi bi-car-front-fill"></i>
                                 </a>
-                                <button id="settings-btn" class="btn btn-sm btn-secondary ms-2"><i class="bi bi-gear-fill"></i></button>
+                                <button id="settings-btn" class="btn settings-button" data-bs-toggle="tooltip" data-bs-title="Table columns settings"><i class="bi bi-gear-fill"></i></button>
                             </div>
                         </div>
                         <div class="card-body">

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -27,8 +27,7 @@ class EngViewRaceTable {
         this.COLUMN_WIDTHS_KEY = 'eng-view-table-column-widths'; // Storage key
         this.COLUMN_VISIBILITY_KEY = 'eng-view-table-column-visibility'; // Storage key for visibility
         this.COLUMN_ORDER_KEY = 'eng-view-table-column-order'; // Storage key for column order
-        this.TELEMETRY_DISABLED_TEXT = "Driver has set telemetry to restricted";
-        this.TELEMETRY_DISABLED_COLOUR = "#ff0000";
+        this.TELEMETRY_DISABLED_TEXT = "⌀";
         this.initTable();
     }
 
@@ -671,8 +670,7 @@ class EngViewRaceTable {
     }
 
     getTelemetryRestrictedContent() {
-        return `<div class="single-line-cell" style="background-color:${this.TELEMETRY_DISABLED_COLOUR};
-                color: white;">N/A</div>`;
+        return this.getSingleLineCell(this.TELEMETRY_DISABLED_TEXT);
     }
 
     getSingleLineCell(value) {

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -179,9 +179,11 @@ class EngViewRaceTable {
         }));
 
         if (tableData && tableData.length > 0) {
-            const scrollPos = this.table.rowManager.element.scrollTop;
+            const scrollPosTop = this.table.rowManager.element.scrollTop;
+            const scrollPosLeft = this.table.rowManager.element.scrollLeft;
             this.table.setData(tableData).then(() => {
-                this.table.rowManager.element.scrollTop = scrollPos;
+                this.table.rowManager.element.scrollTop = scrollPosTop;
+                this.table.rowManager.element.scrollLeft = scrollPosLeft;
             });
         }
     }

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -19,6 +19,7 @@ class EngViewRaceTable {
         this.spectatorIndex = null;
         this.isSpectating = false;
         this.fastestLapMs = 0;
+        this.sessionUID = null;
         this.INVALID_SECTOR = -2;
         this.RED_SECTOR = -1;
         this.YELLOW_SECTOR = 0;
@@ -637,7 +638,7 @@ class EngViewRaceTable {
         return `<div class='${row1Class}'>${row1}</div><div class='${row2Class}'>${row2}</div>`;
     }
 
-    update(drivers, isSpectating, eventType, spectatorCarIndex, fastestLapMs) {
+    update(drivers, isSpectating, eventType, spectatorCarIndex, fastestLapMs, sessionUID) {
         this.spectatorIndex = spectatorCarIndex;
         this.isSpectating = isSpectating;
         this.fastestLapMs = fastestLapMs;
@@ -674,7 +675,7 @@ class EngViewRaceTable {
             const currentDataMap = new Map(currentData.map(row => [row.id, row]));
 
             // Check if we need to force a full update
-            const needsFullUpdate = this.needsFullUpdate(currentData, newTableData, currentDataMap);
+            const needsFullUpdate = this.needsFullUpdate(currentData, newTableData, currentDataMap, sessionUID);
 
             if (needsFullUpdate) {
                 // If reference driver changed or new drivers, do full update
@@ -726,9 +727,16 @@ class EngViewRaceTable {
         }
     }
 
-    needsFullUpdate(currentData, newData, currentDataMap) {
+    needsFullUpdate(currentData, newData, currentDataMap, sessionUID) {
         // If different number of drivers, need full update
         if (currentData.length !== newData.length) {
+            return true;
+        }
+
+        // If session ID has changed, need update
+        if (this.sessionUID !== sessionUID) {
+            this.sessionUID = sessionUID;
+            console.debug("Session UID changed, forcing full update", sessionUID);
             return true;
         }
 
@@ -1048,11 +1056,12 @@ function initDashboard() {
             "is-spectating": isSpectating,
             "event-type": eventType,
             "spectator-car-index": spectatorCarIndex,
-            "fastest-lap-overall" : fastestLapMs
+            "fastest-lap-overall" : fastestLapMs,
+            "session-uid" : sessionUID
         } = data;
 
         if (tableEntries || eventType === "Time Trial") {
-            raceTable.update(tableEntries, isSpectating, eventType, spectatorCarIndex, fastestLapMs);
+            raceTable.update(tableEntries, isSpectating, eventType, spectatorCarIndex, fastestLapMs, sessionUID);
         }
         raceStatus.update(data);
         weatherTable.update(data["weather-forecast-samples"]);

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -573,7 +573,7 @@ class EngViewRaceTable {
                             if (telemetryPublic) {
                                 return `${cell.getValue()}%`;
                             } else {
-                                return `<div class="single-line-cell" style="background-color:${this.TELEMETRY_DISABLED_COLOUR}; color: white;" title="${this.TELEMETRY_DISABLED_TEXT}">---</div>`;
+                                return this.getTelemetryRestrictedContent();
                             }
                         }, ...disableSorting },
                     { title: "FR", field: "damage-info.fr-wing-damage",

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -519,10 +519,11 @@ class EngViewRaceTable {
         } else {
             statusClass = 'drs-not-available';
         }
-        return `
-            <div class="eng-view-tyre-row-1">${position}</div>
-            <div class="${statusClass}">${statusText}</div>
-        `;
+        return this.createMultiLineCell({
+            row1: position,
+            row2: statusText,
+            row2Class: statusClass
+        })
     }
 
     createMultiLineCell({

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -22,13 +22,26 @@ class EngViewRaceTable {
     }
 
     initTable() {
+        const columnDefinitions = this.getColumnDefinitions();
+
+        function applyHeaderClass(columns) {
+            columns.forEach(col => {
+                col.cssClass = "eng-view-table-main-header";
+                if (col.columns) {
+                    applyHeaderClass(col.columns);
+                }
+            });
+        }
+
+        applyHeaderClass(columnDefinitions);
+
         this.table = new Tabulator("#eng-view-table", {
             layout: "fitColumns",
             placeholder: "No Data Available",
             columnHeaderSortMulti: false,
             virtualDom: false,
             index: "id",
-            columns: this.getColumnDefinitions(),
+            columns: columnDefinitions,
             rowFormatter: (row) => {
                 const data = row.getData();
                 const isReferenceDriver = data.isPlayer || data.index === this.spectatorIndex;

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -18,6 +18,11 @@ class EngViewRaceTable {
         this.table = null;
         this.spectatorIndex = null;
         this.isSpectating = false;
+        this.INVALID_SECTOR = -2;
+        this.RED_SECTOR = -1;
+        this.YELLOW_SECTOR = 0;
+        this.GREEN_SECTOR = 1;
+        this.PURPLE_SECTOR = 2;
         this.COLUMN_WIDTHS_KEY = 'eng-view-table-column-widths'; // Storage key
         this.COLUMN_VISIBILITY_KEY = 'eng-view-table-column-visibility'; // Storage key for visibility
         this.COLUMN_ORDER_KEY = 'eng-view-table-column-order'; // Storage key for column order
@@ -209,14 +214,26 @@ class EngViewRaceTable {
             const lapInfo = cell.getValue();
             const driverInfo = cell.getRow().getData();
             const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+            const sectorStatus = lapInfo["sector-status"];
 
             const formattedTime = sectorKey === 'lap'
                 ? formatLapTime(lapInfo[timeKey])
                 : formatSectorTime(lapInfo[timeKey]);
 
             let timeClass = '';
-            if (lapInfo[fastestKey]) timeClass = 'green-time';
-            if (lapInfo[sessionFastestKey]) timeClass = 'purple-time';
+            if (sectorKey !== 'lap' && sectorStatus) {
+                const sectorIndex = parseInt(sectorKey.slice(1)) - 1;
+                if (sectorStatus[sectorIndex] === this.GREEN_SECTOR) {
+                    timeClass = 'green-time';
+                } else if (sectorStatus[sectorIndex] === this.PURPLE_SECTOR) {
+                    timeClass = 'purple-time';
+                } else if (sectorStatus[sectorIndex] === this.RED_SECTOR) {
+                    timeClass = 'red-time';
+                }
+            } else {
+                if (lapInfo[fastestKey]) timeClass = 'green-time';
+                if (lapInfo[sessionFastestKey]) timeClass = 'purple-time';
+            }
 
             const timeElement = `<div class="${timeClass}">${formattedTime}</div>`;
 

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -214,10 +214,10 @@ class EngViewRaceTable {
         }
     }
 
-    createSectorFormatter(sectorKey, timeKey, playerTimeKey) {
+    createSectorFormatter(sectorKey, timeKey, playerTimeKey, isLastLap) {
         return (cell) => {
-            const lapInfo = cell.getValue();
             const driverInfo = cell.getRow().getData();
+            const lapInfo = (isLastLap) ? driverInfo["lap-info"]["last-lap"] : driverInfo["lap-info"]["best-lap"];
             const bestLapInfo = driverInfo["lap-info"]["best-lap"];
             const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
             const sectorStatus = lapInfo["sector-status"];
@@ -261,10 +261,10 @@ class EngViewRaceTable {
         };
     }
 
-    createLastLapFormatter(sectorKey, timeKey, playerTimeKey) {
+    createLastLapFormatter(sectorKey, timeKey, playerTimeKey, isLastLap) {
         return (cell) => {
-            const lapInfo = cell.getValue();
             const driverInfo = cell.getRow().getData();
+            const lapInfo = driverInfo["lap-info"]["last-lap"];
             const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
 
             if (sectorKey === 'lap') {
@@ -289,7 +289,7 @@ class EngViewRaceTable {
                 });
             } else {
                 // For sectors, use the same logic as best lap
-                return this.createSectorFormatter(sectorKey, timeKey, playerTimeKey)(cell);
+                return this.createSectorFormatter(sectorKey, timeKey, playerTimeKey, isLastLap)(cell);
             }
         };
     }
@@ -325,26 +325,26 @@ class EngViewRaceTable {
         return [
             {
                 title: "Lap",
-                field: `lap-info.${lapType}-lap`,
-                formatter: this[formatterMethod]('lap', 'lap-time-ms', 'lap-time-ms-player'),
+                field: `lap-info.${lapType}-lap.lap-time-ms`,
+                formatter: this[formatterMethod]('lap', 'lap-time-ms', 'lap-time-ms-player', isLastLap),
                 ...this.getDisableSorting()
             },
             {
                 title: "S1",
-                field: `lap-info.${lapType}-lap`,
-                formatter: this[formatterMethod]('s1', 's1-time-ms', 's1-time-ms-player'),
+                field: `lap-info.${lapType}-lap.s1-time-ms`,
+                formatter: this[formatterMethod]('s1', 's1-time-ms', 's1-time-ms-player', isLastLap),
                 ...this.getDisableSorting()
             },
             {
                 title: "S2",
-                field: `lap-info.${lapType}-lap`,
-                formatter: this[formatterMethod]('s2', 's2-time-ms', 's2-time-ms-player'),
+                field: `lap-info.${lapType}-lap.s2-time-ms`,
+                formatter: this[formatterMethod]('s2', 's2-time-ms', 's2-time-ms-player', isLastLap),
                 ...this.getDisableSorting()
             },
             {
                 title: "S3",
-                field: `lap-info.${lapType}-lap`,
-                formatter: this[formatterMethod]('s3', 's3-time-ms', 's3-time-ms-player'),
+                field: `lap-info.${lapType}-lap.s3-time-ms`,
+                formatter: this[formatterMethod]('s3', 's3-time-ms', 's3-time-ms-player', isLastLap),
                 ...this.getDisableSorting()
             }
         ];

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -74,7 +74,10 @@ class EngViewRaceTable {
                 field: "name",
                 formatter: (cell, formatterParams, onRendered) => {
                     const data = cell.getRow().getData();
-                    return this.createMultiLineCell(data.name, data.team);
+                    return this.createMultiLineCell({
+                        row1: data.name,
+                        row2: data.team
+                    });
                 },
                 cellClick: (e, cell) => {
                     const data = cell.getRow().getData();
@@ -97,9 +100,15 @@ class EngViewRaceTable {
                     const deltaToCarInFront = deltaInfo["delta-to-car-in-front"] / 1000;
                     const deltaToLeader = deltaInfo["delta-to-leader"] / 1000;
                     if (position == 1) {
-                        return this.createMultiLineCell('Interval', 'Leader');
+                        return this.createMultiLineCell({
+                            row1: 'Interval',
+                            row2: 'Leader'
+                        });
                     }
-                    return this.createMultiLineCell(formatFloatWithThreeDecimalsSigned(deltaToCarInFront), formatFloatWithThreeDecimalsSigned(deltaToLeader));
+                    return this.createMultiLineCell({
+                        row1: formatFloatWithThreeDecimalsSigned(deltaToCarInFront),
+                        row2: formatFloatWithThreeDecimalsSigned(deltaToLeader)
+                    });
                 },
                 ...disableSorting
             },
@@ -138,7 +147,10 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["lap-time-ms"] - lapInfo["lap-time-ms-player"];
-                            return this.createMultiLineCell(timeElement, formatDelta(delta));
+                            return this.createMultiLineCell({
+                                row1: timeElement,
+                                row2: formatDelta(delta)
+                            });
                         },
                         ...disableSorting
                     },
@@ -163,7 +175,10 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s1-time-ms"] - lapInfo["s1-time-ms-player"];
-                            return this.createMultiLineCell(timeElement, formatDelta(delta));
+                            return this.createMultiLineCell({
+                                row1: timeElement,
+                                row2: formatDelta(delta)
+                            });
                         },
                         ...disableSorting
                     },
@@ -188,7 +203,10 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s2-time-ms"] - lapInfo["s2-time-ms-player"];
-                            return this.createMultiLineCell(timeElement, formatDelta(delta));
+                            return this.createMultiLineCell({
+                                row1: timeElement,
+                                row2: formatDelta(delta)
+                            });
                         },
                         ...disableSorting
                     },
@@ -213,7 +231,10 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s3-time-ms"] - lapInfo["s3-time-ms-player"];
-                            return this.createMultiLineCell(timeElement, formatDelta(delta));
+                            return this.createMultiLineCell({
+                                row1: timeElement,
+                                row2: formatDelta(delta)
+                            });
                         },
                         ...disableSorting
                     },
@@ -238,7 +259,10 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["lap-time-ms"] - lapInfo["lap-time-ms-player"];
-                            return this.createMultiLineCell(timeElement, formatDelta(delta));
+                            return this.createMultiLineCell({
+                                row1: timeElement,
+                                row2: formatDelta(delta)
+                            });
                         },
                         ...disableSorting
                     },
@@ -263,7 +287,10 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s1-time-ms"] - lapInfo["s1-time-ms-player"];
-                            return this.createMultiLineCell(timeElement, formatDelta(delta));
+                            return this.createMultiLineCell({
+                                row1: timeElement,
+                                row2: formatDelta(delta)
+                            });
                         },
                         ...disableSorting
                     },
@@ -288,7 +315,10 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s2-time-ms"] - lapInfo["s2-time-ms-player"];
-                            return this.createMultiLineCell(timeElement, formatDelta(delta));
+                            return this.createMultiLineCell({
+                                row1: timeElement,
+                                row2: formatDelta(delta)
+                            });
                         },
                         ...disableSorting
                     },
@@ -313,7 +343,10 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s3-time-ms"] - lapInfo["s3-time-ms-player"];
-                            return this.createMultiLineCell(timeElement, formatDelta(delta));
+                            return this.createMultiLineCell({
+                                row1: timeElement,
+                                row2: formatDelta(delta)
+                            });
                         },
                         ...disableSorting
                     },
@@ -330,7 +363,10 @@ class EngViewRaceTable {
                             const tyreInfo = cell.getRow().getData()["tyre-info"];
                             const tyreIcon = this.iconCache.getIcon(tyreInfo["visual-tyre-compound"]).outerHTML;
                             const agePitInfoStr = `${tyreInfo["tyre-age"]} L (${tyreInfo["num-pitstops"]} pit)`;
-                            return this.createMultiLineCell(tyreIcon, agePitInfoStr);
+                            return this.createMultiLineCell({
+                                row1: tyreIcon,
+                                row2: agePitInfoStr
+                            });
                         },
                         ...disableSorting
                     },
@@ -339,7 +375,10 @@ class EngViewRaceTable {
                         field: "tyre-info.tyre-age",
                         formatter: (cell) => {
                             const predictionLap = g_engView_predLapNum;
-                            return this.createMultiLineCell("cur", (predictionLap) ? (predictionLap) : ("---"));
+                            return this.createMultiLineCell({
+                                row1: "cur",
+                                row2: ((predictionLap) ? (predictionLap) : ("---"))
+                            });
                         },
                         ...disableSorting
                     },
@@ -351,8 +390,12 @@ class EngViewRaceTable {
                             const predictionLap = g_engView_predLapNum;
                             const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
                             const currTyreWearInfo = tyreInfo["current-wear"];
-                            return this.createMultiLineCell(formatFloatWithTwoDecimals(currTyreWearInfo["front-left-wear"]) + '%',
-                                (predictedTyreWearInfo) ? (formatFloatWithTwoDecimals(predictedTyreWearInfo["front-left-wear"]) + '%') : ('---'))
+                            return this.createMultiLineCell({
+                                row1: (formatFloatWithTwoDecimals(currTyreWearInfo["front-left-wear"]) + '%'),
+                                row2: ((predictedTyreWearInfo) ?
+                                        (formatFloatWithTwoDecimals(predictedTyreWearInfo["front-left-wear"]) + '%') :
+                                        ('---'))
+                            });
                         },
                         ...disableSorting
                     },
@@ -364,8 +407,12 @@ class EngViewRaceTable {
                             const predictionLap = g_engView_predLapNum;
                             const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
                             const currTyreWearInfo = tyreInfo["current-wear"];
-                            return this.createMultiLineCell(formatFloatWithTwoDecimals(currTyreWearInfo["front-right-wear"]) + '%',
-                                (predictedTyreWearInfo) ? (formatFloatWithTwoDecimals(predictedTyreWearInfo["front-right-wear"]) + '%') : ('---'))
+                            return this.createMultiLineCell({
+                                row1: (formatFloatWithTwoDecimals(currTyreWearInfo["front-left-wear"]) + '%'),
+                                row2: ((predictedTyreWearInfo) ?
+                                        (formatFloatWithTwoDecimals(predictedTyreWearInfo["front-left-wear"]) + '%') :
+                                        ('---'))
+                            });
                         },
                         ...disableSorting
                     },
@@ -377,8 +424,12 @@ class EngViewRaceTable {
                             const predictionLap = g_engView_predLapNum;
                             const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
                             const currTyreWearInfo = tyreInfo["current-wear"];
-                            return this.createMultiLineCell(formatFloatWithTwoDecimals(currTyreWearInfo["rear-left-wear"]) + '%',
-                                (predictedTyreWearInfo) ? (formatFloatWithTwoDecimals(predictedTyreWearInfo["rear-left-wear"]) + '%') : ('---'))
+                            return this.createMultiLineCell({
+                                row1: (formatFloatWithTwoDecimals(currTyreWearInfo["front-left-wear"]) + '%'),
+                                row2: ((predictedTyreWearInfo) ?
+                                        (formatFloatWithTwoDecimals(predictedTyreWearInfo["front-left-wear"]) + '%') :
+                                        ('---'))
+                            });
                         },
                         ...disableSorting
                     },
@@ -390,8 +441,12 @@ class EngViewRaceTable {
                             const predictionLap = g_engView_predLapNum;
                             const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
                             const currTyreWearInfo = tyreInfo["current-wear"];
-                            return this.createMultiLineCell(formatFloatWithTwoDecimals(currTyreWearInfo["rear-right-wear"]) + '%',
-                                (predictedTyreWearInfo) ? (formatFloatWithTwoDecimals(predictedTyreWearInfo["rear-right-wear"]) + '%') : ('---'))
+                            return this.createMultiLineCell({
+                                row1: (formatFloatWithTwoDecimals(currTyreWearInfo["front-left-wear"]) + '%'),
+                                row2: ((predictedTyreWearInfo) ?
+                                        (formatFloatWithTwoDecimals(predictedTyreWearInfo["front-left-wear"]) + '%') :
+                                        ('---'))
+                            });
                         },
                         ...disableSorting
                     },
@@ -447,7 +502,12 @@ class EngViewRaceTable {
         `;
     }
 
-    createMultiLineCell(row1, row2, row1Class='eng-view-tyre-row-1', row2Class='eng-view-tyre-row-2') {
+    createMultiLineCell({
+        row1,
+        row2,
+        row1Class = 'eng-view-tyre-row-1',
+        row2Class = 'eng-view-tyre-row-2'
+    }) {
         return `<div class='${row1Class}'>${row1}</div><div class='${row2Class}'>${row2}</div>`;
     }
 

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -26,6 +26,7 @@ class EngViewRaceTable {
             layout: "fitColumns",
             placeholder: "No Data Available",
             columnHeaderSortMulti: false,
+            virtualDom: false,
             index: "id",
             columns: this.getColumnDefinitions(),
             rowFormatter: (row) => {
@@ -178,7 +179,10 @@ class EngViewRaceTable {
         }));
 
         if (tableData && tableData.length > 0) {
-            this.table.setData(tableData);
+            const scrollPos = this.table.rowManager.element.scrollTop;
+            this.table.setData(tableData).then(() => {
+                this.table.rowManager.element.scrollTop = scrollPos;
+            });
         }
     }
 

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -39,7 +39,7 @@ class EngViewRaceTable {
 
         try {
             localStorage.setItem(this.COLUMN_WIDTHS_KEY, JSON.stringify(widths));
-            console.log('Column widths saved:', widths);
+            console.debug('Column widths saved:', widths);
         } catch (error) {
             console.warn('Failed to save column widths:', error);
         }
@@ -81,7 +81,7 @@ class EngViewRaceTable {
 
         try {
             localStorage.setItem(this.COLUMN_ORDER_KEY, JSON.stringify(order));
-            console.log('Column order saved:', order);
+            console.debug('Column order saved:', order);
         } catch (error) {
             console.warn('Failed to save column order:', error);
         }
@@ -105,7 +105,7 @@ class EngViewRaceTable {
 
         // Load and apply saved column widths
         const savedWidths = this.loadColumnWidths();
-        console.log('Saved column widths:', savedWidths);
+        console.debug('Saved column widths:', savedWidths);
         this.applyColumnWidths(columnDefinitions, savedWidths);
 
         // Load and apply column order
@@ -153,7 +153,7 @@ class EngViewRaceTable {
         // Add event listener for column resize
         this.table.on("columnResized", (column) => {
             // Debounce the save operation to avoid too frequent saves
-            console.log("Column resized:", column);
+            console.debug("Column resized:", column);
             clearTimeout(this.saveTimeout);
             this.saveTimeout = setTimeout(() => {
                 this.saveColumnWidths();
@@ -163,7 +163,7 @@ class EngViewRaceTable {
         // Add event listener for column resize
         this.table.on("columnMoved", (column, columns) => {
             // Debounce the save operation to avoid too frequent saves
-            console.log("Column moved:", column);
+            console.debug("Column moved:", column);
             clearTimeout(this.saveTimeout);
             this.saveTimeout = setTimeout(() => {
                 this.saveColumnOrder();
@@ -176,10 +176,7 @@ class EngViewRaceTable {
     resetColumnWidths() {
         try {
             localStorage.removeItem(this.COLUMN_WIDTHS_KEY);
-            console.log('Column widths reset to default');
-            // Optionally reload the table
-            // this.table.destroy();
-            // this.initTable();
+            console.debug('Column widths reset to default');
         } catch (error) {
             console.warn('Failed to reset column widths:', error);
         }
@@ -758,7 +755,7 @@ class EngViewRaceStatus {
             let value = parseInt(e.target.value);
             if (!isNaN(value) && value >= e.target.min && value <= e.target.max) {
                 g_engView_predLapNum = value;
-                console.log('Prediction lap changed to:', g_engView_predLapNum);
+                console.debug('Prediction lap changed to:', g_engView_predLapNum);
             } else {
                 console.warn('Invalid input: Out of range');
             }
@@ -786,7 +783,7 @@ class EngViewRaceStatus {
 
     #updatePredLapInputBox() {
         this.predictionLapInput.value = g_engView_predLapNum;
-        console.log("Updated prediction element value", g_engView_predLapNum);
+        console.debug("Updated prediction element value", g_engView_predLapNum);
     }
 
     #getSCStatusString(scStatus) {

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -210,7 +210,7 @@ class EngViewRaceTable {
         }
     }
 
-    createSectorFormatter(sectorKey, timeKey, fastestKey, sessionFastestKey, playerTimeKey) {
+    createSectorFormatter(sectorKey, timeKey, playerTimeKey) {
         return (cell) => {
             const lapInfo = cell.getValue();
             const driverInfo = cell.getRow().getData();
@@ -257,7 +257,7 @@ class EngViewRaceTable {
         };
     }
 
-    createLastLapFormatter(sectorKey, timeKey, fastestKey, sessionFastestKey, playerTimeKey) {
+    createLastLapFormatter(sectorKey, timeKey, playerTimeKey) {
         return (cell) => {
             const lapInfo = cell.getValue();
             const driverInfo = cell.getRow().getData();
@@ -286,7 +286,7 @@ class EngViewRaceTable {
                 });
             } else {
                 // For sectors, use the same logic as best lap
-                return this.createSectorFormatter(sectorKey, timeKey, fastestKey, sessionFastestKey, playerTimeKey)(cell);
+                return this.createSectorFormatter(sectorKey, timeKey, playerTimeKey)(cell);
             }
         };
     }
@@ -317,25 +317,25 @@ class EngViewRaceTable {
             {
                 title: "Lap",
                 field: `lap-info.${lapType}-lap`,
-                formatter: this[formatterMethod]('lap', 'lap-time-ms', 'fastest-lap', 'session-fastest-lap', 'lap-time-ms-player'),
+                formatter: this[formatterMethod]('lap', 'lap-time-ms', 'lap-time-ms-player'),
                 ...this.getDisableSorting()
             },
             {
                 title: "S1",
                 field: `lap-info.${lapType}-lap`,
-                formatter: this[formatterMethod]('s1', 's1-time-ms', 'fastest-s1', 'session-fastest-s1', 's1-time-ms-player'),
+                formatter: this[formatterMethod]('s1', 's1-time-ms', 's1-time-ms-player'),
                 ...this.getDisableSorting()
             },
             {
                 title: "S2",
                 field: `lap-info.${lapType}-lap`,
-                formatter: this[formatterMethod]('s2', 's2-time-ms', 'fastest-s2', 'session-fastest-s2', 's2-time-ms-player'),
+                formatter: this[formatterMethod]('s2', 's2-time-ms', 's2-time-ms-player'),
                 ...this.getDisableSorting()
             },
             {
                 title: "S3",
                 field: `lap-info.${lapType}-lap`,
-                formatter: this[formatterMethod]('s3', 's3-time-ms', 'fastest-s3', 'session-fastest-s3', 's3-time-ms-player'),
+                formatter: this[formatterMethod]('s3', 's3-time-ms', 's3-time-ms-player'),
                 ...this.getDisableSorting()
             }
         ];

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -64,7 +64,7 @@ class EngViewRaceTable {
                 field: "name",
                 formatter: (cell, formatterParams, onRendered) => {
                     const data = cell.getRow().getData();
-                    return `<div class='eng-view-tyre-row-1'>${data.name}</div><div class='eng-view-tyre-row-2'>${data.team}</div>`;
+                    return this.createMultiLineCell(data.name, data.team);
                 },
                 cellClick: (e, cell) => {
                     const data = cell.getRow().getData();
@@ -87,9 +87,9 @@ class EngViewRaceTable {
                     const deltaToCarInFront = deltaInfo["delta-to-car-in-front"] / 1000;
                     const deltaToLeader = deltaInfo["delta-to-leader"] / 1000;
                     if (position == 1) {
-                        return `<div class='eng-view-tyre-row-1'>Interval</div><div class='eng-view-tyre-row-2'>Leader</div>`;
+                        return this.createMultiLineCell('Interval', 'Leader');
                     }
-                    return `<div class='eng-view-tyre-row-1'>${formatFloatWithThreeDecimalsSigned(deltaToCarInFront)}</div><div class='eng-view-tyre-row-2'>${formatFloatWithThreeDecimalsSigned(deltaToLeader)}</div>`;
+                    return this.createMultiLineCell(formatFloatWithThreeDecimalsSigned(deltaToCarInFront), formatFloatWithThreeDecimalsSigned(deltaToLeader));
                 },
                 ...disableSorting
             },
@@ -128,7 +128,7 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["lap-time-ms"] - lapInfo["lap-time-ms-player"];
-                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
+                            return this.createMultiLineCell(timeElement, formatDelta(delta));
                         },
                         ...disableSorting
                     },
@@ -153,7 +153,7 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s1-time-ms"] - lapInfo["s1-time-ms-player"];
-                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
+                            return this.createMultiLineCell(timeElement, formatDelta(delta));
                         },
                         ...disableSorting
                     },
@@ -178,7 +178,7 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s2-time-ms"] - lapInfo["s2-time-ms-player"];
-                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
+                            return this.createMultiLineCell(timeElement, formatDelta(delta));
                         },
                         ...disableSorting
                     },
@@ -203,7 +203,7 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s3-time-ms"] - lapInfo["s3-time-ms-player"];
-                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
+                            return this.createMultiLineCell(timeElement, formatDelta(delta));
                         },
                         ...disableSorting
                     },
@@ -228,7 +228,7 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["lap-time-ms"] - lapInfo["lap-time-ms-player"];
-                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
+                            return this.createMultiLineCell(timeElement, formatDelta(delta));
                         },
                         ...disableSorting
                     },
@@ -253,7 +253,7 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s1-time-ms"] - lapInfo["s1-time-ms-player"];
-                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
+                            return this.createMultiLineCell(timeElement, formatDelta(delta));
                         },
                         ...disableSorting
                     },
@@ -278,7 +278,7 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s2-time-ms"] - lapInfo["s2-time-ms-player"];
-                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
+                            return this.createMultiLineCell(timeElement, formatDelta(delta));
                         },
                         ...disableSorting
                     },
@@ -303,7 +303,7 @@ class EngViewRaceTable {
                                 return timeElement;
                             }
                             const delta = lapInfo["s3-time-ms"] - lapInfo["s3-time-ms-player"];
-                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
+                            return this.createMultiLineCell(timeElement, formatDelta(delta));
                         },
                         ...disableSorting
                     },
@@ -320,7 +320,7 @@ class EngViewRaceTable {
                             const tyreInfo = cell.getRow().getData()["tyre-info"];
                             const tyreIcon = this.iconCache.getIcon(tyreInfo["visual-tyre-compound"]).outerHTML;
                             const agePitInfoStr = `${tyreInfo["tyre-age"]} L (${tyreInfo["num-pitstops"]} pit)`;
-                            return `<div class='eng-view-tyre-row-1'>${tyreIcon}</div><div class='eng-view-tyre-row-2'>${agePitInfoStr}</div>`;
+                            return this.createMultiLineCell(tyreIcon, agePitInfoStr);
                         },
                         ...disableSorting
                     },

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -1,5 +1,8 @@
 let g_engView_predLapNum = null;
 function escapeHtml(unsafe) {
+    if (typeof unsafe !== "string") {
+        return unsafe;
+    }
     return unsafe
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")
@@ -261,7 +264,8 @@ class EngViewRaceTable {
             const delta = timeMs - lapInfo[playerTimeKey];
             return this.createMultiLineCell({
                 row1: timeElement,
-                row2: formatDelta(delta)
+                row2: formatDelta(delta),
+                escapeRow1: false
             });
         };
     }
@@ -290,7 +294,8 @@ class EngViewRaceTable {
                 const delta = lapInfo[timeKey] - lapInfo[playerTimeKey];
                 return this.createMultiLineCell({
                     row1: timeElement,
-                    row2: formatDelta(delta)
+                    row2: formatDelta(delta),
+                    escapeRow1: false
                 });
             } else {
                 // For sectors, use the same logic as best lap
@@ -450,7 +455,8 @@ class EngViewRaceTable {
                             const agePitInfoStr = `${tyreInfo["tyre-age"]} L (${tyreInfo["num-pitstops"]} pit)`;
                             return this.createMultiLineCell({
                                 row1: tyreIcon,
-                                row2: agePitInfoStr
+                                row2: agePitInfoStr,
+                                escapeRow1: false
                             });
                         },
                         ...disableSorting
@@ -507,7 +513,8 @@ class EngViewRaceTable {
                                 return this.getTelemetryRestrictedContent();
                             }
                         },
-                        ...disableSorting },
+                        ...disableSorting
+                    },
                     { title: "Deploy", field: "ers-info.ers-deployed-this-lap",
                         formatter: (cell) => {
                             const driverInfo = cell.getRow().getData();
@@ -517,7 +524,8 @@ class EngViewRaceTable {
                             } else {
                                 return this.getTelemetryRestrictedContent();
                             }
-                        }, ...disableSorting },
+                        }, ...disableSorting
+                    },
                     { title: "Mode", field: "ers-info.ers-mode",
                         formatter: (cell) => {
                             const driverInfo = cell.getRow().getData();
@@ -527,7 +535,8 @@ class EngViewRaceTable {
                             } else {
                                 return this.getTelemetryRestrictedContent();
                             }
-                        }, ...disableSorting },
+                        }, ...disableSorting
+                    },
                 ],
             },
             {
@@ -542,37 +551,40 @@ class EngViewRaceTable {
                                 const cellContent = cell.getValue() == null ? "N/A"
                                     : formatFloatWithTwoDecimals(cell.getValue());
                                 return this.getSingleLineCell(cellContent);
-                          } else {
-                               return this.getTelemetryRestrictedContent();
-                          }
-                      }, ...disableSorting },
-                  { title: "Per Lap", field: "fuel-info.curr-fuel-rate",
-                      formatter: (cell) => {
+                            } else {
+                                return this.getTelemetryRestrictedContent();
+                            }
+                        }, ...disableSorting
+                    },
+                    { title: "Per Lap", field: "fuel-info.curr-fuel-rate",
+                        formatter: (cell) => {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
                                 const cellContent = cell.getValue() == null
                                     ? "N/A" : formatFloatWithTwoDecimals(cell.getValue());
                                 return this.getSingleLineCell(cellContent);
-                          } else {
-                               return this.getTelemetryRestrictedContent();
-                          }
-                      }, ...disableSorting },
-                  { title: "Est", field: "fuel-info.surplus-laps-png",
-                      formatter: (cell) => {
+                            } else {
+                                return this.getTelemetryRestrictedContent();
+                            }
+                        }, ...disableSorting
+                    },
+                    { title: "Est", field: "fuel-info.surplus-laps-png",
+                        formatter: (cell) => {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
                                 const cellContent = cell.getValue() == null ? "N/A"
                                     : formatFloatWithTwoDecimalsSigned(cell.getValue());
                                 return this.getSingleLineCell(cellContent);
-                           } else {
-                               return this.getTelemetryRestrictedContent();
-                           }
-                       }, ...disableSorting },
-               ],
-           },
-           {
+                            } else {
+                                return this.getTelemetryRestrictedContent();
+                            }
+                        }, ...disableSorting
+                    },
+                ],
+            },
+            {
                 title: 'Damage',
                 headerSort: false,
                 columns: [
@@ -585,30 +597,33 @@ class EngViewRaceTable {
                             } else {
                                 return this.getTelemetryRestrictedContent();
                             }
-                        }, ...disableSorting },
+                        }, ...disableSorting
+                    },
                     { title: "FR", field: "damage-info.fr-wing-damage",
                         formatter: (cell) =>  {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
                                 return this.getSingleLineCell(`${cell.getValue()}%`);
-                           } else {
-                               return this.getTelemetryRestrictedContent();
-                           }
-                       }, ...disableSorting },
-                   { title: "RW", field: "damage-info.rear-wing-damage",
-                       formatter: (cell) =>  {
+                            } else {
+                                return this.getTelemetryRestrictedContent();
+                            }
+                        }, ...disableSorting
+                    },
+                    { title: "RW", field: "damage-info.rear-wing-damage",
+                        formatter: (cell) =>  {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
                                 return this.getSingleLineCell(`${cell.getValue()}%`);
-                           } else {
-                               return this.getTelemetryRestrictedContent();
-                           }
-                       }, ...disableSorting },
-               ],
-           },
-       ];
+                            } else {
+                                return this.getTelemetryRestrictedContent();
+                            }
+                        }, ...disableSorting
+                    },
+                ],
+            },
+        ];
     }
 
     createPositionStatusCell(position, driverInfo) {
@@ -636,9 +651,13 @@ class EngViewRaceTable {
         row1,
         row2,
         row1Class = 'eng-view-tyre-row-1',
-        row2Class = 'eng-view-tyre-row-2'}) {
+        row2Class = 'eng-view-tyre-row-2',
+        escapeRow1 = true,
+        escapeRow2 = true}) {
 
-        return `<div class='${row1Class}'>${escapeHtml(row1)}</div><div class='${row2Class}'>${escapeHtml(row2)}</div>`;
+        const processedRow1 = escapeRow1 ? escapeHtml(row1) : row1;
+        const processedRow2 = escapeRow2 ? escapeHtml(row2) : row2;
+        return `<div class='${row1Class}'>${processedRow1}</div><div class='${row2Class}'>${processedRow2}</div>`;
     }
 
     update(drivers, isSpectating, eventType, spectatorCarIndex, fastestLapMs, sessionUID) {
@@ -681,7 +700,11 @@ class EngViewRaceTable {
                 // If reference driver changed or new drivers, do full update
                 this.table.setData(newTableData).then(() => {
                     // Force sort by position after full update
-                    this.table.setSort("position", "asc");
+                    if (this.table && typeof this.table.setSort === 'function') {
+                        this.table.setSort("position", "asc");
+                    } else {
+                        console.warn("Tabulator table or setSort function not available for sorting.");
+                    }
 
                     setTimeout(() => {
                         this.table.rowManager.element.scrollTop = scrollPosTop;
@@ -714,7 +737,11 @@ class EngViewRaceTable {
                 if (rowsToUpdate.length > 0) {
                     this.table.updateOrAddData(rowsToUpdate).then(() => {
                         // Force sort by position after update
-                        this.table.setSort("position", "asc");
+                        if (this.table && typeof this.table.setSort === 'function') {
+                            this.table.setSort("position", "asc");
+                        } else {
+                            console.warn("Tabulator table or setSort function not available for sorting after update.");
+                        }
 
                         // Restore scroll position after a short delay to ensure sorting is complete
                         setTimeout(() => {
@@ -804,8 +831,9 @@ class EngViewRaceTable {
         return this.getSingleLineCell(this.TELEMETRY_DISABLED_TEXT);
     }
 
-    getSingleLineCell(value) {
-        return `<div class="single-line-cell">${escapeHtml(value)}</div>`;
+    getSingleLineCell(value, escape = true) {
+        const processedValue = escape ? escapeHtml(value) : value;
+        return `<div class="single-line-cell">${processedValue}</div>`;
     }
 
     clear() {

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -94,20 +94,148 @@ class EngViewRaceTable {
                 title: 'Best Lap',
                 headerSort: false,
                 columns: [
-                    { title: "Lap", field: "lap-info.best-lap.lap-time-ms", formatter: (cell) => formatLapTime(cell.getValue()), ...disableSorting },
-                    { title: "S1", field: "lap-info.best-lap.s1-time-ms", formatter: (cell) => formatSectorTime(cell.getValue()), ...disableSorting },
-                    { title: "S2", field: "lap-info.best-lap.s2-time-ms", formatter: (cell) => formatSectorTime(cell.getValue()), ...disableSorting },
-                    { title: "S3", field: "lap-info.best-lap.s3-time-ms", formatter: (cell) => formatSectorTime(cell.getValue()), ...disableSorting },
+                    {
+                        title: "Lap",
+                        field: "lap-info.best-lap",
+                        formatter: (cell) => {
+                            const lapInfo = cell.getValue();
+                            const driverInfo = cell.getRow().getData();
+                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const formattedTime = formatLapTime(lapInfo["lap-time-ms"]);
+
+                            if (isReferenceDriver) {
+                                return `<div>${formattedTime}</div>`;
+                            }
+                            const delta = lapInfo["lap-time-ms"] - lapInfo["lap-time-ms-player"];
+                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                        },
+                        ...disableSorting
+                    },
+                    {
+                        title: "S1",
+                        field: "lap-info.best-lap",
+                        formatter: (cell) => {
+                            const lapInfo = cell.getValue();
+                            const driverInfo = cell.getRow().getData();
+                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const formattedTime = formatSectorTime(lapInfo["s1-time-ms"]);
+
+                            if (isReferenceDriver) {
+                                return `<div>${formattedTime}</div>`;
+                            }
+                            const delta = lapInfo["s1-time-ms"] - lapInfo["s1-time-ms-player"];
+                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                        },
+                        ...disableSorting
+                    },
+                    {
+                        title: "S2",
+                        field: "lap-info.best-lap",
+                        formatter: (cell) => {
+                            const lapInfo = cell.getValue();
+                            const driverInfo = cell.getRow().getData();
+                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const formattedTime = formatSectorTime(lapInfo["s2-time-ms"]);
+
+                            if (isReferenceDriver) {
+                                return `<div>${formattedTime}</div>`;
+                            }
+                            const delta = lapInfo["s2-time-ms"] - lapInfo["s2-time-ms-player"];
+                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                        },
+                        ...disableSorting
+                    },
+                    {
+                        title: "S3",
+                        field: "lap-info.best-lap",
+                        formatter: (cell) => {
+                            const lapInfo = cell.getValue();
+                            const driverInfo = cell.getRow().getData();
+                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const formattedTime = formatSectorTime(lapInfo["s3-time-ms"]);
+
+                            if (isReferenceDriver) {
+                                return `<div>${formattedTime}</div>`;
+                            }
+                            const delta = lapInfo["s3-time-ms"] - lapInfo["s3-time-ms-player"];
+                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                        },
+                        ...disableSorting
+                    },
                 ],
             },
             {
                 title: 'Last Lap',
                 headerSort: false,
                 columns: [
-                    { title: "Lap", field: "lap-info.last-lap.lap-time-ms", formatter: (cell) => formatLapTime(cell.getValue()), ...disableSorting },
-                    { title: "S1", field: "lap-info.last-lap.s1-time-ms", formatter: (cell) => formatSectorTime(cell.getValue()), ...disableSorting },
-                    { title: "S2", field: "lap-info.last-lap.s2-time-ms", formatter: (cell) => formatSectorTime(cell.getValue()), ...disableSorting },
-                    { title: "S3", field: "lap-info.last-lap.s3-time-ms", formatter: (cell) => formatSectorTime(cell.getValue()), ...disableSorting },
+                    {
+                        title: "Lap",
+                        field: "lap-info.last-lap",
+                        formatter: (cell) => {
+                            const lapInfo = cell.getValue();
+                            const driverInfo = cell.getRow().getData();
+                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const formattedTime = formatLapTime(lapInfo["lap-time-ms"]);
+
+                            if (isReferenceDriver) {
+                                return `<div>${formattedTime}</div>`;
+                            }
+                            const delta = lapInfo["lap-time-ms"] - lapInfo["lap-time-ms-player"];
+                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                        },
+                        ...disableSorting
+                    },
+                    {
+                        title: "S1",
+                        field: "lap-info.last-lap",
+                        formatter: (cell) => {
+                            const lapInfo = cell.getValue();
+                            const driverInfo = cell.getRow().getData();
+                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const formattedTime = formatSectorTime(lapInfo["s1-time-ms"]);
+
+                            if (isReferenceDriver) {
+                                return `<div>${formattedTime}</div>`;
+                            }
+                            const delta = lapInfo["s1-time-ms"] - lapInfo["s1-time-ms-player"];
+                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                        },
+                        ...disableSorting
+                    },
+                    {
+                        title: "S2",
+                        field: "lap-info.last-lap",
+                        formatter: (cell) => {
+                            const lapInfo = cell.getValue();
+                            const driverInfo = cell.getRow().getData();
+                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const formattedTime = formatSectorTime(lapInfo["s2-time-ms"]);
+
+                            if (isReferenceDriver) {
+                                return `<div>${formattedTime}</div>`;
+                            }
+                            const delta = lapInfo["s2-time-ms"] - lapInfo["s2-time-ms-player"];
+                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                        },
+                        ...disableSorting
+                    },
+                    {
+                        title: "S3",
+                        field: "lap-info.last-lap",
+                        formatter: (cell) => {
+                            const lapInfo = cell.getValue();
+                            const driverInfo = cell.getRow().getData();
+                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const formattedTime = formatSectorTime(lapInfo["s3-time-ms"]);
+
+                            if (isReferenceDriver) {
+                                return `<div>${formattedTime}</div>`;
+                            }
+                            const delta = lapInfo["s3-time-ms"] - lapInfo["s3-time-ms-player"];
+                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                        },
+                        ...disableSorting
+                    },
                 ],
             },
             {
@@ -392,73 +520,55 @@ function initDashboard() {
     const raceStatsModal = false;
     const settingsModal = false;
     window.modalManager = new ModalManager(driverModal, raceStatsModal, settingsModal);
+
+    const connectStart = Date.now();
+    const socketio = io(`${location.protocol}//${location.hostname}:${location.port}`, {
+        reconnection: true,
+        reconnectionAttempts: 5,
+        reconnectionDelay: 500,
+        reconnectionDelayMax: 3000,
+        randomizationFactor: 0.3,
+        timeout: 7000,
+        transports: ['websocket', 'polling'],
+        upgrade: true,
+        rememberUpgrade: true,
+        secure: location.protocol === 'https:',
+    });
+
+    socketio.on('connect', () => {
+        socketio.emit('register-client', { type: 'race-table' });
+        console.log(`⏱️ Socket connected in ${Date.now() - connectStart}ms`);
+    });
+
+    socketio.on('connect_error', (err) => {
+        console.warn('❌ Socket connection error:', err.message);
+    });
+
+    socketio.on('reconnect_attempt', attempt => {
+        console.log(`🔁 Reconnection attempt ${attempt}`);
+    });
+
+    socketio.on('race-table-update', (binaryData) => {
+        let data;
+        try {
+            data = window.msgpack.decode(new Uint8Array(binaryData));
+        } catch (err) {
+            console.error('Failed to decode race-table-update:', err);
+            return;
+        }
+
+        const { "table-entries": tableEntries, "is-spectating": isSpectating, "event-type": eventType, "spectator-car-index": spectatorCarIndex } = data;
+
+        if (tableEntries || eventType === "Time Trial") {
+            raceTable.update(tableEntries, isSpectating, eventType, spectatorCarIndex);
+        }
+        raceStatus.update(data);
+        weatherTable.update(data["weather-forecast-samples"]);
+    });
+
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+    [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
 }
 
 // Start the dashboard when the page loads
 document.addEventListener('DOMContentLoaded', initDashboard);
-
-let awaitingResponse = false;
-let timeoutIntervalId;
-let timeoutIntervalMs = 3000;
-let socketio;
-
-const connectStart = Date.now();
-socketio = io(`${location.protocol}//${location.hostname}:${location.port}`, {
-    reconnection: true,
-    reconnectionAttempts: 5,         // increased for flakier networks
-    reconnectionDelay: 500,          // base delay
-    reconnectionDelayMax: 3000,      // allow more time for retries
-    randomizationFactor: 0.3,        // more jitter helps on bad links
-    timeout: 7000,                   // wait a bit longer before timing out
-    transports: ['websocket', 'polling'], // try WS, fallback to polling
-    upgrade: true,
-    rememberUpgrade: true,
-    secure: location.protocol === 'https:', // optional: makes intent explicit
-});
-console.log("SocketIO initialized");
-
-// Init tooltips
-const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
-const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
-
-function clearSocketIoRequestTimeout() {
-    awaitingResponse = false;
-    clearInterval(timeoutIntervalId);
-}
-
-socketio.on('connect', function () {
-    socketio.emit('register-client', { type: 'race-table' });
-    console.log(`⏱️ Socket connected in ${Date.now() - connectStart}ms`);
-});
-
-socketio.on('connect_error', (err) => {
-    console.warn('❌ Socket connection error:', err.message);
-});
-
-socketio.on('reconnect_attempt', attempt => {
-    console.log(`🔁 Reconnection attempt ${attempt}`);
-});
-
-// Receive details from server
-socketio.on('race-table-update', function (binaryData) {
-
-    let data;
-    try {
-        data = window.msgpack.decode(new Uint8Array(binaryData));
-    } catch (err) {
-        console.error('Failed to decode race-table-update:', err);
-        return;
-    }
-
-    const tableEntries      = data["table-entries"];
-    const isSpectating      = data["is-spectating"];
-    const eventType         = data["event-type"];
-    const spectatorCarIndex = data["spectator-car-index"];
-    if (tableEntries) {
-        raceTable.update(tableEntries, isSpectating, eventType, spectatorCarIndex);
-    } else if (eventType === "Time Trial") {
-        raceTable.update(tableEntries, isSpectating, eventType, spectatorCarIndex);
-    }
-    raceStatus.update(data);
-    weatherTable.update(data["weather-forecast-samples"]);
-});

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -573,7 +573,7 @@ class EngViewRaceTable {
                             if (telemetryPublic) {
                                 return `${cell.getValue()}%`;
                             } else {
-                                return `<div class="telemetry-restricted" style="background-color:${this.TELEMETRY_DISABLED_COLOUR}; color: white;" title="${this.TELEMETRY_DISABLED_TEXT}">---</div>`;
+                                return `<div class="single-line-cell" style="background-color:${this.TELEMETRY_DISABLED_COLOUR}; color: white;" title="${this.TELEMETRY_DISABLED_TEXT}">---</div>`;
                             }
                         }, ...disableSorting },
                     { title: "FR", field: "damage-info.fr-wing-damage",
@@ -669,7 +669,8 @@ class EngViewRaceTable {
     }
 
     getTelemetryRestrictedContent() {
-        return `<div class="telemetry-restricted" style="background-color:${this.TELEMETRY_DISABLED_COLOUR}; color: white;" data-bs-toggle="tooltip" data-bs-title="${this.TELEMETRY_DISABLED_TEXT}">---</div>`;
+        return `<div class="single-line-cell" style="background-color:${this.TELEMETRY_DISABLED_COLOUR};
+                color: white;">N/A</div>`;
     }
 
     clear() {

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -388,7 +388,10 @@ class EngViewRaceTable {
                         formatter: (cell) => {
                             const tyreInfo = cell.getRow().getData()["tyre-info"];
                             const predictionLap = g_engView_predLapNum;
-                            const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
+                            const predictedTyreWearInfo = (predictionLap)
+                                                            ? (tyreInfo["wear-prediction"]["predictions"].find(
+                                                                p => p["lap-number"] === predictionLap))
+                                                            : (null);
                             const currTyreWearInfo = tyreInfo["current-wear"];
                             return this.createMultiLineCell({
                                 row1: (formatFloatWithTwoDecimals(currTyreWearInfo["front-left-wear"]) + '%'),
@@ -405,7 +408,10 @@ class EngViewRaceTable {
                         formatter: (cell) => {
                             const tyreInfo = cell.getRow().getData()["tyre-info"];
                             const predictionLap = g_engView_predLapNum;
-                            const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
+                            const predictedTyreWearInfo = (predictionLap)
+                                                            ? (tyreInfo["wear-prediction"]["predictions"].find(
+                                                                p => p["lap-number"] === predictionLap))
+                                                            : (null);
                             const currTyreWearInfo = tyreInfo["current-wear"];
                             return this.createMultiLineCell({
                                 row1: (formatFloatWithTwoDecimals(currTyreWearInfo["front-left-wear"]) + '%'),
@@ -422,7 +428,10 @@ class EngViewRaceTable {
                         formatter: (cell) => {
                             const tyreInfo = cell.getRow().getData()["tyre-info"];
                             const predictionLap = g_engView_predLapNum;
-                            const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
+                            const predictedTyreWearInfo = (predictionLap)
+                                                            ? (tyreInfo["wear-prediction"]["predictions"].find(
+                                                                p => p["lap-number"] === predictionLap))
+                                                            : (null);
                             const currTyreWearInfo = tyreInfo["current-wear"];
                             return this.createMultiLineCell({
                                 row1: (formatFloatWithTwoDecimals(currTyreWearInfo["front-left-wear"]) + '%'),
@@ -439,7 +448,10 @@ class EngViewRaceTable {
                         formatter: (cell) => {
                             const tyreInfo = cell.getRow().getData()["tyre-info"];
                             const predictionLap = g_engView_predLapNum;
-                            const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
+                            const predictedTyreWearInfo = (predictionLap)
+                                                            ? (tyreInfo["wear-prediction"]["predictions"].find(
+                                                                p => p["lap-number"] === predictionLap))
+                                                            : (null);
                             const currTyreWearInfo = tyreInfo["current-wear"];
                             return this.createMultiLineCell({
                                 row1: (formatFloatWithTwoDecimals(currTyreWearInfo["front-left-wear"]) + '%'),
@@ -457,26 +469,37 @@ class EngViewRaceTable {
                 headerSort: false,
                 columns: [
                     { title: "Avail", field: "ers-info.ers-percent", ...disableSorting },
-                    { title: "Deploy", field: "ers-info.ers-deployed-this-lap", formatter: (cell) => `${formatFloatWithTwoDecimals(cell.getValue())}%`, ...disableSorting },
-                    { title: "Mode", field: "ers-info.ers-mode", formatter: (cell) => getShortERSMode(cell.getValue()), ...disableSorting },
+                    { title: "Deploy", field: "ers-info.ers-deployed-this-lap",
+                        formatter: (cell) => `${formatFloatWithTwoDecimals(cell.getValue())}%`, ...disableSorting },
+                    { title: "Mode", field: "ers-info.ers-mode",
+                        formatter: (cell) => getShortERSMode(cell.getValue()), ...disableSorting },
                 ],
             },
             {
                 title: 'Fuel',
                 headerSort: false,
                 columns: [
-                    { title: "Total", field: "fuel-info.fuel-in-tank", formatter: (cell) => cell.getValue() == null ? "N/A" : formatFloatWithTwoDecimals(cell.getValue()), ...disableSorting },
-                    { title: "Per Lap", field: "fuel-info.curr-fuel-rate", formatter: (cell) => cell.getValue() == null ? "N/A" : formatFloatWithTwoDecimals(cell.getValue()), ...disableSorting },
-                    { title: "Est", field: "fuel-info.surplus-laps-png", formatter: (cell) => cell.getValue() == null ? "N/A" : formatFloatWithTwoDecimalsSigned(cell.getValue()), ...disableSorting },
+                    { title: "Total", field: "fuel-info.fuel-in-tank",
+                        formatter: (cell) => cell.getValue() == null ? "N/A"
+                            : formatFloatWithTwoDecimals(cell.getValue()), ...disableSorting },
+                    { title: "Per Lap", field: "fuel-info.curr-fuel-rate",
+                        formatter: (cell) => cell.getValue() == null
+                            ? "N/A" : formatFloatWithTwoDecimals(cell.getValue()), ...disableSorting },
+                    { title: "Est", field: "fuel-info.surplus-laps-png",
+                        formatter: (cell) => cell.getValue() == null ? "N/A"
+                            : formatFloatWithTwoDecimalsSigned(cell.getValue()), ...disableSorting },
                 ],
             },
             {
                 title: 'Damage',
                 headerSort: false,
                 columns: [
-                    { title: "FL", field: "damage-info.fl-wing-damage", formatter: (cell) => `${cell.getValue()}%`, ...disableSorting },
-                    { title: "FR", field: "damage-info.fr-wing-damage", formatter: (cell) => `${cell.getValue()}%`, ...disableSorting },
-                    { title: "RW", field: "damage-info.rear-wing-damage", formatter: (cell) => `${cell.getValue()}%`, ...disableSorting },
+                    { title: "FL", field: "damage-info.fl-wing-damage",
+                        formatter: (cell) => `${cell.getValue()}%`, ...disableSorting },
+                    { title: "FR", field: "damage-info.fr-wing-damage",
+                        formatter: (cell) => `${cell.getValue()}%`, ...disableSorting },
+                    { title: "RW", field: "damage-info.rear-wing-damage",
+                        formatter: (cell) => `${cell.getValue()}%`, ...disableSorting },
                 ],
             },
         ];
@@ -506,8 +529,8 @@ class EngViewRaceTable {
         row1,
         row2,
         row1Class = 'eng-view-tyre-row-1',
-        row2Class = 'eng-view-tyre-row-2'
-    }) {
+        row2Class = 'eng-view-tyre-row-2'}) {
+
         return `<div class='${row1Class}'>${row1}</div><div class='${row2Class}'>${row2}</div>`;
     }
 

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -1,4 +1,4 @@
-let g_engView_pitLapNum = null;
+let g_engView_predLapNum = null;
 
 function getShortERSMode(mode) {
     switch (mode) {
@@ -438,25 +438,25 @@ class EngViewRaceStatus {
         this.predictionLapInput.addEventListener('input', (e) => {
             let value = parseInt(e.target.value);
             if (!isNaN(value) && value >= e.target.min && value <= e.target.max) {
-                g_engView_pitLapNum = value;
-                console.log('Prediction lap changed to:', g_engView_pitLapNum);
+                g_engView_predLapNum = value;
+                console.log('Prediction lap changed to:', g_engView_predLapNum);
             } else {
                 console.warn('Invalid input: Out of range');
             }
         });
 
         this.predictionPitBtn.addEventListener('click', () => {
-            g_engView_pitLapNum = this.pitLap;
+            g_engView_predLapNum = this.pitLap;
             this.#updatePredLapInputBox();
         });
 
         this.predictionMidBtn.addEventListener('click', () => {
-            g_engView_pitLapNum = this.midLap;
+            g_engView_predLapNum = this.midLap;
             this.#updatePredLapInputBox();
         });
 
         this.predictionLastBtn.addEventListener('click', () => {
-            g_engView_pitLapNum = this.totalLaps;
+            g_engView_predLapNum = this.totalLaps;
             this.#updatePredLapInputBox();
         });
 
@@ -466,8 +466,8 @@ class EngViewRaceStatus {
     }
 
     #updatePredLapInputBox() {
-        this.predictionLapInput.value = g_engView_pitLapNum;
-        console.log("Updated prediction element value", g_engView_pitLapNum);
+        this.predictionLapInput.value = g_engView_predLapNum;
+        console.log("Updated prediction element value", g_engView_predLapNum);
     }
 
     #getSCStatusString(scStatus) {
@@ -511,14 +511,14 @@ class EngViewRaceStatus {
         let shouldUpdatePred = false;
         if (data["total-laps"] != "---" && this.totalLaps != data["total-laps"]) {
             // Set the initial prediction value
-            g_engView_pitLapNum = data["total-laps"];
+            g_engView_predLapNum = data["total-laps"];
             shouldUpdatePred = true;
             this.predictionLastBtn.disabled = false;
         }
 
         if (this.pitLap == null && data["player-pit-window"]) {
             // If the pit window becomes available
-            g_engView_pitLapNum = data["player-pit-window"];
+            g_engView_predLapNum = data["player-pit-window"];
             shouldUpdatePred = true;
             this.predictionPitBtn.disabled = false;
         }

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -328,14 +328,63 @@ class EngViewRaceTable {
                         title: "Lap",
                         field: "tyre-info.tyre-age",
                         formatter: (cell) => {
-                            return `<div class='eng-view-tyre-row-1'>---</div><div class='eng-view-tyre-row-2'>---</div>`;
+                            const predictionLap = g_engView_predLapNum;
+                            return this.createMultiLineCell("cur", (predictionLap) ? (predictionLap) : ("---"));
                         },
                         ...disableSorting
                     },
-                    { title: "FL", field: "tyre-info.current-wear.front-left-wear", formatter: (cell) => `${formatFloatWithTwoDecimals(cell.getValue())}%`, ...disableSorting },
-                    { title: "FR", field: "tyre-info.current-wear.front-right-wear", formatter: (cell) => `${formatFloatWithTwoDecimals(cell.getValue())}%`, ...disableSorting },
-                    { title: "RL", field: "tyre-info.current-wear.rear-left-wear", formatter: (cell) => `${formatFloatWithTwoDecimals(cell.getValue())}%`, ...disableSorting },
-                    { title: "RR", field: "tyre-info.current-wear.rear-right-wear", formatter: (cell) => `${formatFloatWithTwoDecimals(cell.getValue())}%`, ...disableSorting },
+                    {
+                        title: "FL",
+                        field: "tyre-info.current-wear.front-left-wear",
+                        formatter: (cell) => {
+                            const tyreInfo = cell.getRow().getData()["tyre-info"];
+                            const predictionLap = g_engView_predLapNum;
+                            const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
+                            const currTyreWearInfo = tyreInfo["current-wear"];
+                            return this.createMultiLineCell(formatFloatWithTwoDecimals(currTyreWearInfo["front-left-wear"]) + '%',
+                                (predictedTyreWearInfo) ? (formatFloatWithTwoDecimals(predictedTyreWearInfo["front-left-wear"]) + '%') : ('---'))
+                        },
+                        ...disableSorting
+                    },
+                    {
+                        title: "FR",
+                        field: "tyre-info.current-wear.front-right-wear",
+                        formatter: (cell) => {
+                            const tyreInfo = cell.getRow().getData()["tyre-info"];
+                            const predictionLap = g_engView_predLapNum;
+                            const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
+                            const currTyreWearInfo = tyreInfo["current-wear"];
+                            return this.createMultiLineCell(formatFloatWithTwoDecimals(currTyreWearInfo["front-right-wear"]) + '%',
+                                (predictedTyreWearInfo) ? (formatFloatWithTwoDecimals(predictedTyreWearInfo["front-right-wear"]) + '%') : ('---'))
+                        },
+                        ...disableSorting
+                    },
+                    {
+                        title: "RL",
+                        field: "tyre-info.current-wear.rear-left-wear",
+                        formatter: (cell) => {
+                            const tyreInfo = cell.getRow().getData()["tyre-info"];
+                            const predictionLap = g_engView_predLapNum;
+                            const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
+                            const currTyreWearInfo = tyreInfo["current-wear"];
+                            return this.createMultiLineCell(formatFloatWithTwoDecimals(currTyreWearInfo["rear-left-wear"]) + '%',
+                                (predictedTyreWearInfo) ? (formatFloatWithTwoDecimals(predictedTyreWearInfo["rear-left-wear"]) + '%') : ('---'))
+                        },
+                        ...disableSorting
+                    },
+                    {
+                        title: "RR",
+                        field: "tyre-info.current-wear.rear-right-wear",
+                        formatter: (cell) => {
+                            const tyreInfo = cell.getRow().getData()["tyre-info"];
+                            const predictionLap = g_engView_predLapNum;
+                            const predictedTyreWearInfo = (predictionLap) ? (tyreInfo["wear-prediction"]["predictions"].find(p => p["lap-number"] === predictionLap)) : (null);
+                            const currTyreWearInfo = tyreInfo["current-wear"];
+                            return this.createMultiLineCell(formatFloatWithTwoDecimals(currTyreWearInfo["rear-right-wear"]) + '%',
+                                (predictedTyreWearInfo) ? (formatFloatWithTwoDecimals(predictedTyreWearInfo["rear-right-wear"]) + '%') : ('---'))
+                        },
+                        ...disableSorting
+                    },
                 ],
             },
             {
@@ -366,6 +415,10 @@ class EngViewRaceTable {
                 ],
             },
         ];
+    }
+
+    createMultiLineCell(row1, row2) {
+        return `<div class='eng-view-tyre-row-1'>${row1}</div><div class='eng-view-tyre-row-2'>${row2}</div>`;
     }
 
     update(drivers, isSpectating, eventType, spectatorCarIndex) {

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -245,7 +245,7 @@ class EngViewRaceTable {
                 }
             }
 
-            const timeElement = `<div class="${timeClass}">${formattedTime}</div>`;
+            const timeElement = `<div class="single-line-cell ${timeClass}">${formattedTime}</div>`;
 
             if (isReferenceDriver) {
                 return timeElement;
@@ -267,7 +267,6 @@ class EngViewRaceTable {
 
             if (sectorKey === 'lap') {
                 const formattedTime = formatLapTime(lapInfo[timeKey]);
-                const isValid = lapInfo["is-valid"];
                 const bestLapInfo = driverInfo["lap-info"]["best-lap"];
                 let timeClass = '';
                 if (lapInfo[timeKey] === this.fastestLapMs) {
@@ -275,7 +274,7 @@ class EngViewRaceTable {
                 } else if (lapInfo[timeKey] === bestLapInfo[timeKey]) {
                     timeClass = 'green-time';
                 }
-                const timeElement = `<div class="${timeClass}">${formattedTime}</div>`;
+                const timeElement = `<div class="single-line-cell ${timeClass}">${formattedTime}</div>`;
 
                 if (isReferenceDriver) {
                     return timeElement;
@@ -495,7 +494,7 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
-                                return cell.getValue();
+                                return this.getSingleLineCell(cell.getValue());
                             } else {
                                 return this.getTelemetryRestrictedContent();
                             }
@@ -506,7 +505,7 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
-                                return `${formatFloatWithTwoDecimals(cell.getValue())}%`;
+                                return this.getSingleLineCell(`${formatFloatWithTwoDecimals(cell.getValue())}%`);
                             } else {
                                 return this.getTelemetryRestrictedContent();
                             }
@@ -516,7 +515,7 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
-                                return getShortERSMode(cell.getValue());
+                                return this.getSingleLineCell(getShortERSMode(cell.getValue()));
                             } else {
                                 return this.getTelemetryRestrictedContent();
                             }
@@ -532,8 +531,9 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
-                                return cell.getValue() == null ? "N/A"
+                                const cellContent = cell.getValue() == null ? "N/A"
                                     : formatFloatWithTwoDecimals(cell.getValue());
+                                return this.getSingleLineCell(cellContent);
                           } else {
                                return this.getTelemetryRestrictedContent();
                           }
@@ -543,8 +543,9 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
-                                return cell.getValue() == null
+                                const cellContent = cell.getValue() == null
                                     ? "N/A" : formatFloatWithTwoDecimals(cell.getValue());
+                                this.getSingleLineCell(cellContent);
                           } else {
                                return this.getTelemetryRestrictedContent();
                           }
@@ -554,8 +555,9 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
-                                return cell.getValue() == null ? "N/A"
+                                const cellContent = cell.getValue() == null ? "N/A"
                                     : formatFloatWithTwoDecimalsSigned(cell.getValue());
+                                return this.getSingleLineCell(cellContent);
                            } else {
                                return this.getTelemetryRestrictedContent();
                            }
@@ -571,7 +573,7 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
-                                return `${cell.getValue()}%`;
+                                return this.getSingleLineCell(`${cell.getValue()}%`);
                             } else {
                                 return this.getTelemetryRestrictedContent();
                             }
@@ -581,7 +583,7 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
-                                return `${cell.getValue()}%`;
+                                return this.getSingleLineCell(`${cell.getValue()}%`);
                            } else {
                                return this.getTelemetryRestrictedContent();
                            }
@@ -591,7 +593,7 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const telemetryPublic = driverInfo["driver-info"]["telemetry-setting"] === "Public";
                             if (telemetryPublic) {
-                                return `${cell.getValue()}%`;
+                                return this.getSingleLineCell(`${cell.getValue()}%`);
                            } else {
                                return this.getTelemetryRestrictedContent();
                            }
@@ -671,6 +673,10 @@ class EngViewRaceTable {
     getTelemetryRestrictedContent() {
         return `<div class="single-line-cell" style="background-color:${this.TELEMETRY_DISABLED_COLOUR};
                 color: white;">N/A</div>`;
+    }
+
+    getSingleLineCell(value) {
+        return `<div class="single-line-cell">${value}</div>`;
     }
 
     clear() {

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -51,7 +51,7 @@ class EngViewRaceTable {
                 field: "name",
                 formatter: (cell, formatterParams, onRendered) => {
                     const data = cell.getRow().getData();
-                    return `${data.name}<br><span class="text-muted">${data.team}</span>`;
+                    return `<div class='eng-view-tyre-row-1'>${data.name}</div><div class='eng-view-tyre-row-2'>${data.team}</div>`;
                 },
                 cellClick: (e, cell) => {
                     const data = cell.getRow().getData();
@@ -74,9 +74,9 @@ class EngViewRaceTable {
                     const deltaToCarInFront = deltaInfo["delta-to-car-in-front"] / 1000;
                     const deltaToLeader = deltaInfo["delta-to-leader"] / 1000;
                     if (position == 1) {
-                        return `Interval<br>Leader`;
+                        return `<div class='eng-view-tyre-row-1'>Interval</div><div class='eng-view-tyre-row-2'>Leader</div>`;
                     }
-                    return `${formatFloatWithThreeDecimalsSigned(deltaToCarInFront)}<br>${formatFloatWithThreeDecimalsSigned(deltaToLeader)}`;
+                    return `<div class='eng-view-tyre-row-1'>${formatFloatWithThreeDecimalsSigned(deltaToCarInFront)}</div><div class='eng-view-tyre-row-2'>${formatFloatWithThreeDecimalsSigned(deltaToLeader)}</div>`;
                 },
                 ...disableSorting
             },
@@ -91,6 +91,35 @@ class EngViewRaceTable {
                 ],
             },
             {
+                title: 'Status',
+                headerSort: false,
+                columns: [
+                    {
+                        title: "DRS",
+                        field: "drs-status",
+                        formatter: cell => {
+                            const drsStatus = cell.getValue();
+                            if (drsStatus === 'NOT_ALLOWED') return `<span class="drs-not-available">DRS</span>`;
+                            if (drsStatus === 'ALLOWED') return `<span class="drs-available">DRS</span>`;
+                            if (drsStatus === 'ACTIVE') return `<span class="drs-active">DRS</span>`;
+                            return '---';
+                        },
+                        ...disableSorting
+                    },
+                    {
+                        title: "Pit",
+                        field: "pit-status",
+                        formatter: cell => {
+                            const pitStatus = cell.getValue();
+                            if (pitStatus === 'PITTING') return `<span class="driver-pitting">PIT</span>`;
+                            if (pitStatus === 'IN_GARAGE') return `<span class="driver-pitting">GARAGE</span>`;
+                            return '---';
+                        },
+                        ...disableSorting
+                    },
+                ],
+            },
+            {
                 title: 'Best Lap',
                 headerSort: false,
                 columns: [
@@ -102,12 +131,20 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
                             const formattedTime = formatLapTime(lapInfo["lap-time-ms"]);
+                            const fastestLap = lapInfo["fastest-lap"];
+                            const sessionFastestLap = lapInfo["session-fastest-lap"];
+
+                            let timeClass = '';
+                            if (fastestLap) timeClass = 'green-time';
+                            if (sessionFastestLap) timeClass = 'purple-time';
+
+                            const timeElement = `<div class="${timeClass}">${formattedTime}</div>`;
 
                             if (isReferenceDriver) {
-                                return `<div>${formattedTime}</div>`;
+                                return timeElement;
                             }
                             const delta = lapInfo["lap-time-ms"] - lapInfo["lap-time-ms-player"];
-                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
                         },
                         ...disableSorting
                     },
@@ -119,12 +156,20 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
                             const formattedTime = formatSectorTime(lapInfo["s1-time-ms"]);
+                            const fastestS1 = lapInfo["fastest-s1"];
+                            const sessionFastestS1 = lapInfo["session-fastest-s1"];
+
+                            let timeClass = '';
+                            if (fastestS1) timeClass = 'green-time';
+                            if (sessionFastestS1) timeClass = 'purple-time';
+
+                            const timeElement = `<div class="${timeClass}">${formattedTime}</div>`;
 
                             if (isReferenceDriver) {
-                                return `<div>${formattedTime}</div>`;
+                                return timeElement;
                             }
                             const delta = lapInfo["s1-time-ms"] - lapInfo["s1-time-ms-player"];
-                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
                         },
                         ...disableSorting
                     },
@@ -136,12 +181,20 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
                             const formattedTime = formatSectorTime(lapInfo["s2-time-ms"]);
+                            const fastestS2 = lapInfo["fastest-s2"];
+                            const sessionFastestS2 = lapInfo["session-fastest-s2"];
+
+                            let timeClass = '';
+                            if (fastestS2) timeClass = 'green-time';
+                            if (sessionFastestS2) timeClass = 'purple-time';
+
+                            const timeElement = `<div class="${timeClass}">${formattedTime}</div>`;
 
                             if (isReferenceDriver) {
-                                return `<div>${formattedTime}</div>`;
+                                return timeElement;
                             }
                             const delta = lapInfo["s2-time-ms"] - lapInfo["s2-time-ms-player"];
-                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
                         },
                         ...disableSorting
                     },
@@ -153,12 +206,20 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
                             const formattedTime = formatSectorTime(lapInfo["s3-time-ms"]);
+                            const fastestS3 = lapInfo["fastest-s3"];
+                            const sessionFastestS3 = lapInfo["session-fastest-s3"];
+
+                            let timeClass = '';
+                            if (fastestS3) timeClass = 'green-time';
+                            if (sessionFastestS3) timeClass = 'purple-time';
+
+                            const timeElement = `<div class="${timeClass}">${formattedTime}</div>`;
 
                             if (isReferenceDriver) {
-                                return `<div>${formattedTime}</div>`;
+                                return timeElement;
                             }
                             const delta = lapInfo["s3-time-ms"] - lapInfo["s3-time-ms-player"];
-                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
                         },
                         ...disableSorting
                     },
@@ -176,12 +237,14 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
                             const formattedTime = formatLapTime(lapInfo["lap-time-ms"]);
+                            const isValid = lapInfo["is-valid"];
+                            const timeElement = `<div class="${!isValid ? 'red-time' : ''}">${formattedTime}</div>`;
 
                             if (isReferenceDriver) {
-                                return `<div>${formattedTime}</div>`;
+                                return timeElement;
                             }
                             const delta = lapInfo["lap-time-ms"] - lapInfo["lap-time-ms-player"];
-                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
                         },
                         ...disableSorting
                     },
@@ -193,12 +256,20 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
                             const formattedTime = formatSectorTime(lapInfo["s1-time-ms"]);
+                            const fastestS1 = lapInfo["fastest-s1"];
+                            const sessionFastestS1 = lapInfo["session-fastest-s1"];
+
+                            let timeClass = '';
+                            if (fastestS1) timeClass = 'green-time';
+                            if (sessionFastestS1) timeClass = 'purple-time';
+
+                            const timeElement = `<div class="${timeClass}">${formattedTime}</div>`;
 
                             if (isReferenceDriver) {
-                                return `<div>${formattedTime}</div>`;
+                                return timeElement;
                             }
                             const delta = lapInfo["s1-time-ms"] - lapInfo["s1-time-ms-player"];
-                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
                         },
                         ...disableSorting
                     },
@@ -210,12 +281,20 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
                             const formattedTime = formatSectorTime(lapInfo["s2-time-ms"]);
+                            const fastestS2 = lapInfo["fastest-s2"];
+                            const sessionFastestS2 = lapInfo["session-fastest-s2"];
+
+                            let timeClass = '';
+                            if (fastestS2) timeClass = 'green-time';
+                            if (sessionFastestS2) timeClass = 'purple-time';
+
+                            const timeElement = `<div class="${timeClass}">${formattedTime}</div>`;
 
                             if (isReferenceDriver) {
-                                return `<div>${formattedTime}</div>`;
+                                return timeElement;
                             }
                             const delta = lapInfo["s2-time-ms"] - lapInfo["s2-time-ms-player"];
-                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
                         },
                         ...disableSorting
                     },
@@ -227,12 +306,20 @@ class EngViewRaceTable {
                             const driverInfo = cell.getRow().getData();
                             const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
                             const formattedTime = formatSectorTime(lapInfo["s3-time-ms"]);
+                            const fastestS3 = lapInfo["fastest-s3"];
+                            const sessionFastestS3 = lapInfo["session-fastest-s3"];
+
+                            let timeClass = '';
+                            if (fastestS3) timeClass = 'green-time';
+                            if (sessionFastestS3) timeClass = 'purple-time';
+
+                            const timeElement = `<div class="${timeClass}">${formattedTime}</div>`;
 
                             if (isReferenceDriver) {
-                                return `<div>${formattedTime}</div>`;
+                                return timeElement;
                             }
                             const delta = lapInfo["s3-time-ms"] - lapInfo["s3-time-ms-player"];
-                            return `<div>${formattedTime}</div><div>${formatDelta(delta)}</div>`;
+                            return `<div class='eng-view-tyre-row-1'>${timeElement}</div><div class='eng-view-tyre-row-2'>${formatDelta(delta)}</div>`;
                         },
                         ...disableSorting
                     },

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -58,7 +58,17 @@ class EngViewRaceTable {
     getColumnDefinitions() {
         const disableSorting = { headerSort: false };
         return [
-            { title: "Pos", field: "position", width: 40, ...disableSorting },
+            {
+                title: "Pos",
+                field: "position",
+                width: 40,
+                formatter: (cell) => {
+                    const driverInfo = cell.getRow().getData();
+                    const position = driverInfo.position;
+                    return this.createPositionStatusCell(position, driverInfo["driver-info"]);
+                },
+                ...disableSorting
+            },
             {
                 title: "Name",
                 field: "name",
@@ -417,8 +427,28 @@ class EngViewRaceTable {
         ];
     }
 
-    createMultiLineCell(row1, row2) {
-        return `<div class='eng-view-tyre-row-1'>${row1}</div><div class='eng-view-tyre-row-2'>${row2}</div>`;
+    createPositionStatusCell(position, driverInfo) {
+        let statusClass = '';
+        let statusText = 'DRS';
+        if (driverInfo["is-pitting"]) {
+            statusText = 'PIT';
+            statusClass = 'driver-pitting';
+        }
+        else if (driverInfo["drs-activated"]) {
+            statusClass = 'drs-active';
+        } else if (driverInfo["drs-allowed"] || driverInfo["drs-distance"]) {
+            statusClass = 'drs-available';
+        } else {
+            statusClass = 'drs-not-available';
+        }
+        return `
+            <div class="eng-view-tyre-row-1">${position}</div>
+            <div class="${statusClass}">${statusText}</div>
+        `;
+    }
+
+    createMultiLineCell(row1, row2, row1Class='eng-view-tyre-row-1', row2Class='eng-view-tyre-row-2') {
+        return `<div class='${row1Class}'>${row1}</div><div class='${row2Class}'>${row2}</div>`;
     }
 
     update(drivers, isSpectating, eventType, spectatorCarIndex) {

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -645,7 +645,7 @@ class EngViewRaceTable {
 
         if (eventType === "Time Trial") {
             this.table.clearData();
-            this.table.placeholder = "Time Trial not supported in Engineer View";
+            this.table.options.placeholder = "Time Trial not supported in Engineer View";
             return;
         }
 

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -329,8 +329,25 @@ class EngViewRaceTable {
                 title: 'Tyre Wear',
                 headerSort: false,
                 columns: [
-                    { title: "Comp", field: "tyre-info.visual-tyre-compound", formatter: (cell) => this.iconCache.getIcon(cell.getValue()).outerHTML, ...disableSorting },
-                    { title: "Lap", field: "tyre-info.tyre-age", ...disableSorting },
+                    {
+                        title: "Comp",
+                        field: "tyre-info.visual-tyre-compound",
+                        formatter: (cell) => {
+                            const tyreInfo = cell.getRow().getData()["tyre-info"];
+                            const tyreIcon = this.iconCache.getIcon(tyreInfo["visual-tyre-compound"]).outerHTML;
+                            const agePitInfoStr = `${tyreInfo["tyre-age"]} L (${tyreInfo["num-pitstops"]} pit)`;
+                            return `<div class='eng-view-tyre-row-1'>${tyreIcon}</div><div class='eng-view-tyre-row-2'>${agePitInfoStr}</div>`;
+                        },
+                        ...disableSorting
+                    },
+                    {
+                        title: "Lap",
+                        field: "tyre-info.tyre-age",
+                        formatter: (cell) => {
+                            return `<div class='eng-view-tyre-row-1'>---</div><div class='eng-view-tyre-row-2'>---</div>`;
+                        },
+                        ...disableSorting
+                    },
                     { title: "FL", field: "tyre-info.current-wear.front-left-wear", formatter: (cell) => `${formatFloatWithTwoDecimals(cell.getValue())}%`, ...disableSorting },
                     { title: "FR", field: "tyre-info.current-wear.front-right-wear", formatter: (cell) => `${formatFloatWithTwoDecimals(cell.getValue())}%`, ...disableSorting },
                     { title: "RL", field: "tyre-info.current-wear.rear-left-wear", formatter: (cell) => `${formatFloatWithTwoDecimals(cell.getValue())}%`, ...disableSorting },

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -104,35 +104,6 @@ class EngViewRaceTable {
                 ],
             },
             {
-                title: 'Status',
-                headerSort: false,
-                columns: [
-                    {
-                        title: "DRS",
-                        field: "drs-status",
-                        formatter: cell => {
-                            const drsStatus = cell.getValue();
-                            if (drsStatus === 'NOT_ALLOWED') return `<span class="drs-not-available">DRS</span>`;
-                            if (drsStatus === 'ALLOWED') return `<span class="drs-available">DRS</span>`;
-                            if (drsStatus === 'ACTIVE') return `<span class="drs-active">DRS</span>`;
-                            return '---';
-                        },
-                        ...disableSorting
-                    },
-                    {
-                        title: "Pit",
-                        field: "pit-status",
-                        formatter: cell => {
-                            const pitStatus = cell.getValue();
-                            if (pitStatus === 'PITTING') return `<span class="driver-pitting">PIT</span>`;
-                            if (pitStatus === 'IN_GARAGE') return `<span class="driver-pitting">GARAGE</span>`;
-                            return '---';
-                        },
-                        ...disableSorting
-                    },
-                ],
-            },
-            {
                 title: 'Best Lap',
                 headerSort: false,
                 columns: [

--- a/apps/frontend/js/iconCache.js
+++ b/apps/frontend/js/iconCache.js
@@ -22,7 +22,7 @@ class IconCache {
                 }
                 const svgText = await response.text();
                 this.cache[key] = svgText;
-                console.log("Successfully fetched icon", key);
+                console.debug("Successfully fetched icon", key);
             } catch (error) {
                 console.error(`Failed to load icon for ${key}:`, error);
             }

--- a/apps/save_viewer/save_viewer_state/get_telemetry_info.py
+++ b/apps/save_viewer/save_viewer_state/get_telemetry_info.py
@@ -140,6 +140,7 @@ def _get_empty_telemetry_info() -> Dict[str, Any]:
         "current-lap": "---",
         "event-type": "---", # for backward compatibility
         "session-type": "---",
+        "session-uid": None,
         "fastest-lap-overall": 0,
         "fastest-lap-overall-driver": "---",
         "pit-speed-limit": 0,
@@ -167,6 +168,7 @@ def _get_base_rsp_dict(json_data: Dict[str, Any]) -> Dict[str, Any]:
         "air-temperature": json_data["session-info"]["air-temperature"],
         "event-type": json_data["session-info"]["session-type"],
         "session-type": json_data["session-info"]["session-type"],
+        "session-uid": 0, # not important
         "session-time-left": 0,
         "total-laps": json_data["session-info"]["total-laps"],
         "current-lap": json_data["classification-data"][0]["lap-data"]["current-lap-num"],

--- a/apps/save_viewer/save_viewer_state/get_telemetry_info.py
+++ b/apps/save_viewer/save_viewer_state/get_telemetry_info.py
@@ -140,7 +140,6 @@ def _get_empty_telemetry_info() -> Dict[str, Any]:
         "current-lap": "---",
         "event-type": "---", # for backward compatibility
         "session-type": "---",
-        "session-uid": None,
         "fastest-lap-overall": 0,
         "fastest-lap-overall-driver": "---",
         "pit-speed-limit": 0,
@@ -168,7 +167,6 @@ def _get_base_rsp_dict(json_data: Dict[str, Any]) -> Dict[str, Any]:
         "air-temperature": json_data["session-info"]["air-temperature"],
         "event-type": json_data["session-info"]["session-type"],
         "session-type": json_data["session-info"]["session-type"],
-        "session-uid": 0, # ID not relevant for save viewer
         "session-time-left": 0,
         "total-laps": json_data["session-info"]["total-laps"],
         "current-lap": json_data["classification-data"][0]["lap-data"]["current-lap-num"],

--- a/apps/save_viewer/save_viewer_state/get_telemetry_info.py
+++ b/apps/save_viewer/save_viewer_state/get_telemetry_info.py
@@ -140,6 +140,7 @@ def _get_empty_telemetry_info() -> Dict[str, Any]:
         "current-lap": "---",
         "event-type": "---", # for backward compatibility
         "session-type": "---",
+        "session-uid": None,
         "fastest-lap-overall": 0,
         "fastest-lap-overall-driver": "---",
         "pit-speed-limit": 0,
@@ -167,6 +168,7 @@ def _get_base_rsp_dict(json_data: Dict[str, Any]) -> Dict[str, Any]:
         "air-temperature": json_data["session-info"]["air-temperature"],
         "event-type": json_data["session-info"]["session-type"],
         "session-type": json_data["session-info"]["session-type"],
+        "session-uid": 0, # ID not relevant for save viewer
         "session-time-left": 0,
         "total-laps": json_data["session-info"]["total-laps"],
         "current-lap": json_data["classification-data"][0]["lap-data"]["current-lap-num"],

--- a/docs/RUNNING.md
+++ b/docs/RUNNING.md
@@ -52,7 +52,7 @@ poetry run python -m apps.backend
 ### 🛠 Dev Tools (e.g., telemetry replayer)
 
 ```bash
-poetry run python -m apps.dev.telemetry_replayer --file-name example.f1pcap
+poetry run python -m apps.dev_tools.telemetry_replayer --file-name example.f1pcap
 ```
 
 ---

--- a/lib/port_check.py
+++ b/lib/port_check.py
@@ -32,9 +32,9 @@ def is_port_available(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         # Disable socket options that allow re-binding on macOS/Linux
         if platform.system() == "Windows":
+            # pylint: disable=useless-suppression
             # pylint: disable=no-member
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
-
         try:
             sock.bind(('0.0.0.0', port))
             return True


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Migrating engineer view race table to tabulator library.
Now supports column reordering, resizing and column enable/disable

Fixes #19 #50 

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Unit Tests

- [x] All unit tests pass
- Attach test command/output:

```
----------------------------------------------------------------------
Ran 327 tests in 17.345s

OK
```

To run the unit test suite
```bash
poetry run python tests/unit_tests.py
```

### ✅ Integration Tests

* [x] All integration tests pass
* Attach test command/output:

```
===== TEST RESULTS =====
Passed: 27/27

PASS: f1_23_sp_austria.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_mp_fp_austria_full_spec.f1pcap
PASS: f1_25_mp_fp_jeddah.f1pcap
PASS: f1_25_mp_fp_jeddah_player.f1pcap
PASS: f1_25_mp_fp_jeddah_player_2.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_mp_quali_sprint_austria_spec.f1pcap
PASS: f1_25_mp_race_japan_spec.f1pcap
PASS: f1_25_mp_race_jeddah.f1pcap
PASS: f1_25_mp_solo_afk_fp_aus.f1pcap
PASS: f1_25_sp_aus_5lap_1stop.f1pcap
PASS: f1_25_sp_aus_5lap_1stop_flashback.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_sp_baku_mid_session_save_load.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_sp_imola_5lap_1stop.f1pcap
PASS: f1_25_sp_qatar_flashback_1stop.f1pcap
PASS: f1_25_sp_qatar_partial.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
Total time: 11:11.568
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

### ✅ Pylint

* [x] Code passes `pylint`
* Paste summary report:

```
$ pylint --rcfile scripts/.pylintrc apps lib

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

To run pylint
```bash
pylint --rcfile scripts/.pylintrc lib apps
```

---

## 🧱 `lib/` Directory Changes

* [x] This PR modifies or adds files under `lib/`
* [x] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Use Tabulator.js to fully revamp the engineer view race table, adding drag-and-drop columns, resizing, and hide/show functionality with persisted user preferences, refactor the rendering logic for incremental updates, and propagate session UID from backend for update consistency.

New Features:
- Migrate engineer race table to use Tabulator for rendering
- Add support for column reordering, resizing, and visibility toggling via a settings pane

Enhancements:
- Persist column widths, order, and visibility in localStorage
- Optimize table updates with diff-based updates and scroll position retention
- Upgrade socket.io initialization and include session-uid in updates

Build:
- Include Tabulator JS and CSS assets in the frontend