### PR TITLE
Add smoke test mode and GitHub Actions integration

### DIFF
--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -63,3 +63,29 @@ jobs:
           path: |
             dist/*.app
             dist/*.exe
+      - name: Run Smoke Test
+        run: |
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            APP_PATH=$(find dist -name "*.app" | head -n 1)
+            TEST_FILE="$HOME/Library/Application Support/pits_n_giggles/png_smoke_test.txt"
+            # Launch app in smoke test mode with dummy content
+            open -W "$APP_PATH" --args --smoke-test "hello-smoke"
+            # Verify the file was created
+            if [ ! -f "$TEST_FILE" ]; then
+              echo "Smoke test failed: $TEST_FILE not found"
+              exit 1
+            fi
+          else
+            EXE_PATH=$(find dist -name "*.exe" | head -n 1)
+            TEST_FILE="./png_smoke_test.txt"
+            # Launch app in smoke test mode with dummy content
+            "$EXE_PATH" --smoke-test "hello-smoke"
+            # Wait a little for file creation
+            sleep 2
+            if [ ! -f "$TEST_FILE" ]; then
+              echo "Smoke test failed: $TEST_FILE not found"
+              exit 1
+            fi
+          fi
+          echo "Smoke test passed!"
+        shell: bash

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -83,10 +83,16 @@ jobs:
             TEST_FILE="./png_smoke_test.txt"
             # Launch app in smoke test mode with dummy content
             "$EXE_PATH" --smoke-test "hello-smoke"
-            # Wait a little for file creation
-            sleep 2
+            # Wait for file creation with polling (timeout: 10s)
+            TIMEOUT=10
+            INTERVAL=0.5
+            ELAPSED=0
+            while [ ! -f "$TEST_FILE" ] && [ "$(echo "$ELAPSED < $TIMEOUT" | bc)" -eq 1 ]; do
+              sleep $INTERVAL
+              ELAPSED=$(echo "$ELAPSED + $INTERVAL" | bc)
+            done
             if [ ! -f "$TEST_FILE" ]; then
-              echo "Smoke test failed: $TEST_FILE not found"
+              echo "Smoke test failed: $TEST_FILE not found after $TIMEOUT seconds"
               exit 1
             fi
           fi

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -2,6 +2,9 @@ name: Build App for macOS and Windows
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build:

--- a/apps/launcher/launcher.py
+++ b/apps/launcher/launcher.py
@@ -114,7 +114,7 @@ def smoke_test(file_content: str) -> None:
             file_content (str): The content to write to the file.
     """
     path = resolve_user_file("png_smoke_test.txt")
-    with open(path, "w") as f:
+    with open(path, "w", encoding='utf-8') as f:
         f.write(file_content)
 
 atexit.register(_cleanup_temp_icon)

--- a/apps/launcher/launcher.py
+++ b/apps/launcher/launcher.py
@@ -138,7 +138,8 @@ def entry_point() -> None:
 
     # Handle smoke test
     if args.smoke_test is not None:
-        smoke_test(args.smoke_test)
+        # TODO: undo
+        # smoke_test(args.smoke_test)
         sys.exit(0)
 
     # Launch the main application

--- a/apps/launcher/launcher.py
+++ b/apps/launcher/launcher.py
@@ -31,6 +31,7 @@ import tkinter as tk
 
 from apps.launcher.png_launcher import PngLauncher
 from lib.version import get_version
+from lib.file_path import resolve_user_file
 
 # -------------------------------------- GLOBALS -----------------------------------------------------------------------
 
@@ -76,6 +77,12 @@ def _cleanup_temp_icon():
             pass
         _temp_icon_file = None
 
+def smoke_test():
+    """Create a test file and the log file path. Process parent will test if the file exists."""
+    path = resolve_user_file("png_smoke_test.txt")
+    with open(path, "w") as f:
+        f.write("PNG_SMOKE_TEST")
+
 atexit.register(_cleanup_temp_icon)
 
 # -------------------------------------- CONSTANTS ---------------------------------------------------------------------
@@ -86,6 +93,12 @@ SETTINGS_ICON_PATH = str(resource_path("assets/settings.ico"))
 # -------------------------------------- ENTRY POINT -------------------------------------------------------------------
 
 def entry_point():
+
+    smoke_test_arg = "--smoke-test" in sys.argv
+    if smoke_test_arg:
+        smoke_test()
+        sys.exit(0)
+
     debug_mode = "--debug" in sys.argv
     root = tk.Tk()
     root.title("Pits n' Giggles")

--- a/apps/launcher/launcher.py
+++ b/apps/launcher/launcher.py
@@ -22,6 +22,7 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
+import argparse
 import atexit
 import os
 import shutil
@@ -38,6 +39,34 @@ from lib.file_path import resolve_user_file
 _temp_icon_file = None
 
 # -------------------------------------- FUNCTIONS ---------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse command-line arguments for the application.
+
+    Returns:
+        argparse.Namespace: Parsed command-line arguments containing:
+            - smoke_test (Optional[str]): Name or mode for smoke testing, if provided.
+            - debug (bool): True if debug mode is enabled, False otherwise.
+    """
+    parser = argparse.ArgumentParser(description="Launch Pits n' Giggles")
+
+    # Smoke test requires an argument if provided
+    parser.add_argument(
+        "--smoke-test",
+        required=False,
+        help="Run smoke test with a required mode or test name",
+        metavar="TEST_NAME"
+    )
+
+    # Debug mode is an optional boolean flag
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug mode"
+    )
+
+    return parser.parse_args()
 
 def resource_path(relative_path):
     """
@@ -92,23 +121,32 @@ SETTINGS_ICON_PATH = str(resource_path("assets/settings.ico"))
 
 # -------------------------------------- ENTRY POINT -------------------------------------------------------------------
 
-def entry_point():
+def entry_point() -> None:
+    """
+    Main entry point for the Pits n' Giggles application.
 
-    smoke_test_arg = "--smoke-test" in sys.argv
-    if smoke_test_arg:
-        smoke_test()
+    Handles:
+        - Running smoke tests if the --smoke-test flag is provided.
+        - Launching the main Tkinter application otherwise.
+    """
+    args: argparse.Namespace = parse_args()
+
+    # Handle smoke test
+    if args.smoke_test is not None:
+        smoke_test(args.smoke_test)
         sys.exit(0)
 
-    debug_mode = "--debug" in sys.argv
-    root = tk.Tk()
+    # Launch the main application
+    root: tk.Tk = tk.Tk()
     root.title("Pits n' Giggles")
-    root.iconbitmap(load_icon_safely("assets/favicon.ico"))  # Set the icon for the main window
+    root.iconbitmap(load_icon_safely("assets/favicon.ico"))
+
     app = PngLauncher(
         root=root,
         ver_str=get_version(),
         logo_path=APP_ICON_PATH,
         settings_icon_path=SETTINGS_ICON_PATH,
-        debug_mode=debug_mode
+        debug_mode=args.debug
     )
     root.protocol("WM_DELETE_WINDOW", app.on_closing)
     root.createcommand("::tk::mac::Quit", app.on_closing)

--- a/apps/launcher/launcher.py
+++ b/apps/launcher/launcher.py
@@ -106,11 +106,16 @@ def _cleanup_temp_icon():
             pass
         _temp_icon_file = None
 
-def smoke_test():
-    """Create a test file and the log file path. Process parent will test if the file exists."""
+def smoke_test(file_content: str) -> None:
+    """Create a test file at the log file path. (CWD for windows, ~/Library/Application Support/pits_n_giggles for mac)
+        Parent process is responsible to test if the file exists.
+
+        Args:
+            file_content (str): The content to write to the file.
+    """
     path = resolve_user_file("png_smoke_test.txt")
     with open(path, "w") as f:
-        f.write("PNG_SMOKE_TEST")
+        f.write(file_content)
 
 atexit.register(_cleanup_temp_icon)
 

--- a/apps/launcher/launcher.py
+++ b/apps/launcher/launcher.py
@@ -138,8 +138,7 @@ def entry_point() -> None:
 
     # Handle smoke test
     if args.smoke_test is not None:
-        # TODO: undo
-        # smoke_test(args.smoke_test)
+        smoke_test(args.smoke_test)
         sys.exit(0)
 
     # Launch the main application


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Add a smoke test mode where the app will write supplied contents to a file.
Github actions runner will check for this file existence

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [x] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
N/A
Github actions change.
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Implement a smoke test mode in the launcher app with a CLI flag to write a file and integrate it into the GitHub Actions workflow to validate build artifacts.

New Features:
- Add --smoke-test flag and smoke_test() function to write a test file during launch

Enhancements:
- Refactor entry_point to use argparse for handling smoke test and debug flags

CI:
- Introduce a GitHub Actions job step to run and verify the smoke test on macOS and Windows builds