### PR TITLE
Add current lap time support to Engineer and Driver views

### DIFF
--- a/apps/backend/state_mgmt_layer/data_per_driver/lap_info.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/lap_info.py
@@ -25,7 +25,8 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from lib.f1_types import LapHistoryData, VisualTyreCompound, ResultStatus
+from lib.f1_types import (LapData, LapHistoryData, ResultStatus,
+                          VisualTyreCompound)
 
 # -------------------------------------- GLOBALS -----------------------------------------------------------------------
 
@@ -70,3 +71,26 @@ class LapInfo:
     m_is_pitting: Optional[bool] = None
     m_total_race_time: Optional[float] = None
     m_result_status: Optional[ResultStatus] = None
+    m_curr_lap_s1_ms: Optional[int] = None
+    m_curr_lap_s2_ms: Optional[int] = None
+    m_curr_lap_s3_ms: Optional[int] = None
+    m_curr_lap_ms: Optional[int] = None
+    m_curr_sector: Optional[LapData.Sector] = None
+    m_curr_lap_invalid: Optional[bool] = None
+    m_curr_status: Optional[LapData.DriverStatus] = None
+
+    def processLapDataUpdate(self, lap_data: LapData) -> None:
+        """Update the lap information based on the provided lap data object"""
+        self.m_delta_to_car_in_front = lap_data.m_deltaToCarInFrontInMS
+        self.m_delta_to_leader = (
+            lap_data.m_deltaToRaceLeaderInMS +
+            (lap_data.m_deltaToRaceLeaderMinutes * 60000)
+        )
+
+        self.m_curr_lap_ms = lap_data.m_currentLapTimeInMS
+        self.m_curr_lap_invalid = lap_data.m_currentLapInvalid
+        self.m_curr_status = lap_data.m_driverStatus
+        self.m_curr_sector = lap_data.m_sector
+        self.m_curr_lap_s1_ms = lap_data.s1TimeMS
+        self.m_curr_lap_s2_ms = lap_data.s2TimeMS
+        self.m_curr_lap_s3_ms = lap_data.s3TimeMS

--- a/apps/backend/state_mgmt_layer/data_per_driver/lap_info.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/lap_info.py
@@ -54,6 +54,13 @@ class LapInfo:
         m_is_pitting (Optional[bool]): Indicates whether the driver is currently in the pit lane.
         m_total_race_time (Optional[float]): Total race time in seconds.
         m_result_status  (Optional[ResultStatus]): The result status of the driver.
+        m_curr_lap_s1_ms (Optional[int]): Current lap sector 1 time in milliseconds.
+        m_curr_lap_s2_ms (Optional[int]): Current lap sector 2 time in milliseconds.
+        m_curr_lap_s3_ms (Optional[int]): Current lap sector 3 time in milliseconds.
+        m_curr_lap_ms (Optional[int]): Current lap time in milliseconds.
+        m_curr_sector (Optional[LapData.Sector]): Current lap sector.
+        m_curr_lap_invalid (Optional[bool]): Current lap validity
+        m_curr_status (Optional[LapData.DriverStatus]): Current lap driver status
     """
     m_best_lap_ms: Optional[int] = None
     m_best_lap_obj: Optional[LapHistoryData] = None

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -486,11 +486,7 @@ class SessionState:
         """
         driver_obj.m_driver_info.position = lap_data.m_carPosition
         driver_obj.m_driver_info.grid_position = lap_data.m_gridPosition
