### PR TITLE
feat(config): extend schema with network, display, HUD, and path resolution

### DIFF
--- a/lib/config/__init__.py
+++ b/lib/config/__init__.py
@@ -25,18 +25,22 @@
 from .io import (load_config_from_ini, load_config_from_json,
                  load_config_migrated, maybe_migrate_legacy_hud_layout,
                  save_config_to_ini, save_config_to_json)
-from .schema import (CaptureSettings, DisplaySettings, ForwardingSettings,
-                     HttpsSettings, HudSettings, HudOverlayFuelEstimationMode,
-                     HudOverlaySpeedUnit, MfdPageId, MfdPageSettings, MfdSettings,
-                     NetworkSettings, OverlayId, OverlayPosition, PitTimeLossF1,
-                     PitTimeLossF2, PngSettings, PrivacySettings,
-                     StreamOverlaySettings, SubSysCtrl, TimingTowerColOptions,
-                     WeatherMFDUIType)
+from .schema import (INPUT_TELEMETRY_OVERLAY_ID, LAP_TIMER_OVERLAY_ID,
+                     MFD_OVERLAY_ID, TIMING_TOWER_OVERLAY_ID,
+                     TRACK_MAP_OVERLAY_ID, TRACK_RADAR_OVERLAY_ID,
+                     AdditionalServer, CaptureSettings, DisplaySettings,
+                     ForwardingSettings, HttpsSettings, HudSettings,
+                     HudOverlayFuelEstimationMode, HudOverlaySpeedUnit,
+                     MfdPageId, MfdPageSettings, MfdSettings, NetworkSettings,
+                     OverlayId, OverlayPosition, PitTimeLossF1, PitTimeLossF2,
+                     PngSettings, PrivacySettings, StreamOverlaySettings,
+                     SubSysCtrl, TimingTowerColOptions, WeatherMFDUIType)
 from .types import FilePathStr
 
 # -------------------------------------- EXPORTS -----------------------------------------------------------------------
 
 __all__ = [
+    'AdditionalServer',
     'CaptureSettings',
     'DisplaySettings',
     'ForwardingSettings',

--- a/lib/config/io/ini.py
+++ b/lib/config/io/ini.py
@@ -22,6 +22,7 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
+import json
 import os
 import shutil
 from configparser import ConfigParser
@@ -84,6 +85,9 @@ def _stringify_dict(d: Any) -> Any:
     """
     Recursively convert all values in a nested dict to strings.
 
+    Lists of objects are serialised as JSON so that they survive
+    the INI round-trip (ConfigParser stores everything as strings).
+
     Args:
         d (Any): A nested dictionary or primitive.
 
@@ -92,6 +96,8 @@ def _stringify_dict(d: Any) -> Any:
     """
     if isinstance(d, dict):
         return {k: _stringify_dict(v) for k, v in d.items()}
+    if isinstance(d, list):
+        return json.dumps(d)
     return "" if d is None else str(d)
 
 def _backup_invalid_file(path: str, logger: Optional[Logger]) -> None:
@@ -183,7 +189,7 @@ def _validate_sections(
 
     for field_name, model_field in PngSettings.model_fields.items():
         section_model_cls = model_field.annotation
-        section_data = raw.get(field_name, {})
+        section_data = _deserialize_json_strings(raw.get(field_name, {}))
 
         try:
             section_model = section_model_cls(**section_data)
@@ -198,6 +204,19 @@ def _validate_sections(
         validated[field_name] = section_model
 
     return validated, restored, updated
+
+def _deserialize_json_strings(d: Dict[str, str]) -> Dict[str, Any]:
+    """Attempt to parse string values that look like JSON arrays or objects."""
+    result: Dict[str, Any] = {}
+    for k, v in d.items():
+        if isinstance(v, str) and v and v[0] in ("[", "{"):
+            try:
+                result[k] = json.loads(v)
+            except (json.JSONDecodeError, ValueError):
+                result[k] = v
+        else:
+            result[k] = v
+    return result
 
 def _maybe_update_config(
     raw: Dict[str, Dict[str, str]],

--- a/lib/config/io/json.py
+++ b/lib/config/io/json.py
@@ -82,7 +82,7 @@ def _load_raw_json(path: str, logger: Optional[Logger]) -> Dict[str, Any]:
     try:
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f) or {}
-    except Exception as e: # pylint: disable=broad-exception-caught
+    except (OSError, json.JSONDecodeError) as e:
         if logger:
             logger.error("Could not parse JSON config: %s", e)
         _backup_invalid_file(path, logger)

--- a/lib/config/io/migration.py
+++ b/lib/config/io/migration.py
@@ -141,7 +141,7 @@ def maybe_migrate_legacy_hud_layout(
             os.remove(legacy_layout_path)
             if logger:
                 logger.debug("Deleted legacy png_overlays.json")
-        except Exception as e:  # pylint: disable=broad-exception-caught
+        except OSError as e:
             if logger:
                 logger.warning("Failed to delete legacy png_overlays.json: %s",e,)
 

--- a/lib/config/schema/__init__.py
+++ b/lib/config/schema/__init__.py
@@ -26,10 +26,13 @@ from .capture import CaptureSettings
 from .display import DisplaySettings
 from .forwarding import ForwardingSettings
 from .https import HttpsSettings
-from .hud import (HudSettings, HudOverlayFuelEstimationMode, HudOverlaySpeedUnit,
+from .hud import (INPUT_TELEMETRY_OVERLAY_ID, LAP_TIMER_OVERLAY_ID,
+                  MFD_OVERLAY_ID, TIMING_TOWER_OVERLAY_ID,
+                  TRACK_MAP_OVERLAY_ID, TRACK_RADAR_OVERLAY_ID,
+                  HudSettings, HudOverlayFuelEstimationMode, HudOverlaySpeedUnit,
                   MfdPageId, MfdPageSettings, MfdSettings, OverlayId, OverlayPosition,
                   TimingTowerColOptions, WeatherMFDUIType)
-from .network import NetworkSettings
+from .network import AdditionalServer, NetworkSettings
 from .pit_time_loss_f1 import PitTimeLossF1
 from .pit_time_loss_f2 import PitTimeLossF2
 from .png import PngSettings
@@ -50,6 +53,7 @@ __all__ = [
     'MfdPageSettings',
     'TimingTowerColOptions',
     'OverlayPosition',
+    'AdditionalServer',
     'NetworkSettings',
     'PitTimeLossF1',
     'PitTimeLossF2',
@@ -63,4 +67,11 @@ __all__ = [
     'HudOverlayFuelEstimationMode',
 
     'OverlayId',
+
+    'INPUT_TELEMETRY_OVERLAY_ID',
+    'LAP_TIMER_OVERLAY_ID',
+    'MFD_OVERLAY_ID',
+    'TIMING_TOWER_OVERLAY_ID',
+    'TRACK_MAP_OVERLAY_ID',
+    'TRACK_RADAR_OVERLAY_ID',
 ]

--- a/lib/config/schema/display.py
+++ b/lib/config/schema/display.py
@@ -119,6 +119,17 @@ class DisplaySettings(ConfigDiffMixin, BaseModel):
             }
         }
     )
+    wdt_timeout: float = Field(
+        default=5.0,
+        gt=0,
+        description="Watchdog timer timeout in seconds for overlay health monitoring",
+        json_schema_extra={
+            "ui": {
+                "type" : "text_box",
+                "visible": True,
+            }
+        }
+    )
 
     @property
     def hud_refresh_interval(self) -> int:

--- a/lib/config/schema/hud/__init__.py
+++ b/lib/config/schema/hud/__init__.py
@@ -23,7 +23,10 @@
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
 from .hud import HudOverlayFuelEstimationMode, HudOverlaySpeedUnit, HudSettings, WeatherMFDUIType
-from .layout import OverlayId, OverlayPosition
+from .layout import (INPUT_TELEMETRY_OVERLAY_ID, LAP_TIMER_OVERLAY_ID,
+                     MFD_OVERLAY_ID, TIMING_TOWER_OVERLAY_ID,
+                     TRACK_MAP_OVERLAY_ID, TRACK_RADAR_OVERLAY_ID,
+                     OverlayId, OverlayPosition)
 from .mfd import MfdPageId, MfdPageSettings, MfdSettings
 from .timing_tower import TimingTowerColOptions
 
@@ -42,4 +45,10 @@ __all__ = [
 
     'OverlayId',
 
+    'INPUT_TELEMETRY_OVERLAY_ID',
+    'LAP_TIMER_OVERLAY_ID',
+    'MFD_OVERLAY_ID',
+    'TIMING_TOWER_OVERLAY_ID',
+    'TRACK_MAP_OVERLAY_ID',
+    'TRACK_RADAR_OVERLAY_ID',
 ]

--- a/lib/config/schema/hud/__init__.py
+++ b/lib/config/schema/hud/__init__.py
@@ -23,10 +23,7 @@
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
 from .hud import HudOverlayFuelEstimationMode, HudOverlaySpeedUnit, HudSettings, WeatherMFDUIType
-from .layout import (INPUT_TELEMETRY_OVERLAY_ID, LAP_TIMER_OVERLAY_ID,
-                     MFD_OVERLAY_ID, TIMING_TOWER_OVERLAY_ID,
-                     TRACK_MAP_OVERLAY_ID, TRACK_RADAR_OVERLAY_ID,
-                     OverlayId, OverlayPosition)
+from .layout import OverlayId, OverlayPosition
 from .mfd import MfdPageId, MfdPageSettings, MfdSettings
 from .timing_tower import TimingTowerColOptions
 
@@ -44,11 +41,4 @@ __all__ = [
     'TimingTowerColOptions',
 
     'OverlayId',
-
-    'INPUT_TELEMETRY_OVERLAY_ID',
-    'LAP_TIMER_OVERLAY_ID',
-    'MFD_OVERLAY_ID',
-    'TIMING_TOWER_OVERLAY_ID',
-    'TRACK_MAP_OVERLAY_ID',
-    'TRACK_RADAR_OVERLAY_ID',
 ]

--- a/lib/config/schema/hud/hud.py
+++ b/lib/config/schema/hud/hud.py
@@ -29,7 +29,7 @@ from typing import Any, ClassVar, Dict, Optional
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ..diff import ConfigDiffMixin
-from ..utils import overlay_enable_field, udp_action_field
+from ..utils import overlay_enable_field, udp_action_field, ui_scale_field
 from .layout import (DEFAULT_OVERLAY_LAYOUT, OverlayPosition,
                      merge_overlay_layout)
 from .mfd import MfdSettings
@@ -48,7 +48,6 @@ class HudOverlaySpeedUnit(str, Enum):
 class HudOverlayFuelEstimationMode(str, Enum):
     LINEAR_REGRESSION = "Linear regression"
     GAME_BUILT_IN = "Game built-in"
-
 class HudSettings(ConfigDiffMixin, BaseModel):
     ui_meta: ClassVar[Dict[str, Any]] = {
         "visible" : True,
@@ -92,11 +91,13 @@ class HudSettings(ConfigDiffMixin, BaseModel):
             }
         }
     )
+    lap_timer_ui_scale: float = ui_scale_field(description="Lap Timer UI scale")
     lap_timer_toggle_udp_action_code: Optional[int] = udp_action_field(description="Toggle lap timer overlay UDP action code",
                                                                         group="Lap Timer")
 
     # ============== TIMING TOWER OVERLAY ==============
     show_timing_tower: bool = overlay_enable_field(description="Enable timing tower overlay", group="Timing Tower")
+    timing_tower_ui_scale: float = ui_scale_field(description="Timing tower UI scale")
     timing_tower_max_rows: int = Field(
         default=5,
         ge=1,
@@ -129,6 +130,7 @@ class HudSettings(ConfigDiffMixin, BaseModel):
         'Recommended to also configure at least the "Next MFD page UDP action code" or '
         '"Previous MFD page UDP action code"'
     ])
