### PR TITLE
Add AI status and Flashback messages, refine renderers

### DIFF
--- a/apps/frontend/js/populateRaceControlMessagesTab.js
+++ b/apps/frontend/js/populateRaceControlMessagesTab.js
@@ -128,6 +128,14 @@ const detailRenderers = {
       `Driver: ${getDriverDetailsStr(d ?? null)}, Lap: ${lap}`,
   TYRE_CHANGE: ({ 'driver-info': d, 'lap-number': lap, 'old-tyre-compound': oldTyreCompound, 'new-tyre-compound': newTyreCompound}) =>
       `Driver: ${getDriverDetailsStr(d ?? null)}, Lap: ${lap} - Old Compound: ${oldTyreCompound}, New Compound: ${newTyreCompound}`,
+  DRIVER_AI_STATUS_CHANGE: ({
+    'driver-info': d,
+    'lap-number': lap,
+    'old-state': oldState,
+    'new-state': newState}) => {
+    const stateLabel = (s) => (s ? "AI" : "Player");
+    return `Driver: ${getDriverDetailsStr(d ?? null)}, Lap: ${lap} - State changed from ${stateLabel(oldState)} to ${stateLabel(newState)}`;
+  },
 
   DEFAULT: msg => `Type: ${msg['message-type']} - Placeholder details.`
 };

