### PR TITLE
Modals enhancement

### DIFF
--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -345,3 +345,21 @@ input[type="number"]::-webkit-outer-spin-button {
 .inactive .nav-link {
   color: var(--f1-text-secondary);
 }
+
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 200px;
+  background-color: #333; /* Dark background */
+  color: #fff; /* White text */
+  border-radius: 20px; /* Rounded corners */
+  padding: 10px 20px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4); /* Subtle shadow for better visibility */
+}
+
+.toast-body {
+  font-size: 16px; /* Standard font size */
+  text-align: center; /* Centered text */
+}

--- a/apps/frontend/css/modals.css
+++ b/apps/frontend/css/modals.css
@@ -177,6 +177,21 @@
     cursor: pointer;
 }
 
+/* Styling for the driver modal tab panes to prevent overflow */
+.driver-modal-tab-pane {
+    max-height: 60vh; /* Adjust as needed */
+    overflow-y: auto;
+    padding: 10px; /* Add some padding for better appearance */
+}
+
+/* Styling for chart containers within the modal */
+.chart-container,
+.driver-modal-tab-pane canvas {
+    max-height: 55vh; /* Adjust as needed, slightly less than tab-pane to account for padding/margins */
+    width: 100%;
+    display: block; /* Ensure canvas behaves as a block element */
+}
+
 .filter-button-container {
     display: flex;
     justify-content: space-around;

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -13,6 +13,8 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/lapSectorRecords.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreRecords.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/fuelCalculator.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/barChart.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreStintHistoryModal.css') }}">
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/4.4.1/socket.io.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/msgpack-lite@0.1.26/dist/msgpack.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"></script>
@@ -34,6 +36,9 @@
                             <h5 class="mb-0" id="raceStatusHeader">Race Status</h5>
                             <div class="d-flex">
                                 <span style="font-size: 2.1rem;" data-bs-toggle="tooltip" data-bs-title="This symbol shows up when a driver has set their telemetry to restricted">⌀</span>
+                                <button id="race-stats-btn" class="settings-button" data-bs-toggle="tooltip" data-bs-title="Show Race Stats">
+                                    🏁
+                                </button>
                                 <a id="driver-view-btn" class="btn settings-button" href="/" data-bs-toggle="tooltip" data-bs-title="Switch to driver view">
                                     <i class="bi bi-car-front-fill"></i>
                                 </a>
@@ -164,6 +169,40 @@
         </div>
     </div>
 
+    <!-- Race Stats Modal -->
+    <div class="modal fade" id="raceStatsModal" tabindex="-1" aria-labelledby="raceStatsModalLabel" aria-hidden="true">
+      <div class="modal-dialog modal-fullscreen race-stats-modal-dialog">
+        <div class="modal-content race-stats-modal-content bg-dark">
+          <!-- Modal Header -->
+          <div class="modal-header race-stats-modal-header d-flex justify-content-between align-items-center bg-dark border border-dark-subtle rounded">
+            <!-- Title and Navigation Buttons -->
+            <div class="d-flex align-items-center">
+              <h5 class="modal-title m-0 text-white" id="raceStatsModalLabel">Race Stats</h5>
+            </div>
+            <!-- Refresh and Close Buttons -->
+            <div class="d-flex align-items-center">
+              <button type="button" class="icon-btn me-2" id="refreshButtonRace" title="Refresh">
+                <i class="bi bi-arrow-clockwise"></i>
+              </button>
+              <button type="button" class="icon-btn" id="closeButtonRace" data-bs-dismiss="modal" aria-label="Close" title="Close">
+                <i class="bi bi-x-lg"></i>
+              </button>
+            </div>
+          </div>
+          <div class="modal-body race-stats-modal-body border border-dark-subtle rounded">
+            <!-- Nav tabs and tab content will be dynamically injected here by JavaScript -->
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Toast Container -->
+    <div class="toast-container position-fixed bottom-0 end-0 p-3">
+      <div id="liveToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+        <div class="toast-body"></div>
+      </div>
+    </div>
+
     <script src="{{ url_for('static', filename='js/preferences.js') }}"></script>
     <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
     <script src="{{ url_for('static', filename='js/iconCache.js') }}"></script>
@@ -172,10 +211,13 @@
     <script src="{{ url_for('static', filename='js/fuelCalculator.js') }}"></script>
     <script src="{{ url_for('static', filename='js/populateRaceControlMessagesTab.js') }}"></script>
     <script src="{{ url_for('static', filename='js/driverDataModalPopulator.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/raceStatsModalPopulator.js') }}"></script>
     <script src="{{ url_for('static', filename='js/tyreSetsCards.js') }}"></script>
     <script src="{{ url_for('static', filename='js/lapSectorRecords.js') }}"></script>
     <script src="{{ url_for('static', filename='js/tyreRecords.js') }}"></script>
     <script src="{{ url_for('static', filename='js/weatherUI.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/barChart.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/tyreStintHistoryModal.js') }}"></script>
     <script src="{{ url_for('static', filename='js/engView.js') }}"></script>
 </body>
 </html>

--- a/apps/frontend/js/driverDataModalPopulator.js
+++ b/apps/frontend/js/driverDataModalPopulator.js
@@ -1082,8 +1082,7 @@ class DriverModalPopulator {
 
         // Split the tab content into two vertical halves
         const containerDiv = document.createElement('div');
-        containerDiv.className = 'd-flex';
-        // containerDiv.style.height = '100vh';
+        containerDiv.className = 'd-flex h-100';
 
         // Left half: Create the fuel usage table
         const leftDiv = document.createElement('div');
@@ -1092,7 +1091,7 @@ class DriverModalPopulator {
 
         // Right half: Empty for now
         const rightDiv = document.createElement('div');
-        rightDiv.className = 'w-50 border border-light-subtle rounded overflow-auto'; // Half width
+        rightDiv.className = 'w-50 border border-light-subtle rounded overflow-auto d-flex flex-column h-100'; // Half width
         rightPanePopulator(rightDiv);
 
         containerDiv.appendChild(leftDiv);

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -1343,8 +1343,9 @@ function initDashboard() {
     weatherTable = new EngViewWeatherTable(iconCache);
 
     const driverModal = true;
-    const raceStatsModal = false;
-    window.modalManager = new ModalManager(driverModal, raceStatsModal, false);
+    const settingsModal = false;
+    const raceStatsModal = true;
+    window.modalManager = new ModalManager(driverModal, settingsModal, raceStatsModal);
 
     const connectStart = Date.now();
     const socketio = io(`${location.protocol}//${location.hostname}:${location.port}`, {

--- a/apps/frontend/js/modals.js
+++ b/apps/frontend/js/modals.js
@@ -80,7 +80,7 @@ class ModalManager {
     console.log("Changed fuel target state to ", !isDisabled);
   }
 
-  openDriverModal(data) {
+  openDriverModal(data, activeTabId = null) {
     if (!this.driverModal) {
       console.error("Driver modal not initialized");
       return;
@@ -106,6 +106,17 @@ class ModalManager {
     const tabContent = modalDataPopulator.createTabContent();
     modalBody.appendChild(tabContent);
 
+    // Restore active tab if an ID is provided
+    if (activeTabId) {
+      const newActiveTab = document.getElementById(activeTabId);
+      if (newActiveTab) {
+        const newActiveNavLink = document.querySelector(`#driverModal .nav-link[data-bs-target="#${activeTabId}"]`);
+        if (newActiveNavLink) {
+          new bootstrap.Tab(newActiveNavLink).show();
+        }
+      }
+    }
+
     // Event Listeners for Buttons
     refreshButton.onclick = () => this.refreshDriverData(data);
 
@@ -115,6 +126,9 @@ class ModalManager {
 
   refreshDriverData(data) {
     console.log("Refresh clicked", data);
+    const activeTabElement = document.querySelector('#driverModal .tab-pane.active');
+    const activeTabId = activeTabElement ? activeTabElement.id : null;
+
     const requestPayload = {
       "index" : data["index"],
       "__dummy" : {
@@ -128,7 +142,7 @@ class ModalManager {
       })
       .then(data => {
         console.log('Driver info sync response received:', data);
-        this.openDriverModal(data, this.iconCache); // Reload the modal with the current data
+        this.openDriverModal(data, activeTabId); // Reload the modal with the current data, passing the active tab ID
       })
       .catch(err => {
           console.error("Fetch error:", err);
@@ -285,7 +299,7 @@ class ModalManager {
     return tempVal;
   }
 
-  openRaceStatsModal(data) {
+  openRaceStatsModal(data, activeTabId = null) {
 
     if (!this.raceStatsModal) {
       this.console.error("Race stats modal not initialized");
@@ -313,6 +327,17 @@ class ModalManager {
     const tabContent = modalDataPopulator.createTabContent();
     modalBody.appendChild(tabContent);
 
+    // Restore active tab if an ID is provided
+    if (activeTabId) {
+      const newActiveTab = document.getElementById(activeTabId);
+      if (newActiveTab) {
+        const newActiveNavLink = document.querySelector(`#raceStatsModal .nav-link[data-bs-target="#${activeTabId}"]`);
+        if (newActiveNavLink) {
+          new bootstrap.Tab(newActiveNavLink).show();
+        }
+      }
+    }
+
     // Event Listeners for Buttons
     refreshButton.onclick = () => this.refreshRaceStatsData(data);
 
@@ -322,6 +347,9 @@ class ModalManager {
 
   refreshRaceStatsData(data) {
     console.log("Refresh race stats clicked", data);
+    const activeTabElement = document.querySelector('#raceStatsModal .tab-pane.active');
+    const activeTabId = activeTabElement ? activeTabElement.id : null;
+
     const requestPayload = {
       "__dummy" : {
         "refresh" : true
@@ -334,7 +362,7 @@ class ModalManager {
       })
       .then(data => {
         console.log('Race info sync response received:', data);
-        this.openRaceStatsModal(data); // Reload the modal with the current data
+        this.openRaceStatsModal(data, activeTabId); // Reload the modal with the current data, passing the active tab ID
       })
       .catch(err => {
           console.error("Fetch error:", err);


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Brought race stats modals and tooltips to eng view
When driver/race modal is refreshed, previously selected tab is remembered and restored
Fixed speed trap records and position history charts overflowing the modal div

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [ ] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
<paste result here>
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [ ] My code follows project style conventions
* [ ] All new and existing tests pass
* [ ] I have added relevant documentation/comments
* [ ] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->