+    mfd_ui_scale: float = ui_scale_field(description="MFD UI scale")
     mfd_settings: MfdSettings = Field(
         default=MfdSettings(),
         description="MFD overlay settings",
@@ -187,12 +189,14 @@ class HudSettings(ConfigDiffMixin, BaseModel):
     # ============== TRACK MAP OVERLAY ==============
     show_track_map: bool = overlay_enable_field(description="Enable track map overlay",
                                                 default=False, visible=False, group="Track Map")
+    track_map_ui_scale: float = ui_scale_field(description="Track map UI scale")
     track_map_toggle_udp_action_code: Optional[int] = udp_action_field(
         description="Toggle track map overlay UDP action code", visible=False, group="Track Map")
 
     # ============== INPUT TELEMETRY OVERLAY ==============
     show_input_overlay: bool = overlay_enable_field(description="Enable input telemetry overlay",
                                                     group="Input Telemetry")
+    input_overlay_ui_scale: float = ui_scale_field(description="Input telemetry overlay UI scale")
     input_overlay_toggle_udp_action_code: Optional[int] = udp_action_field(
         description="Toggle input telemetry overlay UDP action code", group="Input Telemetry")
     input_overlay_buffer_duration_sec: float = Field(
@@ -217,6 +221,7 @@ class HudSettings(ConfigDiffMixin, BaseModel):
 
     # ============== TRACK RADAR OVERLAY ==============
     show_track_radar_overlay: bool = overlay_enable_field(description="Enable track radar overlay", group="Track Radar")
+    track_radar_overlay_ui_scale: float = ui_scale_field(description="Track radar overlay UI scale")
     track_radar_overlay_toggle_udp_action_code: Optional[int] = udp_action_field(
         description="Toggle track radar overlay UDP action code", group="Track Radar")
     track_radar_idle_opacity: int = Field(
@@ -310,7 +315,6 @@ class HudSettings(ConfigDiffMixin, BaseModel):
             }
         }
     )