--- a/apps/frontend/js/populateRaceControlMessagesTab.js
+++ b/apps/frontend/js/populateRaceControlMessagesTab.js
@@ -81,16 +81,16 @@ function getDriverDetailsStr(driverInfo, brackets=false) {
 
 // Extract detailRenderers into its own constant (can live at top of file or separate module)
 const detailRenderers = {
-  SESSION_START: () => 'N/A',
-  SESSION_END: () => 'N/A',
+  SESSION_START: () => '---',
+  SESSION_END: () => '---',
   FASTEST_LAP: ({ 'driver-info': d, 'lap-time-ms': ms }) =>
       `Driver: ${getDriverDetailsStr(d ?? null)}, Lap Time: ${formatLapTime(ms)}`,
   RETIREMENT: ({ 'driver-info': d }) =>
       `Driver: ${getDriverDetailsStr(d ?? null)}`,
-  DRS_ENABLED: () => 'N/A',
+  DRS_ENABLED: () => '---',
   DRS_DISABLED: ({ reason }) =>
       `Reason: ${reason}`,
-  CHEQUERED_FLAG: () => 'N/A',
+  CHEQUERED_FLAG: () => '---',
   RACE_WINNER: ({ 'driver-info': d }) =>
       getDriverDetailsStr(d ?? null),
   PENALTY: ({ 'driver-info': d, 'penalty-type': pt, 'infringement-type': it, 'other-driver-info': od }) => {
@@ -106,7 +106,7 @@ const detailRenderers = {
       `Driver: ${getDriverDetailsStr(d ?? null)}`,
   STOP_GO_SERVED: ({ 'driver-info': d, 'stop-time': stopTime }) =>
       `Driver: ${getDriverDetailsStr(d ?? null)} - Stop Time: ${formatFloat(stopTime)} s`,
-  RED_FLAG: () => 'N/A',
+  RED_FLAG: () => '---',
   OVERTAKE: ({ 'overtaker-info': overtaker, 'overtaken-info': overtaken }) =>
       `${getDriverDetailsStr(overtaker ?? null)} overtook ${getDriverDetailsStr(overtaken ?? null)}`,
   SAFETY_CAR: ({ 'sc-type': scType, 'event-type': eventType }) =>

--- a/apps/frontend/js/populateRaceControlMessagesTab.js
+++ b/apps/frontend/js/populateRaceControlMessagesTab.js
@@ -126,8 +126,9 @@ const detailRenderers = {
   },
   WING_CHANGE: ({ 'driver-info': d, 'lap-number': lap }) =>
       `Driver: ${getDriverDetailsStr(d ?? null)}, Lap: ${lap}`,
-  TYRE_CHANGE: ({ 'driver-info': d, 'lap-number': lap, 'old-tyre-compound': oldTyreCompound, 'new-tyre-compound': newTyreCompound}) =>
-      `Driver: ${getDriverDetailsStr(d ?? null)}, Lap: ${lap} - Old Compound: ${oldTyreCompound}, New Compound: ${newTyreCompound}`,
+  TYRE_CHANGE: ({ 'driver-info': d, 'lap-number': lap, 'old-tyre-compound': oldTyreCompound, 'old-tyre-index': oldTyreIndex,
+                  'new-tyre-compound': newTyreCompound, 'new-tyre-index': newTyreIndex}) =>
+      `Driver: ${getDriverDetailsStr(d ?? null)}, Lap: ${lap} - ${oldTyreCompound}(${oldTyreIndex}) → ${newTyreCompound}(${newTyreIndex})`,
   DRIVER_AI_STATUS_CHANGE: ({
     'driver-info': d,
     'lap-number': lap,

--- a/apps/frontend/js/populateRaceControlMessagesTab.js
+++ b/apps/frontend/js/populateRaceControlMessagesTab.js
@@ -137,6 +137,7 @@ const detailRenderers = {
     const stateLabel = (s) => (s ? "AI" : "Player");
     return `Driver: ${getDriverDetailsStr(d ?? null)}, Lap: ${lap} - State changed from ${stateLabel(oldState)} to ${stateLabel(newState)}`;
   },
+  FLASHBACK: () => '---',
 
   DEFAULT: msg => `Type: ${msg['message-type']} - Placeholder details.`
 };

--- a/apps/frontend/js/populateRaceControlMessagesTab.js
+++ b/apps/frontend/js/populateRaceControlMessagesTab.js
@@ -97,7 +97,7 @@ const detailRenderers = {
     const base = `${getDriverDetailsStr(d, true)}, ${pt} - ${it}`;
     return od ? `${base}, other driver: ${getDriverDetailsStr(od, true)}` : base;
   },
-  SPEED_TRAP: ({ 'driver-info': d, speed }) =>
+  SPEED_TRAP_RECORD: ({ 'driver-info': d, speed }) =>
       `Driver: ${getDriverDetailsStr(d ?? null)}, Speed: ${formatFloat(speed)} km/h`,
   START_LIGHTS: ({ 'num-lights': numLights }) =>
       `Number of lights: ${numLights}`,

--- a/apps/frontend/js/populateRaceControlMessagesTab.js
+++ b/apps/frontend/js/populateRaceControlMessagesTab.js
@@ -101,7 +101,7 @@ const detailRenderers = {
       `Driver: ${getDriverDetailsStr(d ?? null)}, Speed: ${formatFloat(speed)} km/h`,
   START_LIGHTS: ({ 'num-lights': numLights }) =>
       `Number of lights: ${numLights}`,
-  LIGHTS_OUT: () => 'N/A',
+  LIGHTS_OUT: () => '---',
   DRIVE_THROUGH_SERVED: ({ 'driver-info': d }) =>
       `Driver: ${getDriverDetailsStr(d ?? null)}`,
   STOP_GO_SERVED: ({ 'driver-info': d, 'stop-time': stopTime }) =>

--- a/lib/race_ctrl/__init__.py
+++ b/lib/race_ctrl/__init__.py
@@ -24,8 +24,8 @@
 
 from .driver_mgr import DriverRaceControlManager
 from .factory import race_ctrl_event_msg_factory
-from .messages import (CarDamageRaceControlMessage, DriverPittingRaceCtrlMsg,
-                       MessageType, RaceCtrlMsgBase,
+from .messages import (CarDamageRaceControlMessage, DriverAiStatusChange,
+                       DriverPittingRaceCtrlMsg, MessageType, RaceCtrlMsgBase,
                        TyreChangeRaceControlMessage, WingChangeRaceCtrlMsg)
 from .session_mgr import SessionRaceControlManager
 
@@ -40,6 +40,7 @@ __all__ = [
 
     # Status messages
     "CarDamageRaceControlMessage",
+    "DriverAiStatusChange",
     "DriverPittingRaceCtrlMsg",
     "WingChangeRaceCtrlMsg",
     "TyreChangeRaceControlMessage",

--- a/lib/race_ctrl/factory.py
+++ b/lib/race_ctrl/factory.py
@@ -30,13 +30,13 @@ from lib.f1_types import PacketEventData
 from .messages import (ChequeredFlagRaceCtrlMsg, CollisionRaceCtrlMsg,
                        DrsDisabledRaceCtrlMsg, DrsEnabledRaceCtrlMsg,
                        DtPenServedRaceCtrlMsg, FastestLapRaceCtrlMsg,
-                       LightsOutRaceCtrlMsg, OvertakeRaceCtrlMsg,
-                       PenaltyRaceCtrlMsg, RaceCtrlMsgBase,
-                       RaceWinnerRaceCtrlMsg, RedFlagRaceCtrlMsg,
-                       RetirementRaceCtrlMsg, SafetyCarRaceCtrlMsg,
-                       SessionEndRaceCtrlMsg, SessionStartRaceCtrlMsg,
-                       SgPenServedRaceCtrlMsg, SpeedTrapRaceCtrlMsg,
-                       StartLightsRaceCtrlMsg)
+                       FlashBackRaceCtrlMsg, LightsOutRaceCtrlMsg,
+                       OvertakeRaceCtrlMsg, PenaltyRaceCtrlMsg,
+                       RaceCtrlMsgBase, RaceWinnerRaceCtrlMsg,
+                       RedFlagRaceCtrlMsg, RetirementRaceCtrlMsg,
+                       SafetyCarRaceCtrlMsg, SessionEndRaceCtrlMsg,
+                       SessionStartRaceCtrlMsg, SgPenServedRaceCtrlMsg,
+                       SpeedTrapRaceCtrlMsg, StartLightsRaceCtrlMsg)
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
@@ -134,6 +134,9 @@ def race_ctrl_event_msg_factory(packet: PacketEventData, lap_number: int) -> Opt
             return CollisionRaceCtrlMsg(timestamp=time.time(), involved_drivers=[collision.m_vehicle_1_index,
                                                                                 collision.m_vehicle_2_index],
                                         lap_number=lap_number)
+
+        case PacketEventData.Flashback:
+            return FlashBackRaceCtrlMsg(timestamp=time.time(), lap_number=lap_number)
 
         case _:
             return None

--- a/lib/race_ctrl/factory.py
+++ b/lib/race_ctrl/factory.py
@@ -135,7 +135,7 @@ def race_ctrl_event_msg_factory(packet: PacketEventData, lap_number: int) -> Opt
                                                                                 collision.m_vehicle_2_index],
                                         lap_number=lap_number)
 
-        case PacketEventData.Flashback:
+        case PacketEventData.EventPacketType.FLASHBACK:
             return FlashBackRaceCtrlMsg(timestamp=time.time(), lap_number=lap_number)
 
         case _:

--- a/lib/race_ctrl/messages/__init__.py
+++ b/lib/race_ctrl/messages/__init__.py
@@ -27,6 +27,7 @@ from .driver_event_messages import (FastestLapRaceCtrlMsg, OvertakeRaceCtrlMsg,
                                     RetirementRaceCtrlMsg,
                                     SpeedTrapRaceCtrlMsg)
 from .driver_status_messages import (CarDamageRaceControlMessage,
+                                     DriverAiStatusChange,
                                      DriverPittingRaceCtrlMsg,
                                      TyreChangeRaceControlMessage,
                                      WingChangeRaceCtrlMsg)
@@ -53,6 +54,7 @@ __all__ = [
     "OvertakeRaceCtrlMsg",
 
     # driver - status
+    "DriverAiStatusChange",
     "DriverPittingRaceCtrlMsg",
     "CarDamageRaceControlMessage",
     "WingChangeRaceCtrlMsg",

--- a/lib/race_ctrl/messages/__init__.py
+++ b/lib/race_ctrl/messages/__init__.py
@@ -35,10 +35,10 @@ from .incident_messages import (CollisionRaceCtrlMsg, DtPenServedRaceCtrlMsg,
                                 PenaltyRaceCtrlMsg, SgPenServedRaceCtrlMsg)
 from .session_messages import (ChequeredFlagRaceCtrlMsg,
                                DrsDisabledRaceCtrlMsg, DrsEnabledRaceCtrlMsg,
-                               LightsOutRaceCtrlMsg, RaceWinnerRaceCtrlMsg,
-                               RedFlagRaceCtrlMsg, SafetyCarRaceCtrlMsg,
-                               SessionEndRaceCtrlMsg, SessionStartRaceCtrlMsg,
-                               StartLightsRaceCtrlMsg)
+                               FlashBackRaceCtrlMsg, LightsOutRaceCtrlMsg,
+                               RaceWinnerRaceCtrlMsg, RedFlagRaceCtrlMsg,
+                               SafetyCarRaceCtrlMsg, SessionEndRaceCtrlMsg,
+                               SessionStartRaceCtrlMsg, StartLightsRaceCtrlMsg)
 
 # -------------------------------------- EXPORTS -----------------------------------------------------------------------
 
@@ -70,6 +70,7 @@ __all__ = [
     "ChequeredFlagRaceCtrlMsg",
     "DrsDisabledRaceCtrlMsg",
     "DrsEnabledRaceCtrlMsg",
+    "FlashBackRaceCtrlMsg",
     "LightsOutRaceCtrlMsg",
     "RaceWinnerRaceCtrlMsg",
     "RedFlagRaceCtrlMsg",

--- a/lib/race_ctrl/messages/base.py
+++ b/lib/race_ctrl/messages/base.py
@@ -39,7 +39,7 @@ class MessageType(Enum):
     CHEQUERED_FLAG = auto()
     RACE_WINNER = auto()
     PENALTY = auto()
-    SPEED_TRAP = auto()
+    SPEED_TRAP_RECORD = auto()
     START_LIGHTS = auto()
     LIGHTS_OUT = auto()
     DRIVE_THROUGH_SERVED = auto()

--- a/lib/race_ctrl/messages/base.py
+++ b/lib/race_ctrl/messages/base.py
@@ -52,6 +52,7 @@ class MessageType(Enum):
     CAR_DAMAGE = auto()
     WING_CHANGE = auto()
     TYRE_CHANGE = auto()
+    DRIVER_AI_STATUS_CHANGE = auto()
 
     def __str__(self) -> str:
         return self.name

--- a/lib/race_ctrl/messages/base.py
+++ b/lib/race_ctrl/messages/base.py
@@ -53,6 +53,7 @@ class MessageType(Enum):
     WING_CHANGE = auto()
     TYRE_CHANGE = auto()
     DRIVER_AI_STATUS_CHANGE = auto()
+    FLASHBACK = auto()
 
     def __str__(self) -> str:
         return self.name

--- a/lib/race_ctrl/messages/driver_event_messages.py
+++ b/lib/race_ctrl/messages/driver_event_messages.py
@@ -98,7 +98,7 @@ class SpeedTrapRaceCtrlMsg(RaceCtrlMsgBase):
         """
         super().__init__(
             timestamp=timestamp,
-            message_type=MessageType.SPEED_TRAP,
+            message_type=MessageType.SPEED_TRAP_RECORD,
             involved_drivers=[driver_index],
             lap_number=lap_number)
         self.driver_index: int = driver_index

--- a/lib/race_ctrl/messages/driver_status_messages.py
+++ b/lib/race_ctrl/messages/driver_status_messages.py
@@ -146,3 +146,36 @@ class TyreChangeRaceControlMessage(RaceCtrlMsgBase):
         if driver_info_dict and (driver_info := driver_info_dict.get(self.involved_drivers[0])):
             ret["driver-info"] = driver_info
         return ret
+
+class DriverAiStatusChange(RaceCtrlMsgBase):
+    def __init__(self,
+                 timestamp: float,
+                 driver_index: int,
+                 lap_number: Optional[int],
+                 old_state: bool,
+                 new_state: bool) -> None:
+        """Driver AI status change message
+
+        Args:
+            timestamp (float): Time at which the message was issued (seconds).
+            driver_index (int): Index of the driver.
+            lap_number (Optional[int]): Lap number
+            old_state (bool): Old AI state
+            new_state (bool): New AI state
+        """
+        super().__init__(
+            timestamp=timestamp,
+            message_type=MessageType.DRIVER_AI_STATUS_CHANGE,
+            involved_drivers=[driver_index],
+            lap_number=lap_number)
+        self.old_state: bool = old_state
+        self.new_state: bool = new_state
+
+    def toJSON(self, driver_info_dict = None) -> Dict[str, Any]:
+        """Export the message as a JSON-ready dict."""
+        ret = super().toJSON(driver_info_dict)
+        ret["old-state"] = self.old_state
+        ret["new-state"] = self.new_state
+        if driver_info_dict and (driver_info := driver_info_dict.get(self.involved_drivers[0])):
+            ret["driver-info"] = driver_info
+        return ret

--- a/lib/race_ctrl/messages/session_messages.py
+++ b/lib/race_ctrl/messages/session_messages.py
@@ -205,3 +205,17 @@ class RaceWinnerRaceCtrlMsg(RaceCtrlMsgBase):
         if driver_info_dict and (driver_info := driver_info_dict.get(self.involved_drivers[0])):
             ret["driver-info"] = driver_info
         return ret
+
+class FlashBackRaceCtrlMsg(RaceCtrlMsgBase):
+    def __init__(self, timestamp: float, lap_number: Optional[int] = None) -> None:
+        """Flashback message
+
+        Args:
+            timestamp (float): Time at which the message was issued (seconds).
+            lap_number (Optional[int], optional): Lap number. Defaults to None.
+        """
+        super().__init__(
+            timestamp=timestamp,
+            message_type=MessageType.FLASHBACK,
+            involved_drivers=[],
+            lap_number=lap_number)


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Added Driver AI status change race control message
Added flash back race control message
Replaced N/A with --- in misc renderers

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [x] All integration tests pass
* Attach test command/output:

```
===== TEST RESULTS =====
Passed: 28/28

PASS: f1_23_sp_austria.f1pcap
PASS: f1_23_tt_silverstone.f1pcap
PASS: f1_24_mp_spectator_bahrain.f1pcap
PASS: f1_24_sp_austria_flashback_pit.f1pcap
PASS: f1_24_sp_austria_flashback.f1pcap
PASS: f1_24_sp_austria.f1pcap
PASS: f1_24_tt_silverstone.f1pcap
PASS: f1_25_movie_preview.f1pcap
PASS: f1_25_mp_fp_austria_full_spec.f1pcap
PASS: f1_25_mp_fp_jeddah_player_2.f1pcap
PASS: f1_25_mp_fp_jeddah_player.f1pcap
PASS: f1_25_mp_fp_jeddah.f1pcap
PASS: f1_25_mp_lobby_only_solo.f1pcap
PASS: f1_25_mp_quali_sprint_austria_spec.f1pcap
PASS: f1_25_mp_race_japan_spec.f1pcap
PASS: f1_25_mp_race_jeddah.f1pcap
PASS: f1_25_mp_solo_afk_fp_aus.f1pcap
PASS: f1_25_sp_aus_5lap_1stop_flashback.f1pcap
PASS: f1_25_sp_aus_5lap_1stop.f1pcap
PASS: f1_25_sp_austria_reverse.f1pcap
PASS: f1_25_sp_baku_mid_session_save_load.f1pcap
PASS: f1_25_sp_full_gp_dnf_monaco.f1pcap
PASS: f1_25_sp_imola_5lap_1stop.f1pcap
PASS: f1_25_sp_qatar_flashback_1stop.f1pcap
PASS: f1_25_sp_qatar_partial.f1pcap
PASS: f1_25_story.f1pcap
PASS: f1_25_tt_monza.f1pcap
PASS: f1_25_tt_zandvoort_rev.f1pcap
Total time: 11:41.110
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [x] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Added new message types. Tests already exists
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Add new race control messages for AI status changes and flashbacks, update message type enum and factory, and clean up front-end renderers with consistent placeholders and improved formatting.

New Features:
- Capture and emit Driver AI status change messages in the backend when a participant’s AI control toggles
- Emit Flashback race control messages on FLASHBACK events

Enhancements:
- Add front-end renderers for DRIVER_AI_STATUS_CHANGE and FLASHBACK and replace all 'N/A' placeholders with '---'
- Improve tyre change display format to include both compound and index
- Rename SPEED_TRAP to SPEED_TRAP_RECORD in messages and renderers for consistency