-        driver_obj.m_lap_info.m_delta_to_car_in_front = lap_data.m_deltaToCarInFrontInMS
-        driver_obj.m_lap_info.m_delta_to_leader = (
-            lap_data.m_deltaToRaceLeaderInMS +
-            (lap_data.m_deltaToRaceLeaderMinutes * 60000)
-        )
+        driver_obj.m_lap_info.processLapDataUpdate(lap_data)
 
     def _handleLapChangeLogic(self, driver_obj: DataPerDriver, lap_data: LapData) -> None:
         """Handle lap change detection and snapshot capture

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -1022,6 +1022,7 @@ class DriversListRsp:
             "sector" : str(driver_data.m_lap_info.m_curr_sector),
             "driver-status" : str(driver_data.m_lap_info.m_curr_status),
             "sector-status" : driver_data.getCurrLapSectorStatus(self.m_fastest_s1_ms, self.m_fastest_s2_ms),
+            "lap-num" : driver_data.m_lap_info.m_current_lap,
         }
 
     def _getWarningsPenaltiesJSON(self, driver_data: DataPerDriver) -> Dict[str, Any]:

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -1017,7 +1017,7 @@ class DriversListRsp:
         return {
             "lap-time-ms": driver_data.m_lap_info.m_curr_lap_ms,
             "s1-time-ms": driver_data.m_lap_info.m_curr_lap_s1_ms,
-            "s2-time-ms": driver_data.m_lap_info.m_curr_lap_s1_ms,
+            "s2-time-ms": driver_data.m_lap_info.m_curr_lap_s2_ms,
             "s3-time-ms": driver_data.m_lap_info.m_curr_lap_s3_ms,
             "sector" : str(driver_data.m_lap_info.m_curr_sector),
             "driver-status" : str(driver_data.m_lap_info.m_curr_status),

--- a/apps/backend/state_mgmt_layer/telemetry_web_api.py
+++ b/apps/backend/state_mgmt_layer/telemetry_web_api.py
@@ -966,6 +966,7 @@ class DriversListRsp:
             "current-lap": driver_data.m_lap_info.m_current_lap,
             "last-lap": self._getLapDetailsSubsection(driver_data, for_best_lap=False),
             "best-lap": self._getLapDetailsSubsection(driver_data, for_best_lap=True),
+            "curr-lap": self._getCurrLapSubsection(driver_data),
             "lap-progress": lap_progress,
             "speed-trap-record-kmph": self._getSpeedTrapRecord(driver_data),
             "top-speed-kmph": driver_data.m_lap_info.m_top_speed_kmph_this_lap,
@@ -1009,6 +1010,18 @@ class DriversListRsp:
             "s1-time-ms": s1_time,
             "s2-time-ms": s2_time,
             "s3-time-ms": s3_time,
+        }
+
+    def _getCurrLapSubsection(self, driver_data: DataPerDriver) -> Dict[str, Any]:
+        """Create current lap subsection."""
+        return {
+            "lap-time-ms": driver_data.m_lap_info.m_curr_lap_ms,
+            "s1-time-ms": driver_data.m_lap_info.m_curr_lap_s1_ms,
+            "s2-time-ms": driver_data.m_lap_info.m_curr_lap_s1_ms,
+            "s3-time-ms": driver_data.m_lap_info.m_curr_lap_s3_ms,
+            "sector" : str(driver_data.m_lap_info.m_curr_sector),
+            "driver-status" : str(driver_data.m_lap_info.m_curr_status),
+            "sector-status" : driver_data.getCurrLapSectorStatus(self.m_fastest_s1_ms, self.m_fastest_s2_ms),
         }
 
     def _getWarningsPenaltiesJSON(self, driver_data: DataPerDriver) -> Dict[str, Any]:

--- a/apps/frontend/css/style.css
+++ b/apps/frontend/css/style.css
@@ -206,8 +206,9 @@ body {
 }
 
 .telemetry-table .best-lap,
+.telemetry-table .curr-lap,
 .telemetry-table .last-lap {
-  width: 12%; /* Equal width for "Best Lap" and "Last Lap" */
+  width: 12%; /* Equal width for "Best Lap", "Current Lap" and "Last Lap" */
 }
 
 .telemetry-table th:nth-child(1) { width: 5%; } /* POS */

--- a/apps/frontend/html/driver-view.html
+++ b/apps/frontend/html/driver-view.html
@@ -95,6 +95,7 @@
                 <th>WARNS/PENS</th>
                 <th id="best-lap-th" class="best-lap" data-bs-toggle="tooltip">BEST LAP 🛈</th>
                 <th id="last-lap-th" class="last-lap" data-bs-toggle="tooltip">LAST LAP 🛈</th>
+                <th id="curr-lap-th" class="curr-lap" data-bs-toggle="tooltip">CURRENT LAP</th>
                 <th id="tyre-info-th" data-bs-toggle="tooltip">TYRE INFO 🛈</th>
                 <th id="wear-prediction-th">WEAR PREDICTION</th>
                 <th>WING DAMAGE</th>

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -308,17 +308,15 @@ class EngViewRaceTable {
                 : formatSectorTime(timeMs);
 
             let timeClass = '';
-            if (sectorStatus) {
-                if (sectorKey !== 'lap') {
-                    const sectorIndex = parseInt(sectorKey.slice(1)) - 1;
-                    if (sectorStatus[sectorIndex] === this.GREEN_SECTOR) {
-                        timeClass = 'green-time';
-                    } else if (sectorStatus[sectorIndex] === this.PURPLE_SECTOR) {
-                        timeClass = 'purple-time';
-                    } else if (sectorStatus[sectorIndex] === this.RED_SECTOR) {
-                        timeClass = 'red-time';
-                    }
-                }
+            if (sectorStatus && sectorKey !== 'lap') {
+                  const sectorIndex = parseInt(sectorKey.slice(1)) - 1;
+                  if (sectorStatus[sectorIndex] === this.GREEN_SECTOR) {
+                      timeClass = 'green-time';
+                  } else if (sectorStatus[sectorIndex] === this.PURPLE_SECTOR) {
+                      timeClass = 'purple-time';
+                  } else if (sectorStatus[sectorIndex] === this.RED_SECTOR) {
+                      timeClass = 'red-time';
+                  }
             }
             return this.createSingleLineCell(formattedTime, {className: timeClass});
         };
@@ -859,6 +857,11 @@ class EngViewRaceTable {
         this.spectatorIndex = spectatorCarIndex;
         this.isSpectating = isSpectating;
         this.fastestLapMs = fastestLapMs;
+        if (this.sessionUID !== sessionUID) {
+            // clear the data structures if the session has changed
+            this.previousTableData = [];
+            this.delayedLapData = new Map();
+        }
 
         if (eventType === "Time Trial") {
             if (this.currEventType !== "Time Trial" && this.gridApi) {

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -862,6 +862,7 @@ class EngViewRaceTable {
             this.previousTableData = [];
             this.delayedLapData = new Map();
         }
+        this.sessionUID = sessionUID;
 
         if (eventType === "Time Trial") {
             if (this.currEventType !== "Time Trial" && this.gridApi) {

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -287,12 +287,12 @@ class EngViewRaceTable {
             const driverId = driverInfo.id;
             const delayedData = this.delayedLapData.get(driverId);
             const currentTime = Date.now();
-            const FIVE_SECONDS_MS = 5000;
+            const CURR_LAP_FREEZE_DURATION = 5000; // 5 sec
 
             let lapInfo;
             let sectorStatus;
 
-            if (delayedData && (currentTime - delayedData.timestamp < FIVE_SECONDS_MS)) {
+            if (delayedData && (currentTime - delayedData.timestamp < CURR_LAP_FREEZE_DURATION)) {
                 // Use delayed data
                 lapInfo = delayedData.oldLapData;
                 sectorStatus = lapInfo["sector-status"];

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -279,6 +279,34 @@ class EngViewRaceTable {
         };
     }
 
+    createSectorCellRendererCurrLap(sectorKey, timeKey) {
+        return (params) => {
+            const driverInfo = params.data;
+            const lapInfo = driverInfo["lap-info"]["curr-lap"];
+            const sectorStatus = lapInfo["sector-status"];
+
+            const timeMs = lapInfo[timeKey];
+            const formattedTime = sectorKey === 'lap'
+                ? formatLapTime(timeMs)
+                : formatSectorTime(timeMs);
+
+            let timeClass = '';
+            if (sectorStatus) {
+                if (sectorKey !== 'lap') {
+                    const sectorIndex = parseInt(sectorKey.slice(1)) - 1;
+                    if (sectorStatus[sectorIndex] === this.GREEN_SECTOR) {
+                        timeClass = 'green-time';
+                    } else if (sectorStatus[sectorIndex] === this.PURPLE_SECTOR) {
+                        timeClass = 'purple-time';
+                    } else if (sectorStatus[sectorIndex] === this.RED_SECTOR) {
+                        timeClass = 'red-time';
+                    }
+                }
+            }
+            return this.createSingleLineCell(formattedTime, {className: timeClass});
+        };
+    }
+
     createTyreWearCellRenderer(wearField) {
         return (params) => {
             const tyreInfo = params.data["tyre-info"];
@@ -478,6 +506,48 @@ class EngViewRaceTable {
                             return isReferenceDriver ? 'ag-cell-single-line' : 'ag-cell-multiline';
                         },
                     }
+                ]
+            },
+            {
+                headerName: 'Current Lap',
+                context: {displayName: 'Curr Lap'},
+                children: [
+                    {
+                        headerName: "Lap",
+                        context: {displayName: "Current Lap Time"},
+                        field: `lap-info.curr-lap.lap-time-ms`,
+                        cellRenderer: this.createSectorCellRendererCurrLap('lap', 'lap-time-ms'),
+                        sortable: false,
+                        flex: 2.5,
+                        cellClass: 'ag-cell-single-line',
+                    },
+                    {
+                        headerName: "S1",
+                        context: {displayName: "Current Sector 1"},
+                        field: `lap-info.curr-lap.s1-time-ms`,
+                        cellRenderer: this.createSectorCellRendererCurrLap('s1', 's1-time-ms'),
+                        sortable: false,
+                        flex: 2.5,
+                        cellClass: 'ag-cell-single-line',
+                    },
+                    {
+                        headerName: "S2",
+                        context: {displayName: "Current Sector 2"},
+                        field: `lap-info.curr-lap.s2-time-ms`,
+                        cellRenderer: this.createSectorCellRendererCurrLap('s2', 's2-time-ms'),
+                        sortable: false,
+                        flex: 2.5,
+                        cellClass: 'ag-cell-single-line',
+                    },
+                    {
+                        headerName: "S3",
+                        context: {displayName: "Current Sector 3"},
+                        field: `lap-info.curr-lap.s3-time-ms`,
+                        cellRenderer: this.createSectorCellRendererCurrLap('s3', 's3-time-ms'),
+                        sortable: false,
+                        flex: 2.5,
+                        cellClass: 'ag-cell-single-line',
+                    },
                 ]
             },
             {

--- a/apps/frontend/js/raceTableRowPopulator.js
+++ b/apps/frontend/js/raceTableRowPopulator.js
@@ -231,7 +231,7 @@ class RaceTableRowPopulator {
             if (newLapNum !== oldLapNum && oldLapNum !== null) {
                 // Display old data first
                 lapNumDisplayElement.textContent = `Lap ${oldLapNum}`;
-                updateLapTimeAndSector(oldLapTimeMs, oldSectorStatus);
+                updateLapTimeAndSector(oldLapTimeMs, this.rowData["lap-info"]["last-lap"]["sector-status"]);
 
                 this.context.currLap.lapNumTimeoutId = setTimeout(() => {
                     lapNumDisplayElement.textContent = `Lap ${newLapNum}`;

--- a/apps/frontend/js/raceTableRowPopulator.js
+++ b/apps/frontend/js/raceTableRowPopulator.js
@@ -168,8 +168,25 @@ class RaceTableRowPopulator {
             return this;
         }
 
-        let tempCell = this.row.insertCell();
-        tempCell.textContent = "TODO";
+        const lapInfo = this.rowData["lap-info"]["curr-lap"];
+        const driverStatus = lapInfo["driver-status"];
+        if (driverStatus === "FLYING_LAP" || driverStatus === "ON_TRACK") {
+            const cellContent = [];
+            const lapTimeContent = getFormattedLapTimeStr({
+                lapTimeMs: lapInfo["lap-time-ms"],
+                showAbsoluteFormat: true
+            });
+            cellContent.push(lapTimeContent);
+
+            const cell = this.createMultiLineCell(cellContent);
+            if (lapInfo["lap-time-ms"]) {
+                this.addSectorInfo(cell, lapInfo["sector-status"]);
+            }
+        } else {
+            let idleDriverCell = this.row.insertCell();
+            idleDriverCell.textContent = driverStatus;
+        }
+
         return this;
     }
 

--- a/apps/frontend/js/raceTableRowPopulator.js
+++ b/apps/frontend/js/raceTableRowPopulator.js
@@ -164,7 +164,7 @@ class RaceTableRowPopulator {
     }
 
     addCurrLapInfo() {
-        if (isRaceSession(this.sessionType)) {
+        if (!this.isLiveDataMode || isRaceSession(this.sessionType)) {
             return this;
         }
 
@@ -297,7 +297,7 @@ class RaceTableRowPopulator {
         return midPointPrediction ? [midPointPrediction, lastPrediction] : [lastPrediction];
     }
     addTyrePredictionInfo() {
-        if (!isRaceSession(this.sessionType)) {
+        if (!this.isLiveDataMode || !isRaceSession(this.sessionType)) {
             return this;
         }
 

--- a/apps/frontend/js/telemetryRenderer.js
+++ b/apps/frontend/js/telemetryRenderer.js
@@ -17,6 +17,7 @@ class TelemetryRenderer {
     this.iconCache = iconCache;
     this.uiMode = 'Splash';
     this.driverContextMap = new Map();
+    this.sessionUID = null;
 
     this.connected = null;
     this.statusContainer   = document.getElementById('status-wrapper')
@@ -131,6 +132,13 @@ class TelemetryRenderer {
     const spectatorMode = incomingData["is-spectating"];
     const spectatorCarIndex = incomingData["spectator-car-index"];
     const sessionType = incomingData["session-type"];
+
+    if (this.sessionUID != incomingData["session-uid"]) {
+      // reset map when session changes
+      this.driverContextMap = new Map();
+    }
+    this.sessionUID = incomingData["session-uid"];
+
     this.setDeltaColumnState(isLiveDataMode);
     this.setFuelColumnState(isLiveDataMode, sessionType);
     this.setCurrLapColumnState(isLiveDataMode, sessionType);

--- a/apps/frontend/js/telemetryRenderer.js
+++ b/apps/frontend/js/telemetryRenderer.js
@@ -112,9 +112,6 @@ class TelemetryRenderer {
 
   // Update or create row based on existing data
   updateOrCreateRow(driverRowObj, data, packetFormat, isLiveDataMode, driverIndex, raceEnded, spectatorIndex, sessionType) {
-    if (!driverRowObj) {
-      driverRowObj = { row: null, context: {} };
-    }
     const newRow = this.renderTelemetryRow(data, packetFormat, isLiveDataMode, raceEnded, spectatorIndex, sessionType,
                           driverRowObj.context);
     if (driverRowObj.row) {
@@ -157,6 +154,12 @@ class TelemetryRenderer {
     tableEntries.forEach(data => {
       const driverIndex = data["driver-info"]["index"];
       let driverRowObj = driverRowMap.get(driverIndex);
+
+      if (!driverRowObj) {
+        const existingContext = this.driverContextMap.get(driverIndex) || {};
+        driverRowObj = { row: null, context: existingContext };
+      }
+
       driverRowObj = this.updateOrCreateRow(driverRowObj, data, packetFormat, isLiveDataMode, driverIndex, raceEnded, spectatorCarIndex,
                                     sessionType);
       this.telemetryTable.appendChild(driverRowObj.row);

--- a/apps/frontend/js/telemetryRenderer.js
+++ b/apps/frontend/js/telemetryRenderer.js
@@ -353,13 +353,8 @@ class TelemetryRenderer {
   }
 
   setWearPredictionColumnState(isLiveDataMode, sessionType) {
-    // TODO: hide in save viewer mode
-    let shouldHide = false;
-    if (!isRaceSession(sessionType)) {
-      shouldHide = true;
-    }
-
-    this.hideColumn('WEAR PREDICTION', shouldHide);
+      const shouldHide = !isLiveDataMode || !isRaceSession(sessionType);
+      this.hideColumn('WEAR PREDICTION', shouldHide);
   }
 
   setWingDamageColumnState(sessionType) {

--- a/apps/frontend/js/utils.js
+++ b/apps/frontend/js/utils.js
@@ -417,3 +417,15 @@ function insertRejoinPositions(drivers, pitLoss) {
         driver["tyre-info"]["pit-rejoin-position"] = pos;
     }
 }
+
+function isPracticeSession(sessionType) {
+    return sessionType.includes('Practice');
+}
+
+function isQualiSession(sessionType) {
+    return (sessionType.includes('Qualifying') || sessionType.includes('Shootout'));
+}
+
+function isRaceSession(sessionType) {
+    return !isPracticeSession(sessionType) && !isQualiSession(sessionType);
+}

--- a/lib/f1_types/packet_2_lap_data.py
+++ b/lib/f1_types/packet_2_lap_data.py
@@ -486,6 +486,50 @@ class LapData(F1SubPacketBase):
         """
         return not self.__eq__(other)
 