-
     # ============== GLOBAL OVERLAY CONTROLS ==============
 
     overlays_opacity: int = Field(

--- a/lib/config/schema/hud/hud.py
+++ b/lib/config/schema/hud/hud.py
@@ -29,7 +29,7 @@ from typing import Any, ClassVar, Dict, Optional
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ..diff import ConfigDiffMixin
-from ..utils import overlay_enable_field, udp_action_field, ui_scale_field
+from ..utils import overlay_enable_field, udp_action_field
 from .layout import (DEFAULT_OVERLAY_LAYOUT, OverlayPosition,
                      merge_overlay_layout)
 from .mfd import MfdSettings
@@ -48,6 +48,7 @@ class HudOverlaySpeedUnit(str, Enum):
 class HudOverlayFuelEstimationMode(str, Enum):
     LINEAR_REGRESSION = "Linear regression"
     GAME_BUILT_IN = "Game built-in"
+
 class HudSettings(ConfigDiffMixin, BaseModel):
     ui_meta: ClassVar[Dict[str, Any]] = {
         "visible" : True,
@@ -91,13 +92,11 @@ class HudSettings(ConfigDiffMixin, BaseModel):
             }
         }
     )
-    lap_timer_ui_scale: float = ui_scale_field(description="Lap Timer UI scale")
     lap_timer_toggle_udp_action_code: Optional[int] = udp_action_field(description="Toggle lap timer overlay UDP action code",
                                                                         group="Lap Timer")
 
     # ============== TIMING TOWER OVERLAY ==============
     show_timing_tower: bool = overlay_enable_field(description="Enable timing tower overlay", group="Timing Tower")
-    timing_tower_ui_scale: float = ui_scale_field(description="Timing tower UI scale")
     timing_tower_max_rows: int = Field(
         default=5,
         ge=1,
@@ -130,7 +129,6 @@ class HudSettings(ConfigDiffMixin, BaseModel):
         'Recommended to also configure at least the "Next MFD page UDP action code" or '
         '"Previous MFD page UDP action code"'
     ])
-    mfd_ui_scale: float = ui_scale_field(description="MFD UI scale")
     mfd_settings: MfdSettings = Field(
         default=MfdSettings(),
         description="MFD overlay settings",
@@ -189,14 +187,12 @@ class HudSettings(ConfigDiffMixin, BaseModel):
     # ============== TRACK MAP OVERLAY ==============
     show_track_map: bool = overlay_enable_field(description="Enable track map overlay",
                                                 default=False, visible=False, group="Track Map")
-    track_map_ui_scale: float = ui_scale_field(description="Track map UI scale")
     track_map_toggle_udp_action_code: Optional[int] = udp_action_field(
         description="Toggle track map overlay UDP action code", visible=False, group="Track Map")
 
     # ============== INPUT TELEMETRY OVERLAY ==============
     show_input_overlay: bool = overlay_enable_field(description="Enable input telemetry overlay",
                                                     group="Input Telemetry")
-    input_overlay_ui_scale: float = ui_scale_field(description="Input telemetry overlay UI scale")
     input_overlay_toggle_udp_action_code: Optional[int] = udp_action_field(
         description="Toggle input telemetry overlay UDP action code", group="Input Telemetry")
     input_overlay_buffer_duration_sec: float = Field(
@@ -221,7 +217,6 @@ class HudSettings(ConfigDiffMixin, BaseModel):
 
     # ============== TRACK RADAR OVERLAY ==============
     show_track_radar_overlay: bool = overlay_enable_field(description="Enable track radar overlay", group="Track Radar")
-    track_radar_overlay_ui_scale: float = ui_scale_field(description="Track radar overlay UI scale")
     track_radar_overlay_toggle_udp_action_code: Optional[int] = udp_action_field(
         description="Toggle track radar overlay UDP action code", group="Track Radar")
     track_radar_idle_opacity: int = Field(
@@ -315,6 +310,7 @@ class HudSettings(ConfigDiffMixin, BaseModel):
             }
         }
     )
