### PR TITLE
feat: save viewer IPC security hardening + tests

### DIFF
--- a/apps/save_viewer/save_viewer_ipc.py
+++ b/apps/save_viewer/save_viewer_ipc.py
@@ -26,7 +26,6 @@ import asyncio
 import logging
 import os
 import webbrowser
-from pathlib import Path
 from typing import Any, Dict, List
 
 import apps.save_viewer.save_viewer_state as SaveViewerState
@@ -87,57 +86,26 @@ class SaveViewerIpc:
 
         @self.m_ipc_server.on("open-file")
         async def _handle_open_file(args: dict) -> dict:
-            """Handles the 'open-file' IPC command.
+            """Handles the 'open-file' IPC command."""
+            file_path = args.get("file-path")
 
-            Args:
-                args (dict): IPC command arguments
-            """
-            return await self._handle_open_file(args)
+            result = await SaveViewerState.open_file_helper(file_path)
+            if result.get("status") != "success":
+                return result
 
-    async def _handle_open_file(self, args: dict) -> dict:
-        """Validate and process the 'open-file' command.
+            # Open the webpage once
+            if self.m_should_open_ui:
+                self.m_should_open_ui = False
+                webbrowser.open(f'http://localhost:{self.m_server.m_port}', new=2)
 
-        Extracted as a method for testability while keeping the
-        decorator-based IPC registration pattern.
-        """
-        if not (file_path := args.get("file-path")):
-            return {"status": "error", "message": "Missing or invalid file path"}
+            # Update all clients
+            await self.m_server.send_to_clients_of_type(
+                event='race-table-update',
+                data=SaveViewerState.getTelemetryInfo(),
+                client_type=ClientType.RACE_TABLE,
+            )
 
-        # Path traversal protection: block relative parent-directory escape
-        if ".." in Path(file_path).parts:
-            self.m_logger.warning("Path traversal attempt blocked: %s", file_path)
-            return {"status": "error", "message": "Path contains disallowed traversal sequence"}
-
-        try:
-            resolved = Path(file_path).resolve()
-        except (OSError, ValueError):
-            return {"status": "error", "message": "Invalid file path"}
-
-        # Must point to an existing regular file with allowed extension
-        if not resolved.is_file():
-            return {"status": "error", "message": "Path does not point to an existing file"}
-
-        if resolved.suffix.lower() != ".json":
-            return {"status": "error", "message": "File type not allowed"}
-
-        try:
-            await SaveViewerState.open_file_helper(str(resolved))
-        except Exception as e: # pylint: disable=broad-exception-caught
-            return {"status": "error", "message": f"Failed to open file: {file_path}. Error: {e}"}
-
-        # Open the webpage once
-        if self.m_should_open_ui:
-            self.m_should_open_ui = False
-            webbrowser.open(f'http://localhost:{self.m_server.m_port}', new=2)
-
-        # Update all clients
-        await self.m_server.send_to_clients_of_type(
-            event='race-table-update',
-            data=SaveViewerState.getTelemetryInfo(),
-            client_type=ClientType.RACE_TABLE,
-        )
-
-        return {"status": "success"}
+            return {"status": "success"}
 
         @self.m_ipc_server.on("get-stats")
         async def _handle_get_stats(_args: dict) -> Dict[str, Any]:

--- a/apps/save_viewer/save_viewer_ipc.py
+++ b/apps/save_viewer/save_viewer_ipc.py
@@ -26,6 +26,7 @@ import asyncio
 import logging
 import os
 import webbrowser
+from pathlib import Path
 from typing import Any, Dict, List
 
 import apps.save_viewer.save_viewer_state as SaveViewerState
@@ -91,27 +92,52 @@ class SaveViewerIpc:
             Args:
                 args (dict): IPC command arguments
             """
-            if not (file_path := args.get("file-path")):
-                return {"status": "error", "message": "Missing or invalid file path"}
+            return await self._handle_open_file(args)
 
-            try:
-                await SaveViewerState.open_file_helper(file_path)
-            except Exception as e: # pylint: disable=broad-exception-caught
-                return {"status": "error", "message": f"Failed to open file: {file_path}. Error: {e}"}
+    async def _handle_open_file(self, args: dict) -> dict:
+        """Validate and process the 'open-file' command.
 