+    @property
+    def s1TimeMS(self) -> int:
+        """Return the total S1 time in ms
+
+        Returns:
+            int: Total S1 time in ms
+        """
+
+        return self.__getCombinedTimeMS(self.m_sector1TimeInMS, self.m_sector1TimeMinutes)
+
+    @property
+    def s2TimeMS(self) -> int:
+        """Return the total S2 time in ms
+
+        Returns:
+            int: Total S2 time in ms
+        """
+
+        return self.__getCombinedTimeMS(self.m_sector2TimeInMS, self.m_sector2TimeMinutes)
+
+    @property
+    def s3TimeMS(self) -> int:
+        """Return the total S3 time in ms
+
+        Returns:
+            int: Total S3 time in ms
+        """
+
+        # Since there is no S3 time, return total - (s1 + s2)
+        return self.m_currentLapTimeInMS - (self.s1TimeMS + self.s2TimeMS)
+
+    def __getCombinedTimeMS(self, ms_part: int, min_part: int) -> int:
+        """
+        Combines minutes and milliseconds into a total time in milliseconds.
+
+        Args:
+            ms_part (int): The milliseconds part of the time.
+            min_part (int): The minutes part of the time.
+
+        Returns:
+            int: The total time in milliseconds.
+        """
+        return (min_part * 60 * 1000) + ms_part
+
 class PacketLapData(F1PacketBase):
     """Class representing the incoming PacketLapData.
 

--- a/lib/f1_types/packet_2_lap_data.py
+++ b/lib/f1_types/packet_2_lap_data.py
@@ -495,6 +495,9 @@ class LapData(F1SubPacketBase):
             int: Total S1 time in ms
         """
 