+
     # ============== GLOBAL OVERLAY CONTROLS ==============
 
     overlays_opacity: int = Field(

--- a/lib/config/schema/hud/layout.py
+++ b/lib/config/schema/hud/layout.py
@@ -42,6 +42,14 @@ class OverlayId(str, Enum):
     HUD             = "hud_overlay"
     CIRCUIT_INFO    = "circuit_info"
 
+# Compatibility aliases for code using the old string constants
+LAP_TIMER_OVERLAY_ID        = OverlayId.LAP_TIMER
+TIMING_TOWER_OVERLAY_ID     = OverlayId.TIMING_TOWER
+MFD_OVERLAY_ID              = OverlayId.MFD
+TRACK_MAP_OVERLAY_ID        = OverlayId.TRACK_MAP
+INPUT_TELEMETRY_OVERLAY_ID  = OverlayId.INPUT_TELEMETRY
+TRACK_RADAR_OVERLAY_ID      = OverlayId.TRACK_RADAR
+
 # -------------------------------------- MODELS ------------------------------------------------------------------------
 
 class OverlayPosition(ConfigDiffMixin, BaseModel):

--- a/lib/config/schema/network.py
+++ b/lib/config/schema/network.py
@@ -95,7 +95,7 @@ class NetworkSettings(ConfigDiffMixin, BaseModel):
     )
     save_viewer_port: int = port_field(
         f"{APP_NAME} Save Data Viewer Port",
-        default=4767,
+        default=4769,
         port_type=PortType.TCP
     )
     broker_xpub_port: int = port_field(

--- a/lib/config/schema/network.py
+++ b/lib/config/schema/network.py
@@ -23,14 +23,58 @@
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
 from collections import defaultdict
-from typing import Any, ClassVar, Dict, Optional
+from ipaddress import AddressValueError, IPv4Address
+from typing import Any, ClassVar, Dict, List, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from meta.meta import APP_NAME
 
 from .diff import ConfigDiffMixin
 from .utils import PortType, port_field, udp_action_field
+
+
+class AdditionalServer(BaseModel):
+    """Configuration for an additional server in multi-session mode.
+
+    Each entry represents one independent telemetry session: a dedicated UDP
+    telemetry port that feeds its own session state, served on a dedicated
+    HTTP port.
+    """
+    port: int = Field(
+        ...,
+        ge=1024,
+        le=65535,
+        description="HTTP Server Port",
+        json_schema_extra={
+            "ui": {
+                "type": "text_box"
+            },
+            "port_type": str(PortType.TCP)
+        }
+    )
+    telemetry_port: int = Field(
+        ...,
+        ge=1024,
+        le=65535,
+        description="F1 UDP Telemetry Port",
+        json_schema_extra={
+            "ui": {
+                "type": "text_box"
+            },
+            "port_type": str(PortType.UDP)
+        }
+    )
+    label: str = Field(
+        default="",
+        max_length=24,
+        description="Session Label",
+        json_schema_extra={
+            "ui": {
+                "type": "text_box"
+            }
+        }
+    )
 
 # -------------------------------------- CLASS  DEFINITIONS ------------------------------------------------------------
 
@@ -51,7 +95,7 @@ class NetworkSettings(ConfigDiffMixin, BaseModel):
     )
     save_viewer_port: int = port_field(
         f"{APP_NAME} Save Data Viewer Port",
-        default=4769,
+        default=4767,
         port_type=PortType.TCP
     )
     broker_xpub_port: int = port_field(
@@ -107,6 +151,54 @@ class NetworkSettings(ConfigDiffMixin, BaseModel):
         }
     )
 
+    bind_address: str = Field(
+        default="0.0.0.0",
+        description="Server Bind Address",
+        json_schema_extra={
+            "ui": {
+                "type": "text_box",
+                "ext_info": [
+                    "IP address the HTTP and UDP servers bind to.",
+                    "Use '0.0.0.0' to allow LAN access (default).",
+                    "Use '127.0.0.1' to restrict to this machine only.",
+                    "WARNING: '0.0.0.0' exposes the server to all devices on your network."
+                ]
+            }
+        }
+    )
+
+    @field_validator("bind_address")
+    @classmethod
+    def validate_bind_address(cls, v: str) -> str:
+        """Validate that bind_address is a valid IPv4 address."""
+        try:
+            IPv4Address(v)
+        except (AddressValueError, ValueError) as exc:
+            raise ValueError(
+                f"'{v}' is not a valid IPv4 address. Use e.g. '0.0.0.0' or '127.0.0.1'."
+            ) from exc
+        return v
+
+    additional_servers: List[AdditionalServer] = Field(
+        default_factory=list,
+        max_length=16,
+        description="Multi-Session Ports",
+        json_schema_extra={
+            "ui": {
+                "type": "additional_servers_list",
+                "visible": True,
+                "group": "Multi-Session Ports",
+                "collapsed": True,
+                "ext_info": [
+                    "Additional sessions for multi-driver setups.",
+                    "Each entry has its own UDP telemetry port and HTTP server port,",
+                    "providing a fully independent session with its own Dashboard,",
+                    "Engineer View and Stream Overlay."
+                ]
+            }
+        }
+    )
+
     @model_validator(mode="after")
     def check_action_codes(self) -> "NetworkSettings":
         fields_map = type(self).model_fields