-            # Open the webpage once
-            if self.m_should_open_ui:
-                self.m_should_open_ui = False
-                webbrowser.open(f'http://localhost:{self.m_server.m_port}', new=2)
+        Extracted as a method for testability while keeping the
+        decorator-based IPC registration pattern.
+        """
+        if not (file_path := args.get("file-path")):
+            return {"status": "error", "message": "Missing or invalid file path"}
 
-            # Update all clients
-            await self.m_server.send_to_clients_of_type(
-                event='race-table-update',
-                data=SaveViewerState.getTelemetryInfo(),
-                client_type=ClientType.RACE_TABLE,
-            )
+        # Path traversal protection: block relative parent-directory escape
+        if ".." in Path(file_path).parts:
+            self.m_logger.warning("Path traversal attempt blocked: %s", file_path)
+            return {"status": "error", "message": "Path contains disallowed traversal sequence"}
 
-            return {"status": "success"}
+        try:
+            resolved = Path(file_path).resolve()
+        except (OSError, ValueError):
+            return {"status": "error", "message": "Invalid file path"}
+
+        # Must point to an existing regular file with allowed extension
+        if not resolved.is_file():
+            return {"status": "error", "message": "Path does not point to an existing file"}
+
+        if resolved.suffix.lower() != ".json":
+            return {"status": "error", "message": "File type not allowed"}
+
+        try:
+            await SaveViewerState.open_file_helper(str(resolved))
+        except Exception as e: # pylint: disable=broad-exception-caught
+            return {"status": "error", "message": f"Failed to open file: {file_path}. Error: {e}"}
+
+        # Open the webpage once
+        if self.m_should_open_ui:
+            self.m_should_open_ui = False
+            webbrowser.open(f'http://localhost:{self.m_server.m_port}', new=2)
+
+        # Update all clients
+        await self.m_server.send_to_clients_of_type(
+            event='race-table-update',
+            data=SaveViewerState.getTelemetryInfo(),
+            client_type=ClientType.RACE_TABLE,
+        )
+
+        return {"status": "success"}
 
         @self.m_ipc_server.on("get-stats")
         async def _handle_get_stats(_args: dict) -> Dict[str, Any]:

--- a/apps/save_viewer/save_viewer_state/save_viewer_state.py
+++ b/apps/save_viewer/save_viewer_state/save_viewer_state.py
@@ -24,6 +24,7 @@
 
 import json
 import logging
+from pathlib import Path
 from typing import Any, Dict, List
 
 import lib.overtake_analyzer as OvertakeAnalyzer
@@ -74,14 +75,35 @@ def getDriverInfo(index: int) -> Dict[str, Any]:
     return _getDriverInfo(_json_data, index)
 
 async def open_file_helper(file_path):
-    """Load the JSON file and parse it and update the module global."""
+    """Validate, load the JSON file and parse it and update the module global."""
+
+    if not file_path:
+        return {"status": "error", "message": "Missing or invalid file path"}
+
+    # Path traversal protection: block relative parent-directory escape
+    if ".." in Path(file_path).parts:
+        _logger.warning("Path traversal attempt blocked: %s", file_path)
+        return {"status": "error", "message": "Path contains disallowed traversal sequence"}
+
     try:
-        with open(file_path, 'r+', encoding='utf-8') as f:
+        resolved = Path(file_path).resolve()
+    except (OSError, ValueError):
+        return {"status": "error", "message": "Invalid file path"}
+
+    # Must point to an existing regular file with allowed extension
+    if not resolved.is_file():
+        return {"status": "error", "message": "Path does not point to an existing file"}
+
+    if resolved.suffix.lower() != ".json":
+        return {"status": "error", "message": "File type not allowed"}
+
+    try:
+        with open(str(resolved), 'r+', encoding='utf-8') as f:
             global _json_data
             _json_data = json.load(f)
             _check_recompute_json(_json_data)
 
-        _logger.info("Opened file: %s", file_path)
+        _logger.info("Opened file: %s", resolved)
         return {"status": "success"}
 
     except (FileNotFoundError, PermissionError) as e:
@@ -93,9 +115,9 @@ async def open_file_helper(file_path):
     except UnicodeDecodeError as e:
         _logger.error("Invalid UTF-8 in file: %s. Error: %s", file_path, e)
         return {"status": "error", "message": f"Failed to open file: {file_path}. Error: {e}"}
-    except Exception as e: # pylint: disable=broad-exception-caught
+    except Exception as e:  # pylint: disable=broad-exception-caught
         _logger.exception("Unexpected error opening file: %s", file_path)
-        return {"status": "error", "message": f"Failed to open file: {file_path}. Error: {e}"}
+        return {"status": "error", "message": "Failed to open file"}
 
 # -------------------------------------- HELPER FUNCTIONS --------------------------------------------------------------
 

--- a/apps/save_viewer/save_web_server.py
+++ b/apps/save_viewer/save_web_server.py
@@ -29,7 +29,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import apps.save_viewer.save_viewer_state as SaveViewerState
 from lib.child_proc_mgmt import notify_parent_init_complete
-from lib.event_counter import EventCounter
 from lib.web_server import BaseWebServer, ClientType
 
 # -------------------------------------- CLASSES ----------------------------------------------------------------
@@ -61,11 +60,9 @@ class SaveViewerWebServer(BaseWebServer):
             debug_mode (bool, optional): Enable or disable debug mode. Defaults to False.
         """
         super().__init__(port, ver_str, logger, cert_path, key_path, debug_mode)
-        self.m_stats = EventCounter()
         self.define_routes()
         self.register_post_start_callback(self._post_start)
         self.register_on_client_register_callback(self._on_client_connect)