+        if self.m_sector == LapData.Sector.SECTOR1:
+            # Since S1 is ongoing, it will be 0 in the packet. Hence it is basically the current lap time
+            return self.m_currentLapTimeInMS
         return self.__getCombinedTimeMS(self.m_sector1TimeInMS, self.m_sector1TimeMinutes)
 
     @property
@@ -504,7 +507,13 @@ class LapData(F1SubPacketBase):
         Returns:
             int: Total S2 time in ms
         """
+        if self.m_sector == LapData.Sector.SECTOR1:
+            return 0
+        if self.m_sector == LapData.Sector.SECTOR2:
+            # Since S2 is ongoing, it will be 0 in the packet. Hence it is basically the current lap time minus S1
+            return self.m_currentLapTimeInMS - self.s1TimeMS
 
+        # Since S2 is completed, we can directly read the S2 field
         return self.__getCombinedTimeMS(self.m_sector2TimeInMS, self.m_sector2TimeMinutes)
 
     @property
@@ -514,6 +523,9 @@ class LapData(F1SubPacketBase):
         Returns:
             int: Total S3 time in ms
         """
+
+        if self.m_sector < LapData.Sector.SECTOR3:
+            return 0
 
         # Since there is no S3 time, return total - (s1 + s2)
         return self.m_currentLapTimeInMS - (self.s1TimeMS + self.s2TimeMS)