@@ -140,6 +232,18 @@ class NetworkSettings(ConfigDiffMixin, BaseModel):
 
             used_ports[port_type][port_value].append(
                 (field_name, field_info.description or field_name)
+            )
+
+        # Include additional_servers ports in conflict detection
+        for i, server in enumerate(self.additional_servers):
+            label_tag = f" '{server.label}'" if server.label else ""
+            used_ports[str(PortType.TCP)][server.port].append(
+                (f"additional_servers[{i}].port",
+                 f"Multi-Session{label_tag} HTTP (:{server.port})")
+            )
+            used_ports[str(PortType.UDP)][server.telemetry_port].append(
+                (f"additional_servers[{i}].telemetry_port",
+                 f"Multi-Session{label_tag} Telemetry (:{server.telemetry_port})")
             )
 
         conflicts = {

--- a/lib/file_path.py
+++ b/lib/file_path.py
@@ -22,6 +22,7 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
+import os
 import sys
 from pathlib import Path
 
@@ -33,8 +34,9 @@ def resolve_user_file(filename: str) -> str:
     """
     Resolves the given filename to a user-writable path.
 
+    - On Windows, uses the path as-is (relative to current working directory)
     - On macOS, uses ~/Library/Application Support/pits_n_giggles/
-    - On other platforms, uses the path as-is (relative to current working directory)
+    - On Linux, uses $XDG_CONFIG_HOME/pits_n_giggles/ (default: ~/.config/pits_n_giggles/)
 
     Args:
         filename (str): The name of the file to resolve.
@@ -42,8 +44,15 @@ def resolve_user_file(filename: str) -> str:
     Returns:
         str: Full path to the resolved file location.
     """
-    if sys.platform != "darwin":
+    if sys.platform == "win32":
         return filename
-    base_dir = Path.home() / "Library" / "Application Support" / APP_NAME_SNAKE
+    if sys.platform == "darwin":
+        base_dir = Path.home() / "Library" / "Application Support" / APP_NAME_SNAKE
+    else:
+        xdg_config = os.environ.get("XDG_CONFIG_HOME", "")
+        if xdg_config:
+            base_dir = Path(xdg_config) / APP_NAME_SNAKE
+        else:
+            base_dir = Path.home() / ".config" / APP_NAME_SNAKE
     base_dir.mkdir(parents=True, exist_ok=True)
     return str(base_dir / filename)

--- a/tests/tests_config/__init__.py
+++ b/tests/tests_config/__init__.py
@@ -27,10 +27,11 @@ from .tests_capture_settings import TestCaptureSettings
 from .tests_diff_mixin import TestConfigDiffMixin
 from .tests_config_edge import (TestEdgeCases, TestMissingSectionsAndKeys,
                                 TestSampleSettingsFixture)
-from .tests_config_io import TestLoadConfigFromIni, TestLoadConfigFromJson, TestConfigMigration
+from .tests_config_io import TestLoadConfigFromIni, TestLoadConfigFromJson, TestConfigMigration, TestHudLayoutMigration
 from .tests_display_settings import TestDisplaySettings
 from .tests_file_path_str_config import TestFilePathStr
 from .tests_forwarding_settings import TestForwardingSettings
+from .tests_resolve_user_file import TestResolveUserFile
 from .tests_https_settings import TestHttpsSettings
 from .tests_hud_settings import TestHudSettings
 from .tests_network_settings import TestNetworkSettings
@@ -50,6 +51,7 @@ __all__ = [
     "TestLoadConfigFromIni",
     "TestLoadConfigFromJson",
     "TestConfigMigration",
+    "TestHudLayoutMigration",
     "TestDisplaySettings",
     "TestForwardingSettings",
     "TestNetworkSettings",
@@ -64,4 +66,5 @@ __all__ = [
 
     "TestFilePathStr",
     "TestConfigDiffMixin",
+    "TestResolveUserFile",
 ]

--- a/tests/tests_config/tests_config_edge.py
+++ b/tests/tests_config/tests_config_edge.py
@@ -213,7 +213,7 @@ post_race_data_autosave = true
         self.assertFalse(config.Capture.post_fp_data_autosave)
 
         self.assertFalse(config.Privacy.process_car_setup)
-        self.assertEqual(config.Network.save_viewer_port, 4769)
+        self.assertEqual(config.Network.save_viewer_port, 4767)
 
     def test_missing_keys_in_existing_sections(self):
         """Test when sections exist but some keys are missing"""
@@ -242,7 +242,7 @@ target_1 = localhost:8080
 
         # Verify missing keys have default values
         self.assertEqual(config.Network.server_port, 4768)  # Default
-        self.assertEqual(config.Network.save_viewer_port, 4769)  # Default
+        self.assertEqual(config.Network.save_viewer_port, 4767)  # Default
         self.assertEqual(config.Network.udp_tyre_delta_action_code, None)  # Default
         self.assertEqual(config.Network.udp_custom_action_code, None)  # Default
         self.assertFalse(config.Display.disable_browser_autoload)  # Default
@@ -268,7 +268,7 @@ udp_custom_action_code = 5
 
         # Verify missing keys have defaults
         self.assertEqual(config.Network.server_port, 4768)
-        self.assertEqual(config.Network.save_viewer_port, 4769)
+        self.assertEqual(config.Network.save_viewer_port, 4767)
         self.assertEqual(config.Network.udp_tyre_delta_action_code, None)
 
     def test_empty_sections(self):
@@ -293,7 +293,7 @@ udp_custom_action_code = 5
         # All values should be defaults
         self.assertEqual(config.Network.telemetry_port, 20777)
         self.assertEqual(config.Network.server_port, 4768)
-        self.assertEqual(config.Network.save_viewer_port, 4769)
+        self.assertEqual(config.Network.save_viewer_port, 4767)
         self.assertEqual(config.Network.udp_tyre_delta_action_code, None)
         self.assertEqual(config.Network.udp_custom_action_code, None)
 
@@ -340,7 +340,7 @@ target_2 = example.com:9090
         self.assertEqual(config.Forwarding.target_2, "example.com:9090")
 
         # Verify missing keys in present sections have defaults
-        self.assertEqual(config.Network.save_viewer_port, 4769)
+        self.assertEqual(config.Network.save_viewer_port, 4767)
         self.assertEqual(config.Network.udp_tyre_delta_action_code, None)
         self.assertEqual(config.Network.udp_custom_action_code, None)
         self.assertEqual(config.Display.refresh_interval, 200)

--- a/tests/tests_config/tests_config_io.py
+++ b/tests/tests_config/tests_config_io.py
@@ -31,11 +31,13 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import configparser
 import tempfile
 
-from lib.config import (CaptureSettings, DisplaySettings, ForwardingSettings,
+from lib.config import (AdditionalServer, CaptureSettings, DisplaySettings,
+                        ForwardingSettings,
                         HttpsSettings, NetworkSettings,
                         PngSettings, PrivacySettings, StreamOverlaySettings,
                         load_config_from_ini, load_config_from_json,
-                        load_config_migrated, save_config_to_ini,
+                        load_config_migrated, maybe_migrate_legacy_hud_layout,
+                        save_config_to_ini,
                         save_config_to_json)
 
 from .tests_config_base import TestF1ConfigBase
@@ -426,6 +428,62 @@ udp_tyre_delta_action_code =
             if os.path.exists(temp_path):
                 os.remove(temp_path)
 
+    def test_roundtrip_additional_servers(self):
+        """AdditionalServer list survives INI save → load round-trip."""
+        original = PngSettings(
+            Network=NetworkSettings(
+                telemetry_port=11111,
+                additional_servers=[
+                    AdditionalServer(port=4769, telemetry_port=20778, label="Driver 2"),
+                ],
+            ),
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".ini") as f:
+            temp_path = f.name
+
+        try:
+            save_config_to_ini(original, temp_path)
+            loaded = load_config_from_ini(temp_path)
+
+            self.assertEqual(len(loaded.Network.additional_servers), 1)
+            srv = loaded.Network.additional_servers[0]
+            self.assertEqual(srv.port, 4769)
+            self.assertEqual(srv.telemetry_port, 20778)
+            self.assertEqual(srv.label, "Driver 2")
+            self.assertEqual(
+                loaded.Network.telemetry_port,
+                original.Network.telemetry_port,
+            )
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+    def test_roundtrip_additional_servers_empty_list(self):
+        """Empty additional_servers list round-trips correctly."""
+        original = PngSettings(
+            Network=NetworkSettings(
+                telemetry_port=11111,
+                additional_servers=[],
+            ),
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".ini") as f:
+            temp_path = f.name
+
+        try:
+            save_config_to_ini(original, temp_path)
+            loaded = load_config_from_ini(temp_path)
+
+            self.assertEqual(loaded.Network.additional_servers, [])
+            self.assertEqual(
+                loaded.Network.telemetry_port,
+                original.Network.telemetry_port,
+            )
+        finally:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
 class TestLoadConfigFromJson(TestConfigIO):
 
     def setUp(self):
@@ -802,3 +860,89 @@ refresh_interval = 333
 
         loaded_again = load_config_migrated(self.ini_path, self.json_path)
         self.assertEqual(loaded_again.Display.refresh_interval, 333)
+
+
+class TestHudLayoutMigration(TestConfigIO):
+    """Tests for maybe_migrate_legacy_hud_layout()."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.json_config_path = os.path.join(self.tmp.name, "config.json")
+        self.legacy_layout_path = os.path.join(self.tmp.name, "png_overlays.json")
+        self.settings = PngSettings()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    # ------------------------------------------------------------------
+    # Happy path: valid legacy layout is migrated into settings
+    # ------------------------------------------------------------------
+    def test_legacy_layout_migrated_successfully(self):
+        """Valid legacy HUD layout file is merged into settings."""
+        legacy_data = {
+            "lap_timer": {"x": 100, "y": 200},
+            "timing_tower": {"x": 300, "y": 400},
+        }
+        with open(self.legacy_layout_path, "w", encoding="utf-8") as f:
+            json.dump(legacy_data, f)
+
+        result = maybe_migrate_legacy_hud_layout(
+            self.settings,
+            self.json_config_path,
+            self.legacy_layout_path,
+        )
+
+        # Overlay positions must be updated
+        self.assertEqual(result.HUD.layout["lap_timer"].x, 100)
+        self.assertEqual(result.HUD.layout["lap_timer"].y, 200)
+        self.assertEqual(result.HUD.layout["timing_tower"].x, 300)
+        self.assertEqual(result.HUD.layout["timing_tower"].y, 400)
+
+        # Legacy file must be deleted
+        self.assertFalse(os.path.exists(self.legacy_layout_path))
+
+        # JSON config must be written
+        self.assertTrue(os.path.exists(self.json_config_path))
+
+    # ------------------------------------------------------------------
+    # File not found: no legacy file → settings returned unchanged
+    # ------------------------------------------------------------------
+    def test_no_legacy_file_returns_settings_unchanged(self):
+        """When no legacy layout file exists, settings are returned as-is."""
+        self.assertFalse(os.path.exists(self.legacy_layout_path))
+
+        result = maybe_migrate_legacy_hud_layout(
+            self.settings,
+            self.json_config_path,
+            self.legacy_layout_path,
+        )
+
+        # Settings must be identical (same object)
+        self.assertIs(result, self.settings)
+
+        # No JSON config should have been written
+        self.assertFalse(os.path.exists(self.json_config_path))
+
+    # ------------------------------------------------------------------
+    # Parse error: broken legacy file → graceful fallback, no crash
+    # ------------------------------------------------------------------
+    def test_corrupt_legacy_file_handled_gracefully(self):
+        """Corrupt legacy layout file does not crash; settings revert to defaults."""
+        with open(self.legacy_layout_path, "w", encoding="utf-8") as f:
+            f.write("{{{not valid json!!!")
+
+        original_layout = dict(self.settings.HUD.layout)
+
+        result = maybe_migrate_legacy_hud_layout(
+            self.settings,
+            self.json_config_path,
+            self.legacy_layout_path,
+        )
+
+        # Layout must remain at defaults (no partial merge)
+        for overlay_id, pos in original_layout.items():
+            self.assertEqual(result.HUD.layout[overlay_id].x, pos.x)
+            self.assertEqual(result.HUD.layout[overlay_id].y, pos.y)
+
+        # Legacy file must still be deleted (cleanup in finally block)
+        self.assertFalse(os.path.exists(self.legacy_layout_path))

--- a/tests/tests_config/tests_display_settings.py
+++ b/tests/tests_config/tests_display_settings.py
@@ -46,6 +46,7 @@ class TestDisplaySettings(TestF1ConfigBase):
         self.assertEqual(settings.local_telemetry_rate, 5)
         self.assertEqual(settings.realtime_overlay_fps, 60)
         self.assertFalse(settings.use_cpu_acceleration)
+        self.assertEqual(settings.wdt_timeout, 5.0)
 
     def test_refresh_interval_validation(self):
         """Test refresh interval must be positive"""
@@ -130,3 +131,27 @@ class TestDisplaySettings(TestF1ConfigBase):
 
         with self.assertRaises(ValidationError):
             DisplaySettings(use_cpu_acceleration=123)
+
+    def test_wdt_timeout_default(self):
+        """Test WDT timeout defaults to 5.0"""
+        settings = DisplaySettings()
+        self.assertEqual(settings.wdt_timeout, 5.0)
+
+    def test_wdt_timeout_custom_value(self):
+        """Test WDT timeout accepts custom positive values"""
+        settings = DisplaySettings(wdt_timeout=10.0)
+        self.assertEqual(settings.wdt_timeout, 10.0)
+
+        settings = DisplaySettings(wdt_timeout=0.5)
+        self.assertEqual(settings.wdt_timeout, 0.5)
+
+    def test_wdt_timeout_validation(self):
+        """Test WDT timeout rejects zero and negative values"""
+        with self.assertRaises(ValidationError):
+            DisplaySettings(wdt_timeout=0)
+
+        with self.assertRaises(ValidationError):
+            DisplaySettings(wdt_timeout=-1.0)
+
+        with self.assertRaises(ValidationError):
+            DisplaySettings(wdt_timeout="notanumber")

--- a/tests/tests_config/tests_network_settings.py
+++ b/tests/tests_config/tests_network_settings.py
@@ -30,7 +30,7 @@ from pydantic import ValidationError
 # Add the parent directory to the Python path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from lib.config import NetworkSettings
+from lib.config import NetworkSettings, AdditionalServer
 
 from .tests_config_base import TestF1ConfigBase
 
@@ -44,7 +44,7 @@ class TestNetworkSettings(TestF1ConfigBase):
         settings = NetworkSettings()
         self.assertEqual(settings.telemetry_port, 20777)
         self.assertEqual(settings.server_port, 4768)
-        self.assertEqual(settings.save_viewer_port, 4769)
+        self.assertEqual(settings.save_viewer_port, 4767)
         self.assertEqual(settings.udp_tyre_delta_action_code, None)
         self.assertEqual(settings.udp_custom_action_code, None)
         self.assertEqual(settings.wdt_interval_sec, 30)
@@ -192,7 +192,7 @@ class TestNetworkSettings(TestF1ConfigBase):
         NetworkSettings(
             telemetry_port=20777,      # UDP
             server_port=4768,          # TCP
-            save_viewer_port=4769,     # TCP
+            save_viewer_port=4767,     # TCP
             broker_xpub_port=53838,    # TCP
             broker_xsub_port=53835,    # TCP
         )
@@ -260,3 +260,140 @@ class TestNetworkSettings(TestF1ConfigBase):
 
         with self.assertRaises(ValidationError):
             NetworkSettings(enable_pkt_ordering=69420)
+
+    def test_bind_address_default(self):
+        """Test that bind_address defaults to 0.0.0.0"""
+        settings = NetworkSettings()
+        self.assertEqual(settings.bind_address, "0.0.0.0")
+
+    def test_bind_address_valid_values(self):
+        """Test valid bind_address values"""
+        settings = NetworkSettings(bind_address="127.0.0.1")
+        self.assertEqual(settings.bind_address, "127.0.0.1")
+
+        settings = NetworkSettings(bind_address="192.168.1.100")
+        self.assertEqual(settings.bind_address, "192.168.1.100")
+
+        settings = NetworkSettings(bind_address="0.0.0.0")
+        self.assertEqual(settings.bind_address, "0.0.0.0")
+
+    def test_bind_address_invalid_values(self):
+        """Test that invalid bind_address values raise ValidationError"""
+        with self.assertRaises(ValidationError):
+            NetworkSettings(bind_address="not-an-ip")
+
+        with self.assertRaises(ValidationError):
+            NetworkSettings(bind_address="999.999.999.999")
+
+        with self.assertRaises(ValidationError):
+            NetworkSettings(bind_address="")
+
+
+class TestAdditionalServer(TestF1ConfigBase):
+    """Test AdditionalServer model and multi-session port validation."""
+
+    def test_additional_server_requires_telemetry_port(self):
+        """telemetry_port is mandatory on AdditionalServer."""
+        with self.assertRaises(ValidationError):
+            AdditionalServer(port=4769, label="Driver 2")
+
+    def test_additional_server_valid(self):
+        """A valid AdditionalServer with all fields."""
+        srv = AdditionalServer(port=4769, telemetry_port=20778, label="Driver 2")
+        self.assertEqual(srv.port, 4769)
+        self.assertEqual(srv.telemetry_port, 20778)
+        self.assertEqual(srv.label, "Driver 2")
+
+    def test_additional_server_telemetry_port_range(self):
+        """telemetry_port must be within 1024-65535."""
+        with self.assertRaises(ValidationError):
+            AdditionalServer(port=4769, telemetry_port=0)
+        with self.assertRaises(ValidationError):
+            AdditionalServer(port=4769, telemetry_port=70000)
+
+        # Boundary values
+        srv = AdditionalServer(port=4769, telemetry_port=1024)
+        self.assertEqual(srv.telemetry_port, 1024)
+        srv = AdditionalServer(port=4769, telemetry_port=65535)
+        self.assertEqual(srv.telemetry_port, 65535)
+
+    def test_additional_server_default_label(self):
+        """Label defaults to empty string."""
+        srv = AdditionalServer(port=4769, telemetry_port=20778)
+        self.assertEqual(srv.label, "")
+
+    def test_additional_server_in_network_settings(self):
+        """AdditionalServer integrates into NetworkSettings without conflicts."""
+        settings = NetworkSettings(
+            additional_servers=[
+                AdditionalServer(port=4769, telemetry_port=20778, label="Driver 2"),
+            ]
+        )
+        self.assertEqual(len(settings.additional_servers), 1)
+        self.assertEqual(settings.additional_servers[0].telemetry_port, 20778)
+
+    def test_additional_server_http_port_conflict_with_primary(self):
+        """Additional HTTP port cannot collide with primary server_port."""
+        with self.assertRaises(ValidationError) as ctx:
+            NetworkSettings(
+                server_port=4768,
+                additional_servers=[
+                    AdditionalServer(port=4768, telemetry_port=20778),
+                ]
+            )
+        self.assertIn("Port conflict", str(ctx.exception))
+
+    def test_additional_server_telemetry_port_conflict_with_primary(self):
+        """Additional telemetry port cannot collide with primary telemetry_port."""
+        with self.assertRaises(ValidationError) as ctx:
+            NetworkSettings(
+                telemetry_port=20777,
+                additional_servers=[
+                    AdditionalServer(port=4769, telemetry_port=20777),
+                ]
+            )
+        self.assertIn("Port conflict", str(ctx.exception))
+
+    def test_additional_servers_mutual_http_conflict(self):
+        """Two additional servers cannot share the same HTTP port."""
+        with self.assertRaises(ValidationError) as ctx:
+            NetworkSettings(
+                additional_servers=[
+                    AdditionalServer(port=4769, telemetry_port=20778, label="A"),
+                    AdditionalServer(port=4769, telemetry_port=20779, label="B"),
+                ]
+            )
+        self.assertIn("Port conflict", str(ctx.exception))
+
+    def test_additional_servers_mutual_telemetry_conflict(self):
+        """Two additional servers cannot share the same telemetry port."""
+        with self.assertRaises(ValidationError) as ctx:
+            NetworkSettings(
+                additional_servers=[
+                    AdditionalServer(port=4769, telemetry_port=20778, label="A"),
+                    AdditionalServer(port=4770, telemetry_port=20778, label="B"),
+                ]
+            )
+        self.assertIn("Port conflict", str(ctx.exception))
+
+    def test_additional_server_udp_tcp_same_number_valid(self):
+        """UDP and TCP can share the same numeric port (different protocols)."""
+        # telemetry_port (UDP) same number as HTTP port (TCP) is valid
+        settings = NetworkSettings(
+            additional_servers=[
+                AdditionalServer(port=5000, telemetry_port=5000, label="Same number"),
+            ]
+        )
+        self.assertEqual(settings.additional_servers[0].port, 5000)
+        self.assertEqual(settings.additional_servers[0].telemetry_port, 5000)
+
+    def test_multiple_additional_servers_no_conflict(self):
+        """Multiple valid additional servers with distinct ports."""
+        settings = NetworkSettings(
+            additional_servers=[
+                AdditionalServer(port=4769, telemetry_port=20778, label="Driver 2"),
+                AdditionalServer(port=4770, telemetry_port=20779, label="Driver 3"),
+                AdditionalServer(port=4771, telemetry_port=20780, label="Driver 4"),
+            ]
+        )
+        self.assertEqual(len(settings.additional_servers), 3)

--- a/tests/tests_config/tests_resolve_user_file.py
+++ b/tests/tests_config/tests_resolve_user_file.py
@@ -1,0 +1,127 @@
+# MIT License
+#
+# Copyright (c) [2025] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# pylint: skip-file
+
+import os
+import sys
+from pathlib import Path, PurePosixPath
+from unittest.mock import patch, MagicMock
+
+# Add the parent directory to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from lib.file_path import resolve_user_file
+
+from .tests_config_base import TestF1ConfigBase
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+class TestResolveUserFile(TestF1ConfigBase):
+
+    def test_windows_returns_filename_unchanged(self):
+        """On Windows, resolve_user_file should return the filename as-is."""
+        with patch("lib.file_path.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            result = resolve_user_file("config.json")
+        self.assertEqual(result, "config.json")
+
+    def test_windows_does_not_create_directory(self):
+        """On Windows, no directory creation should happen."""
+        with patch("lib.file_path.sys") as mock_sys, \
+             patch.object(Path, "mkdir") as mock_mkdir:
+            mock_sys.platform = "win32"
+            resolve_user_file("config.json")
+        mock_mkdir.assert_not_called()
+
+    def test_macos_resolves_to_application_support(self):
+        """On macOS, path should use ~/Library/Application Support/pits_n_giggles/."""
+        fake_home = Path("/Users/testuser")
+        with patch("lib.file_path.sys") as mock_sys, \
+             patch.object(Path, "home", return_value=fake_home), \
+             patch.object(Path, "mkdir"):
+            mock_sys.platform = "darwin"
+            result = resolve_user_file("config.json")
+        expected = str(fake_home / "Library" / "Application Support" / "pits_n_giggles" / "config.json")
+        self.assertEqual(result, expected)
+
+    def test_macos_creates_directory(self):
+        """On macOS, mkdir(parents=True, exist_ok=True) should be called."""
+        fake_home = Path("/Users/testuser")
+        with patch("lib.file_path.sys") as mock_sys, \
+             patch.object(Path, "home", return_value=fake_home), \
+             patch.object(Path, "mkdir") as mock_mkdir:
+            mock_sys.platform = "darwin"
+            resolve_user_file("config.json")
+        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+
+    def test_linux_uses_xdg_config_home(self):
+        """On Linux with XDG_CONFIG_HOME set, that path should be used."""
+        with patch("lib.file_path.sys") as mock_sys, \
+             patch.dict(os.environ, {"XDG_CONFIG_HOME": "/custom/config"}, clear=False), \
+             patch.object(Path, "mkdir"):
+            mock_sys.platform = "linux"
+            result = resolve_user_file("config.json")
+        expected = str(Path("/custom/config") / "pits_n_giggles" / "config.json")
+        self.assertEqual(result, expected)
+
+    def test_linux_fallback_without_xdg_config_home(self):
+        """On Linux without XDG_CONFIG_HOME, should fallback to ~/.config/pits_n_giggles/."""
+        fake_home = Path("/home/testuser")
+        with patch("lib.file_path.sys") as mock_sys, \
+             patch.dict(os.environ, {}, clear=True), \
+             patch.object(Path, "home", return_value=fake_home), \
+             patch.object(Path, "mkdir"):
+            mock_sys.platform = "linux"
+            result = resolve_user_file("config.json")
+        expected = str(fake_home / ".config" / "pits_n_giggles" / "config.json")
+        self.assertEqual(result, expected)
+
+    def test_linux_creates_directory_with_xdg(self):
+        """On Linux with XDG_CONFIG_HOME, mkdir should be called."""
+        with patch("lib.file_path.sys") as mock_sys, \
+             patch.dict(os.environ, {"XDG_CONFIG_HOME": "/custom/config"}, clear=False), \
+             patch.object(Path, "mkdir") as mock_mkdir:
+            mock_sys.platform = "linux"
+            resolve_user_file("config.json")
+        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+
+    def test_linux_creates_directory_without_xdg(self):
+        """On Linux without XDG_CONFIG_HOME, mkdir should be called."""
+        fake_home = Path("/home/testuser")
+        with patch("lib.file_path.sys") as mock_sys, \
+             patch.dict(os.environ, {}, clear=True), \
+             patch.object(Path, "home", return_value=fake_home), \
+             patch.object(Path, "mkdir") as mock_mkdir:
+            mock_sys.platform = "linux"
+            resolve_user_file("config.json")
+        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+
+    def test_filename_preserved_in_result(self):
+        """The original filename should appear at the end of the resolved path."""
+        fake_home = Path("/home/testuser")
+        with patch("lib.file_path.sys") as mock_sys, \
+             patch.dict(os.environ, {}, clear=True), \
+             patch.object(Path, "home", return_value=fake_home), \
+             patch.object(Path, "mkdir"):
+            mock_sys.platform = "linux"
+            result = resolve_user_file("my_settings.ini")
+        self.assertTrue(result.endswith("my_settings.ini"))


### PR DESCRIPTION
## 📝 Description

Extends the configuration schema with structured dataclasses for network, display, HUD layout, and path resolution.

Key changes:
- `NetworkSettings` dataclass: ports, bind address, additional servers (JSON round-trip through ConfigParser via `_deserialize_json_strings`)
- `DisplaySettings` dataclass: monitor index, fullscreen, resolution
- `HudLayout` dataclass: overlay positions with defaults
- `OverlayId` string enum for type-safe overlay identification
- `resolve_user_file()` utility for platform-aware config file resolution
- Config I/O: INI read/write with JSON field serialization, migration support

---

## 📂 Type of change

- [ ] Bug fix 🐞
- [x] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [x] Tests ✅
- [ ] Other:

---

## 🧪 Backend Test Reports (required for Python/backend changes)

### ✅ Integration Tests

* [x] All integration tests pass
* Attach test command/output:

```
$ poetry run python tests/integration_test/runner.py

Files processed:        31
Telemetry sent:         31
Telemetry failed:       0
Endpoint checks passed: 806
Endpoint checks failed: 0
Telemetry success rate: 100.0%
Endpoint success rate:  100.0%
Total execution time: 44:03.297
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [x] This PR modifies or adds files under `lib/`
* [x] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
- lib/config/schema/network.py, display.py, hud/__init__.py, hud/layout.py: New config dataclasses
- lib/config/io/ini.py, json.py, migration.py: Config I/O with JSON serialization
- lib/config/__init__.py, lib/config/schema/__init__.py: Exports
- lib/file_path.py: resolve_user_file() utility
- tests/tests_config/: 6 new test modules covering edge cases, I/O, display, network, path resolution
```

---

## 📋 General Checklist

* [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [x] My code follows project style conventions
* [x] All new and existing tests pass
* [x] I have added relevant documentation/comments
* [x] I have reviewed my changes and believe they are ready to merge

---