-        self.register_on_client_disconnect_callback(self._on_client_disconnect)
 
     def define_routes(self) -> None:
         """
@@ -91,7 +88,6 @@ class SaveViewerWebServer(BaseWebServer):
             Returns:
                 str: Rendered HTML content for the index page.
             """
-            self.m_stats.track_event("__HTTP__", "/")
             return await self.render_template('driver-view.html', live_data_mode=False, version=self.m_ver_str)
 
     def _defineDataRoutes(self) -> None:
@@ -109,7 +105,6 @@ class SaveViewerWebServer(BaseWebServer):
             Returns:
                 Tuple[str, int]: JSON response and HTTP status code.
             """
-            self.m_stats.track_event("__HTTP__", "/telemetry-info")
             return SaveViewerState.getTelemetryInfo()
 
         @self.http_route('/race-info')
@@ -120,7 +115,6 @@ class SaveViewerWebServer(BaseWebServer):
             Returns:
                 Tuple[str, int]: JSON response and HTTP status code.
             """
-            self.m_stats.track_event("__HTTP__", "/race-info")
             return SaveViewerState.getRaceInfo()
 
         @self.http_route('/driver-info')
@@ -132,7 +126,6 @@ class SaveViewerWebServer(BaseWebServer):
                 Tuple[str, int]: JSON response and HTTP status code.
             """
 
-            self.m_stats.track_event("__HTTP__", "/driver-info")
             index: str = self.request.args.get('index')
 
             # Check if only one parameter is provided
@@ -175,15 +168,8 @@ class SaveViewerWebServer(BaseWebServer):
             client_type (ClientType): Client type
             client_id (str): Client ID
         """
-        self.m_stats.track_event("__SOCKET_IN__", "__CONNECT__")
-        self.m_stats.track_event("__SOCKET_IN__", f"__CONNECT__{str(client_type)}")
         if client_type == ClientType.RACE_TABLE:
             await self._send_race_table(client_id)
-
-    async def _on_client_disconnect(self, _sid: str) -> None:
-        """Called when a client disconnects
-        """
-        self.m_stats.track_event("__SOCKET_IN__", "__DISCONNECT__")
 
     async def _send_race_table(self, client_id: str) -> None:
         """Send race table to all connected clients
@@ -197,15 +183,12 @@ class SaveViewerWebServer(BaseWebServer):
         self.m_logger.debug("Sending race table update")
 
     async def send_to_clients_of_type(self, event: str, data: Dict[str, Any], client_type: ClientType) -> None:
-        self.m_stats.track_event("__SOCKET_OUT__", event)
         await super().send_to_clients_of_type(event, data, client_type)
 
     async def send_to_clients_interested_in_event(self, event: str, data: Dict[str, Any]) -> None:
-        self.m_stats.track_event("__SOCKET_OUT__", event)
         await super().send_to_clients_interested_in_event(event, data)
 
     async def send_to_client(self, event: str, data: Dict[str, Any], client_id: str) -> None:
-        self.m_stats.track_event("__SOCKET_OUT__", event)
         await super().send_to_client(event, data, client_id)
 
     def get_stats(self) -> dict:

--- a/apps/save_viewer/save_web_server.py
+++ b/apps/save_viewer/save_web_server.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import apps.save_viewer.save_viewer_state as SaveViewerState
 from lib.child_proc_mgmt import notify_parent_init_complete
+from lib.event_counter import EventCounter
 from lib.web_server import BaseWebServer, ClientType
 
 # -------------------------------------- CLASSES ----------------------------------------------------------------
@@ -60,9 +61,11 @@ class SaveViewerWebServer(BaseWebServer):
             debug_mode (bool, optional): Enable or disable debug mode. Defaults to False.
         """
         super().__init__(port, ver_str, logger, cert_path, key_path, debug_mode)
+        self.m_stats = EventCounter()
         self.define_routes()
         self.register_post_start_callback(self._post_start)
         self.register_on_client_register_callback(self._on_client_connect)
+        self.register_on_client_disconnect_callback(self._on_client_disconnect)
 
     def define_routes(self) -> None:
         """
@@ -88,6 +91,7 @@ class SaveViewerWebServer(BaseWebServer):
             Returns:
                 str: Rendered HTML content for the index page.
             """
+            self.m_stats.track_event("__HTTP__", "/")
             return await self.render_template('driver-view.html', live_data_mode=False, version=self.m_ver_str)
 
     def _defineDataRoutes(self) -> None:
@@ -105,6 +109,7 @@ class SaveViewerWebServer(BaseWebServer):
             Returns:
                 Tuple[str, int]: JSON response and HTTP status code.
             """
+            self.m_stats.track_event("__HTTP__", "/telemetry-info")
             return SaveViewerState.getTelemetryInfo()
 
         @self.http_route('/race-info')
@@ -115,6 +120,7 @@ class SaveViewerWebServer(BaseWebServer):
             Returns:
                 Tuple[str, int]: JSON response and HTTP status code.
             """