--- a/lib/f1_types/packet_2_lap_data.py
+++ b/lib/f1_types/packet_2_lap_data.py
@@ -24,7 +24,8 @@
 import struct
 from typing import Any, Dict, List
 
-from .base_pkt import F1BaseEnum, F1PacketBase, F1SubPacketBase
+from .base_pkt import (F1BaseEnum, F1CompareableEnum, F1PacketBase,
+                       F1SubPacketBase)
 from .common import F1Utils, ResultStatus
 from .header import PacketHeader
 
@@ -235,7 +236,7 @@ class LapData(F1SubPacketBase):
         PITTING = 1
         IN_PIT_AREA = 2
 
-    class Sector(F1BaseEnum):
+    class Sector(F1CompareableEnum):
         """
         Enumeration representing the sector of a racing track.
         """


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Adds support for current lap time in both views
Engineer view:
- A new column called current lap time has been created with lap, s1, s2 and s3 columns
- When a lap is completed, the old value stays on the row for 5 seconds. After this, the new lap data starts being updated

Driver view:
- In FP/Quali modes, a new current lap column is created. In race mode, the same old columns are displayed
- When a lap is completed, the old value stays on the row for 5 seconds. After this, the new lap data starts being updated
- Previous data is now stored via a context mechanism for each row.

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [x] All integration tests pass
* Attach test command/output:

```
===== TEST RESULTS =====
Passed: 28/28

PASS: f1_23_sp_austria.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_mp_fp_austria_full_spec.f1pcap
PASS: f1_25_mp_fp_jeddah.f1pcap
PASS: f1_25_mp_fp_jeddah_player.f1pcap
PASS: f1_25_mp_fp_jeddah_player_2.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_mp_quali_sprint_austria_spec.f1pcap
PASS: f1_25_mp_race_japan_spec.f1pcap
PASS: f1_25_mp_race_jeddah.f1pcap
PASS: f1_25_mp_solo_afk_fp_aus.f1pcap
PASS: f1_25_sp_aus_5lap_1stop.f1pcap
PASS: f1_25_sp_aus_5lap_1stop_flashback.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_sp_baku_mid_session_save_load.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_sp_imola_5lap_1stop.f1pcap
PASS: f1_25_sp_qatar_flashback_1stop.f1pcap
PASS: f1_25_sp_qatar_partial.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_tt_monza.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
Total time: 08:05.047

```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
N/A
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [ ] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Implement current lap timing support across frontend and backend. Extend backend API to emit detailed current lap data. Enhance frontend engineer and driver views to render real-time lap and sector data with a 5-second grace period after each lap completion, and conditionally show columns by session type. Refactor tyre info rendering and LapData calculations to support the new feature.

New Features:
- Display current lap and sector split times in engineer view AG grid with color-coded sectors
- Add current lap column in driver view for FP/Quali sessions with 5-second retention of previous lap data
- Include a "curr-lap" section in backend telemetry API with lap time, sector times, statuses, and sector-validation

Enhancements:
- Introduce session-type utilities and conditional column visibility for current lap, wear prediction, damage, and fuel
- Refactor tyre information rendering in driver view with helper methods and telemetry-restricted formatting
- Add computed s1/s2/s3 time properties to LapData and centralize LapInfo updates via a processLapDataUpdate method