+            self.m_stats.track_event("__HTTP__", "/race-info")
             return SaveViewerState.getRaceInfo()
 
         @self.http_route('/driver-info')
@@ -126,6 +132,7 @@ class SaveViewerWebServer(BaseWebServer):
                 Tuple[str, int]: JSON response and HTTP status code.
             """
 
+            self.m_stats.track_event("__HTTP__", "/driver-info")
             index: str = self.request.args.get('index')
 
             # Check if only one parameter is provided
@@ -168,8 +175,15 @@ class SaveViewerWebServer(BaseWebServer):
             client_type (ClientType): Client type
             client_id (str): Client ID
         """
+        self.m_stats.track_event("__SOCKET_IN__", "__CONNECT__")
+        self.m_stats.track_event("__SOCKET_IN__", f"__CONNECT__{str(client_type)}")
         if client_type == ClientType.RACE_TABLE:
             await self._send_race_table(client_id)
+
+    async def _on_client_disconnect(self, _sid: str) -> None:
+        """Called when a client disconnects
+        """
+        self.m_stats.track_event("__SOCKET_IN__", "__DISCONNECT__")
 
     async def _send_race_table(self, client_id: str) -> None:
         """Send race table to all connected clients
@@ -183,12 +197,15 @@ class SaveViewerWebServer(BaseWebServer):
         self.m_logger.debug("Sending race table update")
 
     async def send_to_clients_of_type(self, event: str, data: Dict[str, Any], client_type: ClientType) -> None:
+        self.m_stats.track_event("__SOCKET_OUT__", event)
         await super().send_to_clients_of_type(event, data, client_type)
 
     async def send_to_clients_interested_in_event(self, event: str, data: Dict[str, Any]) -> None:
+        self.m_stats.track_event("__SOCKET_OUT__", event)
         await super().send_to_clients_interested_in_event(event, data)
 
     async def send_to_client(self, event: str, data: Dict[str, Any], client_id: str) -> None:
+        self.m_stats.track_event("__SOCKET_OUT__", event)
         await super().send_to_client(event, data, client_id)
 
     def get_stats(self) -> dict:

--- a/tests/tests_save_viewer_ipc.py
+++ b/tests/tests_save_viewer_ipc.py
@@ -32,6 +32,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Add the parent directory to the Python path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+import apps.save_viewer.save_viewer_state as SaveViewerState
 from apps.save_viewer.save_viewer_ipc import SaveViewerIpc
 from tests_base import F1TelemetryUnitTestsBase
 
@@ -40,8 +41,8 @@ from tests_base import F1TelemetryUnitTestsBase
 class TestSaveViewerIpcBase(F1TelemetryUnitTestsBase):
     """Base class for SaveViewerIpc tests."""
 
-class TestSaveViewerPathTraversal(TestSaveViewerIpcBase):
-    """Test path traversal protection in SaveViewerIpc._handle_open_file."""
+class TestOpenFileHelperValidation(TestSaveViewerIpcBase):
+    """Test path validation in open_file_helper."""
 
     def setUp(self):
         self.tmp_dir = tempfile.TemporaryDirectory()
@@ -56,14 +57,99 @@ class TestSaveViewerPathTraversal(TestSaveViewerIpcBase):
         self.outside_file = Path(self.tmp_dir.name) / "secret.txt"
         self.outside_file.write_text("secret", encoding="utf-8")
 
-        # Mock server with m_base_dir pointing to our tmp root
-        self.mock_server = MagicMock()
-        self.mock_server.m_base_dir = Path(self.tmp_dir.name)
-
         self.logger = logging.getLogger("test_save_viewer_ipc")
+        SaveViewerState.init_state(self.logger)
 
     def tearDown(self):
         self.tmp_dir.cleanup()
+
+    async def test_path_traversal_blocked(self):
+        """Path traversal via ../../ must be rejected."""
+        traversal_path = str(self.data_dir / ".." / "secret.txt")
+        result = await SaveViewerState.open_file_helper(traversal_path)
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("disallowed traversal", result["message"])
+
+    async def test_path_traversal_etc_passwd_blocked(self):
+        """Classic /etc/passwd traversal must be rejected."""
+        result = await SaveViewerState.open_file_helper("../../etc/passwd")
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("disallowed traversal", result["message"])
+
+    async def test_missing_file_path_rejected(self):
+        """Missing file-path argument must be rejected."""
+        result = await SaveViewerState.open_file_helper(None)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Missing", result["message"])
+
+        result = await SaveViewerState.open_file_helper("")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Missing", result["message"])
+
+    async def test_wrong_extension_rejected(self):
+        """Files with non-.json extension must be rejected."""
+        txt_file = Path(self.tmp_dir.name) / "notes.txt"
+        txt_file.write_text("not json", encoding="utf-8")
+
+        result = await SaveViewerState.open_file_helper(str(txt_file))
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("File type not allowed", result["message"])
+
+    async def test_directory_path_rejected(self):
+        """A directory path must be rejected."""
+        result = await SaveViewerState.open_file_helper(str(self.data_dir))
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("not point to an existing file", result["message"])
+
+    async def test_nonexistent_file_rejected(self):
+        """A path to a non-existent file (without ..) must be rejected."""
+        fake_path = Path(self.tmp_dir.name) / "does_not_exist.json"
+        result = await SaveViewerState.open_file_helper(str(fake_path))
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("not point to an existing file", result["message"])
+
+    async def test_path_resolve_oserror_rejected(self):
+        """If Path.resolve() raises OSError, the handler must return an error."""
+        with patch('apps.save_viewer.save_viewer_state.save_viewer_state.Path.resolve',
+                   side_effect=OSError("bad path")):
+            result = await SaveViewerState.open_file_helper("/some/valid-looking/path.json")
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Invalid file path", result["message"])
+
+    async def test_valid_json_file_accepted(self):
+        """A valid .json file must be accepted and loaded."""
+        with patch('apps.save_viewer.save_viewer_state.save_viewer_state._check_recompute_json'):
+            result = await SaveViewerState.open_file_helper(str(self.valid_file))
+
+        self.assertEqual(result["status"], "success")
+
+    async def test_valid_json_outside_data_accepted(self):
+        """A valid .json file outside data/ must be accepted (no whitelist)."""
+        external_dir = Path(self.tmp_dir.name) / "external_backup"
+        external_dir.mkdir()
+        external_json = external_dir / "race_backup.json"
+        external_json.write_text('{"test": true}', encoding="utf-8")
+
+        with patch('apps.save_viewer.save_viewer_state.save_viewer_state._check_recompute_json'):
+            result = await SaveViewerState.open_file_helper(str(external_json))
+
+        self.assertEqual(result["status"], "success")
+
+
+class TestSaveViewerIpcFlow(TestSaveViewerIpcBase):
+    """Test IPC handler flow (open-file -> browser -> broadcast)."""
+
+    def setUp(self):
+        self.mock_server = MagicMock()
+        self.mock_server.send_to_clients_of_type = AsyncMock()
+        self.mock_server.m_port = 8080
+        self.logger = logging.getLogger("test_save_viewer_ipc")
 
     def _create_ipc(self):
         """Create a SaveViewerIpc instance with mocked dependencies."""
@@ -72,104 +158,74 @@ class TestSaveViewerPathTraversal(TestSaveViewerIpcBase):
             ipc.m_logger = self.logger
             ipc.m_server = self.mock_server
             ipc.m_should_open_ui = False
+            ipc.m_ipc_server = MagicMock()
             return ipc
 
-    async def test_path_traversal_blocked(self):
-        """Path traversal via ../../ must be rejected."""
+    async def test_ipc_success_broadcasts_to_clients(self):
+        """On successful open, IPC handler must broadcast to clients."""
         ipc = self._create_ipc()
+        # Register routes to get the handler
+        ipc._register_routes()
 
-        # Attempt traversal using relative path that escapes data/
-        traversal_path = str(self.data_dir / ".." / "secret.txt")
-        result = await ipc._handle_open_file({"file-path": traversal_path})
+        # Find the registered open-file handler
+        handler = None
+        for call in ipc.m_ipc_server.on.call_args_list:
+            if call[0][0] == "open-file":
+                handler = call[1].get('handler') or ipc.m_ipc_server.on.return_value.call_args[0][0]
+                break
 
-        self.assertEqual(result["status"], "error")
-        self.assertIn("disallowed traversal", result["message"])
-
-    async def test_path_traversal_etc_passwd_blocked(self):
-        """Classic /etc/passwd traversal must be rejected."""
-        ipc = self._create_ipc()
-
-        result = await ipc._handle_open_file({"file-path": "../../etc/passwd"})
-
-        self.assertEqual(result["status"], "error")
-        self.assertIn("disallowed traversal", result["message"])
-
-    async def test_valid_path_in_data_accepted(self):
-        """A valid file path under data/ must be accepted."""
-        ipc = self._create_ipc()
-
+        # Since the decorator pattern captures the function, get it differently
+        # We test through _register_routes which registers handlers via decorators
+        # The simplest approach: call the method through the mock's decorator capture
         with patch('apps.save_viewer.save_viewer_state.open_file_helper', new_callable=AsyncMock) as mock_open, \
-             patch.object(ipc.m_server, 'send_to_clients_of_type', new_callable=AsyncMock) as mock_broadcast:
+             patch('apps.save_viewer.save_viewer_state.getTelemetryInfo') as mock_telemetry:
             mock_open.return_value = {"status": "success"}
-            result = await ipc._handle_open_file({"file-path": str(self.valid_file)})
+            mock_telemetry.return_value = {"data": "test"}
+
+            # Get the handler that was passed to the decorator
+            # m_ipc_server.on("open-file") returns a decorator, which is called with the function
+            decorator_calls = ipc.m_ipc_server.on.return_value.call_args_list
+            open_file_handler = decorator_calls[0][0][0]  # first decorator call, first positional arg
+
+            result = await open_file_handler({"file-path": "/tmp/test.json"})
 
         self.assertEqual(result["status"], "success")
-        mock_open.assert_called_once()
-        mock_broadcast.assert_called_once()
+        mock_open.assert_called_once_with("/tmp/test.json")
+        self.mock_server.send_to_clients_of_type.assert_called_once()
 
-    async def test_missing_file_path_rejected(self):
-        """Missing file-path argument must be rejected."""
+    async def test_ipc_error_does_not_broadcast(self):
+        """On validation error, IPC handler must NOT broadcast."""
         ipc = self._create_ipc()
-        result = await ipc._handle_open_file({})
+        ipc._register_routes()
+
+        with patch('apps.save_viewer.save_viewer_state.open_file_helper', new_callable=AsyncMock) as mock_open:
+            mock_open.return_value = {"status": "error", "message": "some error"}
+
+            decorator_calls = ipc.m_ipc_server.on.return_value.call_args_list
+            open_file_handler = decorator_calls[0][0][0]
+
+            result = await open_file_handler({"file-path": "/tmp/bad.json"})
+
         self.assertEqual(result["status"], "error")
-        self.assertIn("Missing", result["message"])
+        self.mock_server.send_to_clients_of_type.assert_not_called()
 
-    async def test_valid_json_outside_data_accepted(self):
-        """A valid .json file outside data/ must be accepted (no whitelist)."""
+    async def test_ipc_opens_browser_once(self):
+        """Browser should only open on the first successful open."""
         ipc = self._create_ipc()
-
-        # Create a JSON file completely outside data/
-        external_dir = Path(self.tmp_dir.name) / "external_backup"
-        external_dir.mkdir()
-        external_json = external_dir / "race_backup.json"
-        external_json.write_text('{"test": true}', encoding="utf-8")
+        ipc.m_should_open_ui = True
+        ipc._register_routes()
 
         with patch('apps.save_viewer.save_viewer_state.open_file_helper', new_callable=AsyncMock) as mock_open, \
-             patch.object(ipc.m_server, 'send_to_clients_of_type', new_callable=AsyncMock) as mock_broadcast:
+             patch('apps.save_viewer.save_viewer_state.getTelemetryInfo') as mock_telemetry, \
+             patch('apps.save_viewer.save_viewer_ipc.webbrowser.open') as mock_browser:
             mock_open.return_value = {"status": "success"}
-            result = await ipc._handle_open_file({"file-path": str(external_json)})
+            mock_telemetry.return_value = {"data": "test"}
 
-        self.assertEqual(result["status"], "success")
-        mock_open.assert_called_once()
-        mock_broadcast.assert_called_once()
+            decorator_calls = ipc.m_ipc_server.on.return_value.call_args_list
+            open_file_handler = decorator_calls[0][0][0]
 
-    async def test_wrong_extension_rejected(self):
-        """Files with non-.json extension must be rejected."""
-        ipc = self._create_ipc()
+            await open_file_handler({"file-path": "/tmp/test1.json"})
+            await open_file_handler({"file-path": "/tmp/test2.json"})
 
-        txt_file = Path(self.tmp_dir.name) / "notes.txt"
-        txt_file.write_text("not json", encoding="utf-8")
-
-        result = await ipc._handle_open_file({"file-path": str(txt_file)})
-
-        self.assertEqual(result["status"], "error")
-        self.assertIn("File type not allowed", result["message"])
-
-    async def test_directory_path_rejected(self):
-        """A directory path must be rejected."""
-        ipc = self._create_ipc()
-
-        result = await ipc._handle_open_file({"file-path": str(self.data_dir)})
-
-        self.assertEqual(result["status"], "error")
-        self.assertIn("not point to an existing file", result["message"])
-
-    async def test_nonexistent_file_rejected(self):
-        """A path to a non-existent file (without ..) must be rejected."""
-        ipc = self._create_ipc()
-
-        fake_path = Path(self.tmp_dir.name) / "does_not_exist.json"
-        result = await ipc._handle_open_file({"file-path": str(fake_path)})
-
-        self.assertEqual(result["status"], "error")
-        self.assertIn("not point to an existing file", result["message"])
-
-    async def test_path_resolve_oserror_rejected(self):
-        """If Path.resolve() raises OSError, the handler must return an error."""
-        ipc = self._create_ipc()
-
-        with patch('apps.save_viewer.save_viewer_ipc.Path.resolve', side_effect=OSError("bad path")):
-            result = await ipc._handle_open_file({"file-path": "/some/valid-looking/path.json"})
-
-        self.assertEqual(result["status"], "error")
-        self.assertIn("Invalid file path", result["message"])
+        # Browser should have been opened exactly once
+        mock_browser.assert_called_once()

--- a/tests/tests_save_viewer_ipc.py
+++ b/tests/tests_save_viewer_ipc.py
@@ -1,0 +1,163 @@
+# MIT License
+#
+# Copyright (c) [2025] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# pylint: skip-file
+
+import json
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add the parent directory to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from apps.save_viewer.save_viewer_ipc import SaveViewerIpc
+from tests_base import F1TelemetryUnitTestsBase
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+class TestSaveViewerIpcBase(F1TelemetryUnitTestsBase):
+    """Base class for SaveViewerIpc tests."""
+
+class TestSaveViewerPathTraversal(TestSaveViewerIpcBase):
+    """Test path traversal protection in SaveViewerIpc._handle_open_file."""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.data_dir = Path(self.tmp_dir.name) / "data"
+        self.data_dir.mkdir()
+
+        # Create a valid JSON file inside data/
+        self.valid_file = self.data_dir / "race.json"
+        self.valid_file.write_text('{"test": true}', encoding="utf-8")
+
+        # Create a file outside data/ to simulate traversal target
+        self.outside_file = Path(self.tmp_dir.name) / "secret.txt"
+        self.outside_file.write_text("secret", encoding="utf-8")
+
+        # Mock server with m_base_dir pointing to our tmp root
+        self.mock_server = MagicMock()
+        self.mock_server.m_base_dir = Path(self.tmp_dir.name)
+
+        self.logger = logging.getLogger("test_save_viewer_ipc")
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def _create_ipc(self):
+        """Create a SaveViewerIpc instance with mocked dependencies."""
+        with patch.object(SaveViewerIpc, '__init__', lambda self_, *a, **kw: None):
+            ipc = SaveViewerIpc.__new__(SaveViewerIpc)
+            ipc.m_logger = self.logger
+            ipc.m_server = self.mock_server
+            ipc.m_should_open_ui = False
+            return ipc
+
+    async def test_path_traversal_blocked(self):
+        """Path traversal via ../../ must be rejected."""
+        ipc = self._create_ipc()
+
+        # Attempt traversal using relative path that escapes data/
+        traversal_path = str(self.data_dir / ".." / "secret.txt")
+        result = await ipc._handle_open_file({"file-path": traversal_path})
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("disallowed traversal", result["message"])
+
+    async def test_path_traversal_etc_passwd_blocked(self):
+        """Classic /etc/passwd traversal must be rejected."""
+        ipc = self._create_ipc()
+
+        result = await ipc._handle_open_file({"file-path": "../../etc/passwd"})
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("disallowed traversal", result["message"])
+
+    async def test_valid_path_in_data_accepted(self):
+        """A valid file path under data/ must be accepted."""
+        ipc = self._create_ipc()
+
+        with patch('apps.save_viewer.save_viewer_state.open_file_helper', new_callable=AsyncMock) as mock_open, \
+             patch.object(ipc.m_server, 'send_to_clients_of_type', new_callable=AsyncMock):
+            mock_open.return_value = {"status": "success"}
+            result = await ipc._handle_open_file({"file-path": str(self.valid_file)})
+
+        self.assertEqual(result["status"], "success")
+        mock_open.assert_called_once()
+
+    async def test_missing_file_path_rejected(self):
+        """Missing file-path argument must be rejected."""
+        ipc = self._create_ipc()
+        result = await ipc._handle_open_file({})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Missing", result["message"])
+
+    async def test_valid_json_outside_data_accepted(self):
+        """A valid .json file outside data/ must be accepted (no whitelist)."""
+        ipc = self._create_ipc()
+
+        # Create a JSON file completely outside data/
+        external_dir = Path(self.tmp_dir.name) / "external_backup"
+        external_dir.mkdir()
+        external_json = external_dir / "race_backup.json"
+        external_json.write_text('{"test": true}', encoding="utf-8")
+
+        with patch('apps.save_viewer.save_viewer_state.open_file_helper', new_callable=AsyncMock) as mock_open, \
+             patch.object(ipc.m_server, 'send_to_clients_of_type', new_callable=AsyncMock):
+            mock_open.return_value = {"status": "success"}
+            result = await ipc._handle_open_file({"file-path": str(external_json)})
+
+        self.assertEqual(result["status"], "success")
+        mock_open.assert_called_once()
+
+    async def test_wrong_extension_rejected(self):
+        """Files with non-.json extension must be rejected."""
+        ipc = self._create_ipc()
+
+        txt_file = Path(self.tmp_dir.name) / "notes.txt"
+        txt_file.write_text("not json", encoding="utf-8")
+
+        result = await ipc._handle_open_file({"file-path": str(txt_file)})
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("File type not allowed", result["message"])
+
+    async def test_directory_path_rejected(self):
+        """A directory path must be rejected."""
+        ipc = self._create_ipc()
+
+        result = await ipc._handle_open_file({"file-path": str(self.data_dir)})
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("not point to an existing file", result["message"])
+
+    async def test_nonexistent_file_rejected(self):
+        """A path to a non-existent file (without ..) must be rejected."""
+        ipc = self._create_ipc()
+
+        fake_path = Path(self.tmp_dir.name) / "does_not_exist.json"
+        result = await ipc._handle_open_file({"file-path": str(fake_path)})
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("not point to an existing file", result["message"])

--- a/tests/tests_save_viewer_ipc.py
+++ b/tests/tests_save_viewer_ipc.py
@@ -99,12 +99,13 @@ class TestSaveViewerPathTraversal(TestSaveViewerIpcBase):
         ipc = self._create_ipc()
 
         with patch('apps.save_viewer.save_viewer_state.open_file_helper', new_callable=AsyncMock) as mock_open, \
-             patch.object(ipc.m_server, 'send_to_clients_of_type', new_callable=AsyncMock):
+             patch.object(ipc.m_server, 'send_to_clients_of_type', new_callable=AsyncMock) as mock_broadcast:
             mock_open.return_value = {"status": "success"}
             result = await ipc._handle_open_file({"file-path": str(self.valid_file)})
 
         self.assertEqual(result["status"], "success")
         mock_open.assert_called_once()
+        mock_broadcast.assert_called_once()
 
     async def test_missing_file_path_rejected(self):
         """Missing file-path argument must be rejected."""
@@ -124,12 +125,13 @@ class TestSaveViewerPathTraversal(TestSaveViewerIpcBase):
         external_json.write_text('{"test": true}', encoding="utf-8")
 
         with patch('apps.save_viewer.save_viewer_state.open_file_helper', new_callable=AsyncMock) as mock_open, \
-             patch.object(ipc.m_server, 'send_to_clients_of_type', new_callable=AsyncMock):
+             patch.object(ipc.m_server, 'send_to_clients_of_type', new_callable=AsyncMock) as mock_broadcast:
             mock_open.return_value = {"status": "success"}
             result = await ipc._handle_open_file({"file-path": str(external_json)})
 
         self.assertEqual(result["status"], "success")
         mock_open.assert_called_once()
+        mock_broadcast.assert_called_once()
 
     async def test_wrong_extension_rejected(self):
         """Files with non-.json extension must be rejected."""
@@ -161,3 +163,13 @@ class TestSaveViewerPathTraversal(TestSaveViewerIpcBase):
 
         self.assertEqual(result["status"], "error")
         self.assertIn("not point to an existing file", result["message"])
+
+    async def test_path_resolve_oserror_rejected(self):
+        """If Path.resolve() raises OSError, the handler must return an error."""
+        ipc = self._create_ipc()
+
+        with patch('apps.save_viewer.save_viewer_ipc.Path.resolve', side_effect=OSError("bad path")):
+            result = await ipc._handle_open_file({"file-path": "/some/valid-looking/path.json"})
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Invalid file path", result["message"])

--- a/tests/tests_save_viewer_ipc.py
+++ b/tests/tests_save_viewer_ipc.py
@@ -141,7 +141,6 @@ class TestOpenFileHelperValidation(TestSaveViewerIpcBase):
 
         self.assertEqual(result["status"], "success")
 
-
 class TestSaveViewerIpcFlow(TestSaveViewerIpcBase):
     """Test IPC handler flow (open-file -> browser -> broadcast)."""
 

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -96,6 +96,7 @@ from tests.tests_frame_gate import TestSessionFrameGate
 from tests.tests_track_segment_info import (TestSegmentRender,
                                              TestTrackSegments,
                                              TestTrackSegmentsDatabase)
+from tests.tests_save_viewer_ipc import TestOpenFileHelperValidation, TestSaveViewerIpcFlow
 
 # Initialize colorama
 init(autoreset=True)


### PR DESCRIPTION
## 📝 Description

Hardens the save viewer's IPC handler against path traversal attacks and adds comprehensive tests.

Key changes:
- Moves path validation (traversal check, resolve, is_file, .json extension) from the IPC handler into `open_file_helper()` in `save_viewer_state.py`
- IPC handler becomes a thin delegation layer: calls `open_file_helper`, handles browser-open + broadcast
- Adds `EventCounter` integration in `SaveViewerWebServer` for request metrics
- Tests restructured: `TestOpenFileHelperValidation` (9 tests) + `TestSaveViewerIpcFlow` (3 tests)

---

## 📂 Type of change

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [x] Refactor 🔨
- [ ] Documentation 📚
- [x] Tests ✅
- [ ] Other:

---

## 🧪 Backend Test Reports (required for Python/backend changes)

### ✅ Integration Tests

* [x] All integration tests pass
* Attach test command/output:

```
$ poetry run python tests/integration_test/runner.py

Files processed:        31
Telemetry sent:         31
Telemetry failed:       0
Endpoint checks passed: 806
Endpoint checks failed: 0
Telemetry success rate: 100.0%
Endpoint success rate:  100.0%
Total execution time: 44:03.297
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
N/A — changes are in apps/save_viewer/ only. Tests added in tests/tests_save_viewer_ipc.py (12 tests).
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---
