### PR TITLE
feat(eng-view): add pinnable ref driver and track map rotation

### DIFF
--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -673,7 +673,7 @@ input[type="number"]::-webkit-outer-spin-button {
     align-self: start;
 }
 
-.global-stats-section-header > :nth-child(2) {
+.global-stats-section-header > :last-child {
     margin-left: auto;
 }
 
@@ -783,6 +783,40 @@ input[type="number"]::-webkit-outer-spin-button {
 
 .track-map-zoom-reset:hover {
     background: rgba(60, 60, 80, 0.95);
+}
+
+/* ── Track Map Rotation Control ──────────────────────────────── */
+
+.track-map-rotation-ctrl {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex: 1;
+    min-width: 0;
+}
+
+.track-map-rotation-label {
+    color: #aaa;
+    font-size: 1.1rem;
+    flex-shrink: 0;
+}
+
+.track-map-rotation-slider {
+    flex: 1;
+    min-width: 0;
+    accent-color: #e10600;
+    cursor: pointer;
+}
+
+.track-map-rotation-input {
+    width: 58px;
+    background: transparent;
+    border: 1px solid #555;
+    border-radius: 3px;
+    color: #fff;
+    font-size: 0.75rem;
+    text-align: center;
+    padding: 3px 4px;
 }
 
 /* ── Responsive: AG Grid font scaling ────────────────────────── */

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -125,8 +125,10 @@ body {
 }
 
 .collapsed-bar-icon {
-    font-size: 0.8rem;
     color: var(--f1-text-secondary);
+    width: 1em;
+    height: 1em;
+    flex-shrink: 0;
 }
 
 .collapsed-bar-actions {

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -326,6 +326,48 @@ input[type="number"]::-webkit-outer-spin-button {
     border-radius: 4px !important;
 }
 
+/* Pin reference driver button inside Name cell */
+.driver-name-cell {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+}
+
+.driver-name-cell-text {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.pin-ref-btn {
+    background: none;
+    border: none;
+    color: var(--f1-text-secondary);
+    cursor: pointer;
+    padding: 0 4px;
+    font-size: 0.85rem;
+    opacity: 0;
+    transition: opacity 0.15s, color 0.15s;
+    flex-shrink: 0;
+}
+
+.ag-row:hover .pin-ref-btn {
+    opacity: 1;
+}
+
+.ref-row .pin-ref-btn {
+    opacity: 1;
+}
+
+.pin-ref-btn:hover {
+    color: #ffd700;
+}
+
+@media (hover: none) {
+    .pin-ref-btn { opacity: 1; }
+}
+
 .ag-header-cell-text {
     text-align: center;
 }

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -982,7 +982,11 @@ input[type="number"]::-webkit-outer-spin-button {
     }
 
     #raceStatusSummary {
-        flex-shrink: 0;
+        flex-shrink: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 }
 
@@ -1090,19 +1094,19 @@ input[type="number"]::-webkit-outer-spin-button {
         max-width: 100% !important;
     }
 
-    /* ── Mobile header fix: wrap title+summary / buttons ──── */
+    /* Allow header to wrap only when content doesn't fit — don't force 2 rows */
     .global-stats-section-header {
         flex-wrap: wrap;
     }
 
     .race-status-header-left {
-        width: 100%;
+        flex: 1 1 auto;
+        min-width: 0;
     }
 
     .global-stats-section-header > .d-flex:not(.race-status-header-left) {
-        margin-left: auto;
-        flex-wrap: wrap;
-        gap: 0.25rem;
+        flex: 0 0 auto;
+        flex-wrap: nowrap;
     }
 }
 
@@ -1110,26 +1114,27 @@ input[type="number"]::-webkit-outer-spin-button {
 
 @media (max-width: 600px) {
 
-    /* ── Header: 2-row layout (info + actions) ──── */
+    /* ── Header: wrap to 2 rows only when needed ──── */
 
     .global-stats-section-header {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 0.375rem;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.25rem;
         padding: 0.5rem 0.75rem;
     }
 
-    /* Row 1: track name + session summary */
+    /* Info side: shrink but don't force full width */
     .race-status-header-left {
-        width: 100%;
-        flex-wrap: wrap;
+        flex: 1 1 auto;
+        min-width: 0;
+        flex-wrap: nowrap;
         gap: 0;
         order: 0;
     }
 
     #raceStatusHeader {
-        width: 100%;
-        flex-shrink: 0;
+        flex-shrink: 1;
+        min-width: 0;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
@@ -1138,28 +1143,32 @@ input[type="number"]::-webkit-outer-spin-button {
     }
 
     #raceStatusSummary {
-        width: 100%;
         flex-shrink: 1;
+        min-width: 0;
         white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-size: 0.72rem;
         margin-left: 0;
-        margin-top: 0.125rem;
     }
 
     .race-status-summary-sep {
         margin: 0 0.2rem;
     }
 
-    /* Row 2: action buttons */
+    /* Buttons side: don't force full width, sit next to info when space allows */
     .global-stats-section-header > .d-flex:not(.race-status-header-left) {
-        width: 100%;
-        justify-content: space-between;
+        flex: 0 0 auto;
+        justify-content: flex-end;
         flex-wrap: nowrap;
         order: 1;
-        border-top: 1px solid rgba(255, 255, 255, 0.08);
-        padding-top: 0.375rem;
-        margin-left: 0;
+        margin-left: auto;
         gap: 0;
+    }
+
+    /* When buttons wrap to their own row, stretch them edge-to-edge */
+    @supports (container-type: inline-size) {
+        /* fallback handled via the flex natural wrapping */
     }
 
     /* Buttons: keep 44px touch targets, tighten spacing */
@@ -1178,7 +1187,7 @@ input[type="number"]::-webkit-outer-spin-button {
         font-size: 1.6rem !important;
     }
 
-    /* Chevron: ganz links in der Button-Reihe */
+    /* Chevron: first in the button group */
     #raceStatusCollapseBtn {
         order: -1;
     }

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -25,8 +25,65 @@ body {
 
 .eng-view-global-data-section {
     flex: 0 1 auto;
-    padding: 1rem;
-    border-bottom: 1px solid #333;
+    padding: 0.75rem;
+    background: var(--f1-darker);
+}
+
+/* ── Upper Section Accordion ─────────────────────────────────── */
+
+.upper-section-accordion-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.35rem 1rem;
+    background: var(--f1-darker);
+    border: 1px solid var(--bs-secondary-border-subtle, #495057);
+    border-radius: 0.375rem 0.375rem 0 0;
+    cursor: pointer;
+    user-select: none;
+}
+
+.upper-section-accordion-header:hover {
+    background: var(--f1-gray);
+}
+
+.upper-section-accordion-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--f1-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.upper-section-chevron {
+    font-size: 0.75rem;
+    transition: transform 0.3s ease;
+}
+
+.upper-section-accordion-header.collapsed .upper-section-chevron {
+    transform: rotate(-90deg);
+}
+
+.upper-section-accordion-body {
+    padding: 0.75rem;
+    overflow: hidden;
+    transition: max-height 0.35s ease, opacity 0.25s ease, padding 0.35s ease;
+    max-height: 1000px;
+    opacity: 1;
+    border: 1px solid var(--bs-secondary-border-subtle, #495057);
+    border-top: none;
+    border-radius: 0 0 0.375rem 0.375rem;
+    background: var(--f1-dark);
+}
+
+.upper-section-accordion-body.collapsed {
+    max-height: 0 !important;
+    opacity: 0;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
 }
 
 .eng-view-race-table-section {

--- a/apps/frontend/css/engView.css
+++ b/apps/frontend/css/engView.css
@@ -41,6 +41,13 @@ body {
     border-radius: 0.375rem 0.375rem 0 0;
     cursor: pointer;
     user-select: none;
+    min-height: 2.25rem;
+    transition: min-height 0.35s ease;
+}
+
+.upper-section-accordion-header.collapsed {
+    min-height: 3.25rem;
+    border-radius: 0.375rem;
 }
 
 .upper-section-accordion-header:hover {
@@ -65,6 +72,109 @@ body {
 
 .upper-section-accordion-header.collapsed .upper-section-chevron {
     transform: rotate(-90deg);
+}
+
+/* ── Collapsed Info Bar ──────────────────────────────────────── */
+
+.upper-section-collapsed-bar {
+    display: none;
+    align-items: center;
+    gap: 0.6rem;
+    flex: 1;
+    margin-left: 1rem;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.upper-section-accordion-header.collapsed .upper-section-collapsed-bar {
+    display: flex;
+}
+
+.collapsed-bar-circuit {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--f1-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 14rem;
+}
+
+.collapsed-bar-time {
+    font-size: 0.85rem;
+    color: var(--f1-text-secondary);
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+
+.collapsed-bar-sep {
+    width: 1px;
+    height: 1.2rem;
+    background: rgba(255, 255, 255, 0.15);
+    flex-shrink: 0;
+}
+
+.collapsed-bar-item {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+    color: var(--f1-text);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.collapsed-bar-icon {
+    font-size: 0.8rem;
+    color: var(--f1-text-secondary);
+}
+
+.collapsed-bar-actions {
+    margin-left: auto;
+    gap: 0.5rem;
+}
+
+.collapsed-bar-action-btn {
+    background: none;
+    border: none;
+    padding: 0.1rem 0.3rem;
+    font-size: 0.85rem;
+    line-height: 1;
+    color: var(--f1-text);
+    cursor: pointer;
+}
+
+.collapsed-bar-action-btn:hover {
+    color: var(--f1-red);
+}
+
+.collapsed-bar-pred {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.collapsed-bar-pred-label {
+    font-size: 0.75rem;
+    color: var(--f1-text-secondary);
+    white-space: nowrap;
+    margin: 0;
+}
+
+.collapsed-bar-pred-input {
+    width: 64px !important;
+    height: 26px;
+    padding: 0.1rem 0.35rem;
+    font-size: 0.8rem;
+    background-color: #111 !important;
+    color: var(--f1-text) !important;
+    border-color: #333 !important;
+}
+
+.collapsed-bar-pred-input:focus {
+    background-color: #222 !important;
+    border-color: #444 !important;
+    box-shadow: 0 0 0 0.15rem rgba(66, 70, 73, 0.5) !important;
 }
 
 .upper-section-accordion-body {

--- a/apps/frontend/html/eng-view-trackmap.html
+++ b/apps/frontend/html/eng-view-trackmap.html
@@ -128,6 +128,45 @@
             background: rgba(60, 60, 80, 0.95);
         }
 
+        .track-map-rotation-ctrl {
+            position: absolute;
+            bottom: 10px;
+            left: 10px;
+            right: 10px;
+            z-index: 10;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            background: rgba(21, 21, 30, 0.85);
+            border: 1px solid #555;
+            border-radius: 6px;
+            padding: 5px 10px;
+        }
+
+        .track-map-rotation-label {
+            color: #aaa;
+            font-size: 0.85rem;
+            white-space: nowrap;
+        }
+
+        .track-map-rotation-slider {
+            flex: 1;
+            min-width: 0;
+            accent-color: #e10600;
+            cursor: pointer;
+        }
+
+        .track-map-rotation-input {
+            width: 54px;
+            background: transparent;
+            border: 1px solid #555;
+            border-radius: 3px;
+            color: #fff;
+            font-size: 0.85rem;
+            text-align: center;
+            padding: 2px 4px;
+        }
+
         #trackLabel {
             position: absolute;
             top: 10px;

--- a/apps/frontend/html/eng-view-trackmap.html
+++ b/apps/frontend/html/eng-view-trackmap.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Exo+2:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.4.1/socket.io.min.js" integrity="sha384-fKnu0iswBIqkjxrhQCTZ7qlLHOFEgNkRmK2vaO/LbTZSXdJfAu6ewRBdwHPhBo/H" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/msgpack-lite@0.1.26/dist/msgpack.min.js" integrity="sha384-MWenGdy0IO91D1IxYZ3jomrUiVLYQO2MbFrzI61UCdaN80K3Ys3u8eLu/ZDlaoIm" crossorigin="anonymous"></script>
+    <script src="{{ url_for('static', filename='js/socketio.js') }}"></script>
     <style>
         :root {
             --f1-dark: #15151e;
@@ -151,18 +152,7 @@
             const trackMap = new TrackMap('#trackMapContainer');
             const label = document.getElementById('trackLabel');
 
-            const socketio = io(`${location.protocol}//${location.hostname}:${location.port}`, {
-                reconnection: true,
-                reconnectionAttempts: Infinity,
-                reconnectionDelay: 1000,
-                reconnectionDelayMax: 5000,
-                transports: ['websocket', 'polling'],
-                secure: location.protocol === 'https:',
-            });
-
-            socketio.on('connect', () => {
-                socketio.emit('register-client', { type: 'race-table', id: 'eng-view-trackmap' });
-            });
+            const socketio = initializeSocketIO('race-table', 'eng-view-trackmap');
 
             let refDriverTeam = null;
 

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -68,10 +68,9 @@
                                 </a>
                                 <button id="clear-ref-driver-btn"
                                         class="btn settings-button"
-                                        style="display:none;"
                                         data-bs-toggle="tooltip"
-                                        data-bs-title="Clear pinned reference driver">
-                                    <i class="bi bi-pin-angle-fill" style="color:#ffd700;"></i>
+                                        data-bs-title="Clear reference driver selection">
+                                    <i class="bi bi-star-fill" style="color:#ffd700;"></i>
                                 </button>
                                 <button id="settings-btn" class="btn settings-button" data-bs-toggle="tooltip" data-bs-title="Table columns settings"><i class="bi bi-gear-fill"></i></button>
                                 {% if port_info %}

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -7,7 +7,6 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/css2?family=Exo+2:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" integrity="sha384-/o6I2CkkWC//PSjvWC/eYN7l3xM3tJm8ZzVkCOfp//W05QcE3mlGskpoHB6XqI+B" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/engView.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/modals.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreSetsCards.css') }}">
@@ -43,11 +42,11 @@
                     <span class="collapsed-bar-time" id="collapsedBarTime">—</span>
                     <div class="collapsed-bar-sep"></div>
                     <div class="collapsed-bar-item" data-bs-toggle="tooltip" data-bs-title="Track Temperature">
-                        <i class="fa-solid fa-road collapsed-bar-icon"></i>
+                        <img src="/overlays/track-temperature.svg" class="collapsed-bar-icon" alt="Track Temperature">
                         <span id="collapsedBarTrackTemp">—</span>
                     </div>
                     <div class="collapsed-bar-item" data-bs-toggle="tooltip" data-bs-title="Air Temperature">
-                        <i class="bi bi-thermometer-half collapsed-bar-icon"></i>
+                        <img src="/overlays/air-temperature.svg" class="collapsed-bar-icon" alt="Air Temperature">
                         <span id="collapsedBarAirTemp">—</span>
                     </div>
                     <div class="collapsed-bar-sep"></div>

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -66,6 +66,13 @@
                                 <a id="driver-view-btn" class="btn settings-button" href="/" data-bs-toggle="tooltip" data-bs-title="Switch to driver view">
                                     <i class="bi bi-car-front-fill"></i>
                                 </a>
+                                <button id="clear-ref-driver-btn"
+                                        class="btn settings-button"
+                                        style="display:none;"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-title="Clear pinned reference driver">
+                                    <i class="bi bi-pin-angle-fill" style="color:#ffd700;"></i>
+                                </button>
                                 <button id="settings-btn" class="btn settings-button" data-bs-toggle="tooltip" data-bs-title="Table columns settings"><i class="bi bi-gear-fill"></i></button>
                                 {% if port_info %}
                                 <span class="port-badge" title="Multi-session port identifier">📍 {{ port_info }}</span>

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -30,6 +30,13 @@
     <div class="container-fluid">
         <!-- Global Data Section -->
         <div class="eng-view-global-data-section">
+            <div class="upper-section-accordion-header" id="upperSectionAccordionHeader">
+                <span class="upper-section-accordion-title">
+                    <i class="bi bi-chevron-down upper-section-chevron" id="upperSectionChevron"></i>
+                    Session Overview
+                </span>
+            </div>
+            <div class="upper-section-accordion-body" id="upperSectionAccordionBody">
             <div class="row">
                 <div class="col-md-5 race-status-col">
                     <div class="card border-secondary global-stats-section">
@@ -187,6 +194,7 @@
                     </div>
                 </div>
             </div>
+            </div><!-- /.upper-section-accordion-body -->
         </div>
 
         <!-- Race Table Section -->

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -7,6 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" integrity="sha384-tViUnnbYAV00FLIhhi3v/dWt3Jxw4gZQcNoSCxCIFNJVCx7/D55/wXsrNIRANwdD" crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/css2?family=Exo+2:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" integrity="sha384-/o6I2CkkWC//PSjvWC/eYN7l3xM3tJm8ZzVkCOfp//W05QcE3mlGskpoHB6XqI+B" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/engView.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/modals.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tyreSetsCards.css') }}">
@@ -35,6 +36,36 @@
                     <i class="bi bi-chevron-down upper-section-chevron" id="upperSectionChevron"></i>
                     Session Overview
                 </span>
+                <!-- Collapsed info bar — only visible when accordion is collapsed -->
+                <div class="upper-section-collapsed-bar" id="upperSectionCollapsedBar">
+                    <span class="collapsed-bar-circuit" id="collapsedBarCircuit">—</span>
+                    <div class="collapsed-bar-sep"></div>
+                    <span class="collapsed-bar-time" id="collapsedBarTime">—</span>
+                    <div class="collapsed-bar-sep"></div>
+                    <div class="collapsed-bar-item" data-bs-toggle="tooltip" data-bs-title="Track Temperature">
+                        <i class="fa-solid fa-road collapsed-bar-icon"></i>
+                        <span id="collapsedBarTrackTemp">—</span>
+                    </div>
+                    <div class="collapsed-bar-item" data-bs-toggle="tooltip" data-bs-title="Air Temperature">
+                        <i class="bi bi-thermometer-half collapsed-bar-icon"></i>
+                        <span id="collapsedBarAirTemp">—</span>
+                    </div>
+                    <div class="collapsed-bar-sep"></div>
+                    <div class="collapsed-bar-item collapsed-bar-actions">
+                        <button id="collapsed-clear-ref-btn"
+                                class="btn collapsed-bar-action-btn"
+                                data-bs-toggle="tooltip"
+                                data-bs-title="Clear reference driver">
+                            <i class="bi bi-star-fill" style="color:#ffd700;"></i>
+                        </button>
+                        <div class="collapsed-bar-pred">
+                            <label class="collapsed-bar-pred-label">Pred L</label>
+                            <input type="number" id="collapsedPredictionLap"
+                                   class="form-control form-control-sm collapsed-bar-pred-input"
+                                   value="1" min="1" max="80">
+                        </div>
+                    </div>
+                </div>
             </div>
             <div class="upper-section-accordion-body" id="upperSectionAccordionBody">
             <div class="row">

--- a/apps/frontend/html/eng-view.html
+++ b/apps/frontend/html/eng-view.html
@@ -212,6 +212,11 @@
                     <div class="card border-secondary global-stats-section">
                         <div class="card-header border-secondary global-stats-section-header">
                             <h5 class="mb-0" id="trackMapHeader">Track Map</h5>
+                            <div class="track-map-rotation-ctrl" id="trackMapRotationCtrl">
+                                <i class="bi bi-arrow-repeat track-map-rotation-label"></i>
+                                <input type="range" class="track-map-rotation-slider" id="trackMapRotationSlider" min="0" max="359" value="0" step="1">
+                                <input type="number" class="track-map-rotation-input" id="trackMapRotationInput" min="0" max="359" value="0" step="1">
+                            </div>
                             <a href="/eng-view/trackmap" target="_blank" rel="noopener noreferrer"
                                class="btn btn-sm btn-outline-secondary" data-bs-toggle="tooltip"
                                data-bs-title="Open Track Map fullscreen in new tab">
@@ -271,6 +276,11 @@
         <div id="track-map-drawer" class="context-drawer">
             <div class="context-drawer-header">
                 <h5>Track Map</h5>
+                <div class="track-map-rotation-ctrl" id="trackMapDrawerRotationCtrl">
+                    <i class="bi bi-arrow-repeat track-map-rotation-label"></i>
+                    <input type="range" class="track-map-rotation-slider" id="trackMapDrawerRotationSlider" min="0" max="359" value="0" step="1">
+                    <input type="number" class="track-map-rotation-input" id="trackMapDrawerRotationInput" min="0" max="359" value="0" step="1">
+                </div>
                 <button class="btn-close btn-close-white context-drawer-close"
                         data-drawer="track-map-drawer" aria-label="Close"></button>
             </div>

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -131,7 +131,6 @@ class EngViewRaceTable {
         this.INVALID_TEAMS = new Set(["F1 Generic"]);
         this.MANUAL_REF_LS_KEY = 'eng-view-manual-ref-driver';
         this.manualRefDriverIndex = null;
-        this.clearRefDriverBtn = document.getElementById('clear-ref-driver-btn');
 
         // Column visibility pane elements
         this.settingsButton = document.getElementById('settings-btn');
@@ -685,14 +684,14 @@ class EngViewRaceTable {
                 cellRenderer: (params) => {
                     const data = params.data;
                     const isPinned = this.manualRefDriverIndex === data.index;
-                    const pinIcon = isPinned ? 'bi-pin-fill' : 'bi-pin';
-                    const pinStyle = isPinned ? 'color:#ffd700;' : '';
+                    const starIcon = isPinned ? 'bi-star-fill' : 'bi-star';
+                    const starStyle = isPinned ? 'color:#ffd700;' : '';
                     return `<div class="driver-name-cell">` +
                         `<div class="driver-name-cell-text">` +
                             this.createMultiLineCell({ row1: data.name, row2: data.team }) +
                         `</div>` +
-                        `<button class="pin-ref-btn" data-driver-index="${data.index}" title="Pin as reference driver">` +
-                            `<i class="bi ${pinIcon}" style="${pinStyle}"></i>` +
+                        `<button class="pin-ref-btn" data-driver-index="${data.index}" title="Set as reference driver">` +
+                            `<i class="bi ${starIcon}" style="${starStyle}"></i>` +
                         `</button>` +
                     `</div>`;
                 },
@@ -1406,14 +1405,9 @@ class EngViewRaceTable {
             const parsed = parseInt(saved, 10);
             this.manualRefDriverIndex = isNaN(parsed) ? null : parsed;
         }
-        this.clearRefDriverBtn?.addEventListener('click', () => this.#clearManualRef());
-        this.#syncClearButton();
+        document.getElementById('clear-ref-driver-btn')?.addEventListener('click', () => this.#clearManualRef());
     }
 
-    #syncClearButton() {
-        if (!this.clearRefDriverBtn) return;
-        this.clearRefDriverBtn.style.display = this.manualRefDriverIndex !== null ? '' : 'none';
-    }
 
     #setManualRef(index) {
         if (this.manualRefDriverIndex === index) {
@@ -1422,14 +1416,12 @@ class EngViewRaceTable {
         }
         this.manualRefDriverIndex = index;
         localStorage.setItem(this.MANUAL_REF_LS_KEY, index.toString());
-        this.#syncClearButton();
         if (this.gridApi) this.gridApi.redrawRows();
     }
 
     #clearManualRef() {
         this.manualRefDriverIndex = null;
         localStorage.removeItem(this.MANUAL_REF_LS_KEY);
-        this.#syncClearButton();
         if (this.gridApi) this.gridApi.redrawRows();
     }
 
@@ -1477,7 +1469,6 @@ class EngViewRaceTable {
             if (!stillPresent) {
                 this.manualRefDriverIndex = null;
                 localStorage.removeItem(this.MANUAL_REF_LS_KEY);
-                this.#syncClearButton();
             }
         }
 

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -1948,6 +1948,13 @@ class EngViewRaceStatus {
         this.LS_COLLAPSE_KEY = 'raceStatusCollapsed';
         this._collapseMediaQuery = window.matchMedia('(max-width: 1439px)');
 
+        // Collapsed accordion bar elements
+        this.collapsedBarCircuit = document.getElementById('collapsedBarCircuit');
+        this.collapsedBarTime = document.getElementById('collapsedBarTime');
+        this.collapsedBarTrackTemp = document.getElementById('collapsedBarTrackTemp');
+        this.collapsedBarAirTemp = document.getElementById('collapsedBarAirTemp');
+        this.collapsedPredictionLap = document.getElementById('collapsedPredictionLap');
+
         this._initCollapse();
 
         this.predictionLapInput.addEventListener('input', (e) => {
@@ -1978,6 +1985,21 @@ class EngViewRaceStatus {
         this.predictionPitBtn.disabled = true;
         this.predictionMidBtn.disabled = true;
         this.predictionLastBtn.disabled = true;
+
+        // Collapsed bar: clear-ref button mirrors main clear-ref
+        document.getElementById('collapsed-clear-ref-btn')?.addEventListener('click', (e) => {
+            e.stopPropagation();
+            document.getElementById('clear-ref-driver-btn')?.click();
+        });
+
+        // Collapsed bar: prediction input stays in sync with main input
+        this.collapsedPredictionLap?.addEventListener('input', (e) => {
+            const value = parseInt(e.target.value);
+            if (!isNaN(value) && value >= 1) {
+                g_engView_predLapNum = value;
+                this.predictionLapInput.value = value;
+            }
+        });
     }
 
     _initCollapse() {
@@ -2024,6 +2046,7 @@ class EngViewRaceStatus {
 
     #updatePredLapInputBox() {
         this.predictionLapInput.value = g_engView_predLapNum;
+        if (this.collapsedPredictionLap) this.collapsedPredictionLap.value = g_engView_predLapNum;
         console.debug("Updated prediction element value", g_engView_predLapNum);
     }
 
@@ -2115,6 +2138,26 @@ class EngViewRaceStatus {
         }
 
         this.#updateSummary(data);
+        this.#updateCollapsedBar(data);
+    }
+
+    #updateCollapsedBar(data) {
+        if (this.collapsedBarCircuit) {
+            this.collapsedBarCircuit.textContent = this.#getRaceStatusHeaderString(data);
+        }
+        if (this.collapsedBarTime) {
+            this.collapsedBarTime.textContent = this.#getSessionTimeString(data);
+        }
+        if (this.collapsedBarTrackTemp) {
+            this.collapsedBarTrackTemp.textContent = data['track-temperature'] + ' °C';
+        }
+        if (this.collapsedBarAirTemp) {
+            this.collapsedBarAirTemp.textContent = data['air-temperature'] + ' °C';
+        }
+        if (this.collapsedPredictionLap && this.collapsedPredictionLap !== document.activeElement) {
+            this.collapsedPredictionLap.value = g_engView_predLapNum;
+            this.collapsedPredictionLap.max = this.totalLaps;
+        }
     }
 }
 
@@ -2313,7 +2356,9 @@ function initUpperSectionAccordion() {
     const saved = localStorage.getItem(LS_KEY);
     apply(saved === 'true');
 
-    header.addEventListener('click', () => {
+    header.addEventListener('click', (e) => {
+        // Don't toggle when clicking interactive elements inside the collapsed bar
+        if (e.target.closest('#upperSectionCollapsedBar')) return;
         const nowCollapsed = !body.classList.contains('collapsed');
         apply(nowCollapsed);
         localStorage.setItem(LS_KEY, nowCollapsed);

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -1425,11 +1425,27 @@ class EngViewRaceTable {
         if (this.gridApi) this.gridApi.redrawRows();
     }
 
+    #getCurrentRefIndex() {
+        if (this.manualRefDriverIndex !== null) return this.manualRefDriverIndex;
+        if (this.isSpectating) return this.spectatorIndex;
+        const playerRow = this.previousTableData?.find(d => d.isPlayer);
+        return playerRow?.index ?? null;
+    }
+
+    get currentRefIndex() {
+        return this.#getCurrentRefIndex();
+    }
+
     #isRefDriver(index, isPlayer) {
-        if (this.manualRefDriverIndex !== null) {
-            return index === this.manualRefDriverIndex;
-        }
+        const refIndex = this.#getCurrentRefIndex();
+        if (refIndex !== null) return index === refIndex;
         return isPlayer || index === this.spectatorIndex;
+    }
+
+    #isRefDriverEntry(entry) {
+        const driverInfo = entry["driver-info"];
+        if (!driverInfo) return false;
+        return this.#isRefDriver(driverInfo["index"], driverInfo["is-player"]);
     }
 
     #clear() {
@@ -1467,27 +1483,18 @@ class EngViewRaceTable {
         if (this.manualRefDriverIndex !== null) {
             const stillPresent = drivers.some(d => d["driver-info"]["index"] === this.manualRefDriverIndex);
             if (!stillPresent) {
-                this.manualRefDriverIndex = null;
-                localStorage.removeItem(this.MANUAL_REF_LS_KEY);
+                this.#clearManualRef();
             }
         }
 
-        const refEntry = updateReferenceLapTimes(drivers, (entry) => {
-            if (this.manualRefDriverIndex !== null) {
-                return entry["driver-info"]?.["index"] === this.manualRefDriverIndex;
-            }
-            return this.isSpectating
-                ? entry["driver-info"]?.["index"] == this.spectatorIndex
-                : entry["driver-info"]?.["is-player"];
-        });
+        const refEntry = updateReferenceLapTimes(drivers, (entry) => this.#isRefDriverEntry(entry));
         if (refEntry) {
-            // this.refDriverTeam = refEntry["driver-info"]?.["team"] || '';
             this.refDriverTeam = refEntry["driver-info"]["team"];
         }
 
         // Sort, compute and insert rejoin positions
         drivers.sort((a, b) => a["driver-info"]["position"] - b["driver-info"]["position"]);
-        const refIndex = this.manualRefDriverIndex ?? refEntry?.["driver-info"]?.["index"] ?? null;
+        const refIndex = this.#getCurrentRefIndex() ?? refEntry?.["driver-info"]?.["index"] ?? null;
         insertRejoinPositions(drivers, pitTimeLoss, refIndex);
         const newTableData = drivers.map(driver => ({
             ...driver,
@@ -2417,12 +2424,12 @@ function initDashboard() {
             trackMap.loadTrack(circuit, gameYear);
         }
         if (tableEntries && tableEntries.length > 0) {
-            const effectiveSpectating = isSpectating || (raceTable.manualRefDriverIndex !== null);
-            const effectiveRefIndex = raceTable.manualRefDriverIndex ?? spectatorCarIndex;
+            const refIndex = raceTable.currentRefIndex ?? spectatorCarIndex;
+            const effectiveSpectating = isSpectating || (refIndex !== spectatorCarIndex);
             trackMap.updateDrivers(
                 tableEntries,
                 effectiveSpectating,
-                effectiveRefIndex,
+                refIndex,
                 raceTable.refDriverTeam
             );
         }

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -129,7 +129,6 @@ class EngViewRaceTable {
         this.previousTableData = []; // Stores the data from the previous update cycle
         this.refDriverTeam = null; // Team of the reference driver (player or spectated)
         this.INVALID_TEAMS = new Set(["F1 Generic"]);
-        this.MANUAL_REF_LS_KEY = 'eng-view-manual-ref-driver';
         this.manualRefDriverIndex = null;
 
         // Column visibility pane elements
@@ -147,7 +146,7 @@ class EngViewRaceTable {
 
         this.initGrid();
         this.setupSettingsEventListeners();
-        this.#loadManualRef();
+        document.getElementById('clear-ref-driver-btn')?.addEventListener('click', () => this.#clearManualRef());
     }
 
     saveColumnState() {
@@ -1399,14 +1398,6 @@ class EngViewRaceTable {
         return `<div class='${row1Class}'>${processedRow1}</div><div class='${row2Class}'>${processedRow2}</div>`;
     }
 
-    #loadManualRef() {
-        const saved = localStorage.getItem(this.MANUAL_REF_LS_KEY);
-        if (saved !== null) {
-            const parsed = parseInt(saved, 10);
-            this.manualRefDriverIndex = isNaN(parsed) ? null : parsed;
-        }
-        document.getElementById('clear-ref-driver-btn')?.addEventListener('click', () => this.#clearManualRef());
-    }
 
 
     #setManualRef(index) {
@@ -1415,13 +1406,11 @@ class EngViewRaceTable {
             return;
         }
         this.manualRefDriverIndex = index;
-        localStorage.setItem(this.MANUAL_REF_LS_KEY, index.toString());
         if (this.gridApi) this.gridApi.redrawRows();
     }
 
     #clearManualRef() {
         this.manualRefDriverIndex = null;
-        localStorage.removeItem(this.MANUAL_REF_LS_KEY);
         if (this.gridApi) this.gridApi.redrawRows();
     }
 

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -129,6 +129,9 @@ class EngViewRaceTable {
         this.previousTableData = []; // Stores the data from the previous update cycle
         this.refDriverTeam = null; // Team of the reference driver (player or spectated)
         this.INVALID_TEAMS = new Set(["F1 Generic"]);
+        this.MANUAL_REF_LS_KEY = 'eng-view-manual-ref-driver';
+        this.manualRefDriverIndex = null;
+        this.clearRefDriverBtn = document.getElementById('clear-ref-driver-btn');
 
         // Column visibility pane elements
         this.settingsButton = document.getElementById('settings-btn');
@@ -145,6 +148,7 @@ class EngViewRaceTable {
 
         this.initGrid();
         this.setupSettingsEventListeners();
+        this.#loadManualRef();
     }
 
     saveColumnState() {
@@ -391,7 +395,7 @@ class EngViewRaceTable {
             getRowClass: (params) => {
                 const data = params.data;
                 if (!data) return;
-                const isReferenceDriver = data.isPlayer || data.index === this.spectatorIndex;
+                const isReferenceDriver = this.#isRefDriver(data.index, data.isPlayer);
                 if (isReferenceDriver) {
                     return 'ref-row';
                 }
@@ -401,6 +405,7 @@ class EngViewRaceTable {
                 return '';
             },
             onRowClicked: (params) => {
+                if (params.event?.target?.closest('.pin-ref-btn')) return;
                 const data = params.data;
                 fetch(`/driver-info?index=${data.index}`)
                     .then(response => response.json())
@@ -416,6 +421,14 @@ class EngViewRaceTable {
             this.grid = agGrid.createGrid(gridDiv, gridOptions);
             this.gridInitialized = true;
         }
+
+        gridDiv.addEventListener('click', (e) => {
+            const btn = e.target.closest('.pin-ref-btn');
+            if (btn) {
+                e.stopPropagation();
+                this.#setManualRef(parseInt(btn.dataset.driverIndex, 10));
+            }
+        });
     }
 
     debounceSaveColumnState() {
@@ -430,7 +443,7 @@ class EngViewRaceTable {
             const driverInfo = params.data;
             const lapInfo = (isLastLap) ? driverInfo["lap-info"]["last-lap"] : driverInfo["lap-info"]["best-lap"];
             const bestLapInfo = driverInfo["lap-info"]["best-lap"];
-            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+            const isReferenceDriver = this.#isRefDriver(driverInfo.index, driverInfo.isPlayer);
             const sectorStatus = lapInfo["sector-status"];
 
             const timeMs = lapInfo[timeKey];
@@ -671,10 +684,17 @@ class EngViewRaceTable {
                 flex: 12,
                 cellRenderer: (params) => {
                     const data = params.data;
-                    return this.createMultiLineCell({
-                        row1: data.name,
-                        row2: data.team
-                    });
+                    const isPinned = this.manualRefDriverIndex === data.index;
+                    const pinIcon = isPinned ? 'bi-pin-fill' : 'bi-pin';
+                    const pinStyle = isPinned ? 'color:#ffd700;' : '';
+                    return `<div class="driver-name-cell">` +
+                        `<div class="driver-name-cell-text">` +
+                            this.createMultiLineCell({ row1: data.name, row2: data.team }) +
+                        `</div>` +
+                        `<button class="pin-ref-btn" data-driver-index="${data.index}" title="Pin as reference driver">` +
+                            `<i class="bi ${pinIcon}" style="${pinStyle}"></i>` +
+                        `</button>` +
+                    `</div>`;
                 },
                 sortable: false,
                 cellClass: 'ag-cell-multiline',
@@ -755,7 +775,7 @@ class EngViewRaceTable {
                         flex: 2.5,
                         cellClass: (params) => {
                             const driverInfo = params.data;
-                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const isReferenceDriver = this.#isRefDriver(driverInfo.index, driverInfo.isPlayer);
                             return isReferenceDriver ? 'ag-cell-single-line' : 'ag-cell-multiline';
                         },
                         equals: this.createLapTimeEqualsComparator('best-lap'),
@@ -770,7 +790,7 @@ class EngViewRaceTable {
                         flex: 2.5,
                         cellClass: (params) => {
                             const driverInfo = params.data;
-                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const isReferenceDriver = this.#isRefDriver(driverInfo.index, driverInfo.isPlayer);
                             return isReferenceDriver ? 'ag-cell-single-line' : 'ag-cell-multiline';
                         },
                         equals: this.createSectorTimeEqualsComparator('best-lap', 's1', 's1-time-ms'),
@@ -785,7 +805,7 @@ class EngViewRaceTable {
                         flex: 2.5,
                         cellClass: (params) => {
                             const driverInfo = params.data;
-                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const isReferenceDriver = this.#isRefDriver(driverInfo.index, driverInfo.isPlayer);
                             return isReferenceDriver ? 'ag-cell-single-line' : 'ag-cell-multiline';
                         },
                         equals: this.createSectorTimeEqualsComparator('best-lap', 's2', 's2-time-ms'),
@@ -800,7 +820,7 @@ class EngViewRaceTable {
                         flex: 2.5,
                         cellClass: (params) => {
                             const driverInfo = params.data;
-                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const isReferenceDriver = this.#isRefDriver(driverInfo.index, driverInfo.isPlayer);
                             return isReferenceDriver ? 'ag-cell-single-line' : 'ag-cell-multiline';
                         },
                         equals: this.createSectorTimeEqualsComparator('best-lap', 's3', 's3-time-ms'),
@@ -822,7 +842,7 @@ class EngViewRaceTable {
                         flex: 2.5,
                         cellClass: (params) => {
                             const driverInfo = params.data;
-                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const isReferenceDriver = this.#isRefDriver(driverInfo.index, driverInfo.isPlayer);
                             return isReferenceDriver ? 'ag-cell-single-line' : 'ag-cell-multiline';
                         },
                         equals: this.createLapTimeEqualsComparator('last-lap'),
@@ -837,7 +857,7 @@ class EngViewRaceTable {
                         flex: 2.5,
                         cellClass: (params) => {
                             const driverInfo = params.data;
-                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const isReferenceDriver = this.#isRefDriver(driverInfo.index, driverInfo.isPlayer);
                             return isReferenceDriver ? 'ag-cell-single-line' : 'ag-cell-multiline';
                         },
                         equals: this.createSectorTimeEqualsComparator('last-lap', 's1', 's1-time-ms'),
@@ -852,7 +872,7 @@ class EngViewRaceTable {
                         flex: 2.5,
                         cellClass: (params) => {
                             const driverInfo = params.data;
-                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const isReferenceDriver = this.#isRefDriver(driverInfo.index, driverInfo.isPlayer);
                             return isReferenceDriver ? 'ag-cell-single-line' : 'ag-cell-multiline';
                         },
                         equals: this.createSectorTimeEqualsComparator('last-lap', 's2', 's2-time-ms'),
@@ -867,7 +887,7 @@ class EngViewRaceTable {
                         flex: 2.5,
                         cellClass: (params) => {
                             const driverInfo = params.data;
-                            const isReferenceDriver = driverInfo.isPlayer || driverInfo.index === this.spectatorIndex;
+                            const isReferenceDriver = this.#isRefDriver(driverInfo.index, driverInfo.isPlayer);
                             return isReferenceDriver ? 'ag-cell-single-line' : 'ag-cell-multiline';
                         },
                         equals: this.createSectorTimeEqualsComparator('last-lap', 's3', 's3-time-ms'),
@@ -1380,6 +1400,46 @@ class EngViewRaceTable {
         return `<div class='${row1Class}'>${processedRow1}</div><div class='${row2Class}'>${processedRow2}</div>`;
     }
 
+    #loadManualRef() {
+        const saved = localStorage.getItem(this.MANUAL_REF_LS_KEY);
+        if (saved !== null) {
+            const parsed = parseInt(saved, 10);
+            this.manualRefDriverIndex = isNaN(parsed) ? null : parsed;
+        }
+        this.clearRefDriverBtn?.addEventListener('click', () => this.#clearManualRef());
+        this.#syncClearButton();
+    }
+
+    #syncClearButton() {
+        if (!this.clearRefDriverBtn) return;
+        this.clearRefDriverBtn.style.display = this.manualRefDriverIndex !== null ? '' : 'none';
+    }
+
+    #setManualRef(index) {
+        if (this.manualRefDriverIndex === index) {
+            this.#clearManualRef();
+            return;
+        }
+        this.manualRefDriverIndex = index;
+        localStorage.setItem(this.MANUAL_REF_LS_KEY, index.toString());
+        this.#syncClearButton();
+        if (this.gridApi) this.gridApi.redrawRows();
+    }
+
+    #clearManualRef() {
+        this.manualRefDriverIndex = null;
+        localStorage.removeItem(this.MANUAL_REF_LS_KEY);
+        this.#syncClearButton();
+        if (this.gridApi) this.gridApi.redrawRows();
+    }
+
+    #isRefDriver(index, isPlayer) {
+        if (this.manualRefDriverIndex !== null) {
+            return index === this.manualRefDriverIndex;
+        }
+        return isPlayer || index === this.spectatorIndex;
+    }
+
     #clear() {
         this.previousTableData = [];
         this.delayedLapData = new Map();
@@ -1411,11 +1471,24 @@ class EngViewRaceTable {
             this.gridApi.hideOverlay();
         }
 
-        const refEntry = updateReferenceLapTimes(drivers, (entry) =>
-            this.isSpectating ?
-            entry["driver-info"]?.["index"] == this.spectatorIndex :
-            entry["driver-info"]?.["is-player"]
-        );
+        // If the manually-pinned driver is no longer in the session, clear the override
+        if (this.manualRefDriverIndex !== null) {
+            const stillPresent = drivers.some(d => d["driver-info"]["index"] === this.manualRefDriverIndex);
+            if (!stillPresent) {
+                this.manualRefDriverIndex = null;
+                localStorage.removeItem(this.MANUAL_REF_LS_KEY);
+                this.#syncClearButton();
+            }
+        }
+
+        const refEntry = updateReferenceLapTimes(drivers, (entry) => {
+            if (this.manualRefDriverIndex !== null) {
+                return entry["driver-info"]?.["index"] === this.manualRefDriverIndex;
+            }
+            return this.isSpectating
+                ? entry["driver-info"]?.["index"] == this.spectatorIndex
+                : entry["driver-info"]?.["is-player"];
+        });
         if (refEntry) {
             // this.refDriverTeam = refEntry["driver-info"]?.["team"] || '';
             this.refDriverTeam = refEntry["driver-info"]["team"];
@@ -1423,7 +1496,7 @@ class EngViewRaceTable {
 
         // Sort, compute and insert rejoin positions
         drivers.sort((a, b) => a["driver-info"]["position"] - b["driver-info"]["position"]);
-        const refIndex = refEntry?.["driver-info"]?.["index"] ?? null;
+        const refIndex = this.manualRefDriverIndex ?? refEntry?.["driver-info"]?.["index"] ?? null;
         insertRejoinPositions(drivers, pitTimeLoss, refIndex);
         const newTableData = drivers.map(driver => ({
             ...driver,
@@ -2285,10 +2358,12 @@ function initDashboard() {
             trackMap.loadTrack(circuit, gameYear);
         }
         if (tableEntries && tableEntries.length > 0) {
+            const effectiveSpectating = isSpectating || (raceTable.manualRefDriverIndex !== null);
+            const effectiveRefIndex = raceTable.manualRefDriverIndex ?? spectatorCarIndex;
             trackMap.updateDrivers(
                 tableEntries,
-                isSpectating,
-                spectatorCarIndex,
+                effectiveSpectating,
+                effectiveRefIndex,
                 raceTable.refDriverTeam
             );
         }

--- a/apps/frontend/js/engView.js
+++ b/apps/frontend/js/engView.js
@@ -2298,6 +2298,28 @@ function initCardCollapseToggles() {
     }
 }
 
+// ── Upper Section Accordion ──────────────────────────────────────
+
+function initUpperSectionAccordion() {
+    const LS_KEY = 'engViewUpperSectionCollapsed';
+    const header = document.getElementById('upperSectionAccordionHeader');
+    const body   = document.getElementById('upperSectionAccordionBody');
+
+    const apply = (collapsed) => {
+        header.classList.toggle('collapsed', collapsed);
+        body.classList.toggle('collapsed', collapsed);
+    };
+
+    const saved = localStorage.getItem(LS_KEY);
+    apply(saved === 'true');
+
+    header.addEventListener('click', () => {
+        const nowCollapsed = !body.classList.contains('collapsed');
+        apply(nowCollapsed);
+        localStorage.setItem(LS_KEY, nowCollapsed);
+    });
+}
+
 // Initialize the dashboard
 function initDashboard() {
     iconCache = new IconCache();
@@ -2306,6 +2328,7 @@ function initDashboard() {
     weatherGraph = new WeatherGraph(document.getElementById('weatherGraphContainer'));
     weatherTable = new EngViewWeatherTable(weatherGraph);
     trackMap = new TrackMap();
+    initUpperSectionAccordion();
     initWeatherDisplayToggle();
     initCardCollapseToggles();
     window.drawerManager = new DrawerManager();

--- a/apps/frontend/js/socketio.js
+++ b/apps/frontend/js/socketio.js
@@ -8,9 +8,8 @@ function initializeSocketIO(clientType, clientId) {
         reconnectionDelayMax: 5000,
         randomizationFactor: 0.3,
         timeout: 10000,
-        transports: ['websocket', 'polling'],
+        transports: ['polling', 'websocket'],
         upgrade: true,
-        rememberUpgrade: true,
         secure: location.protocol === 'https:',
     });
 

--- a/apps/frontend/js/trackMap.js
+++ b/apps/frontend/js/trackMap.js
@@ -117,8 +117,8 @@ class TrackMap {
 
         // -- Rotation state --
         this._rotation = 0;
-        this._rotationSlider = null;
-        this._rotationInput = null;
+        this._rotationSliders = [];
+        this._rotationInputs = [];
         this._rotationCtrl = null;
 
         this._initZoomControls();
@@ -329,7 +329,6 @@ class TrackMap {
         this._unpinPopup();
         this._resetZoomState();
         this.container.appendChild(this._resetBtn);
-        if (this._rotationCtrl) this.container.appendChild(this._rotationCtrl);
     }
 
     /** Reset internal state (e.g. on session change). */
@@ -366,7 +365,9 @@ class TrackMap {
         this._wrapper.appendChild(this.canvas);
         this.container.appendChild(this._wrapper);
         this.container.appendChild(this._resetBtn);
-        if (this._rotationCtrl) this.container.appendChild(this._rotationCtrl);
+        if (this._rotationCtrl) {
+            this.container.appendChild(this._rotationCtrl);
+        }
 
         // Attach mouse/touch events for interaction
         this._initCanvasInteraction();
@@ -793,61 +794,68 @@ class TrackMap {
     }
 
     _initRotationControls() {
+        const { sliders, inputs, ctrl } = this._findOrCreateRotationControls();
+        this._rotationSliders = sliders;
+        this._rotationInputs = inputs;
+        this._rotationCtrl = ctrl || null;
+        this._wireRotationControls();
+    }
+
+    _findOrCreateRotationControls() {
         // Prefer controls already in the HTML (eng-view card header + drawer header).
         // Fall back to creating them in the container (fullscreen page).
-        const existing = document.getElementById('trackMapRotationCtrl');
-        if (existing) {
-            this._rotationCtrl = null; // lives in header, not managed by teardown
-            this._rotationSliders = [
-                document.getElementById('trackMapRotationSlider'),
-                document.getElementById('trackMapDrawerRotationSlider'),
-            ].filter(Boolean);
-            this._rotationInputs = [
-                document.getElementById('trackMapRotationInput'),
-                document.getElementById('trackMapDrawerRotationInput'),
-            ].filter(Boolean);
-        } else {
-            const ctrl = document.createElement('div');
-            ctrl.className = 'track-map-rotation-ctrl';
-
-            const label = document.createElement('i');
-            label.className = 'bi bi-arrow-repeat track-map-rotation-label';
-
-            const slider = document.createElement('input');
-            slider.type = 'range';
-            slider.className = 'track-map-rotation-slider';
-            slider.min = 0;
-            slider.max = 359;
-            slider.value = 0;
-            slider.step = 1;
-
-            const input = document.createElement('input');
-            input.type = 'number';
-            input.className = 'track-map-rotation-input';
-            input.min = 0;
-            input.max = 359;
-            input.value = 0;
-            input.step = 1;
-
-            ctrl.appendChild(label);
-            ctrl.appendChild(slider);
-            ctrl.appendChild(input);
-            this._rotationCtrl = ctrl;
-            this.container.appendChild(ctrl);
-
-            this._rotationSliders = [slider];
-            this._rotationInputs = [input];
+        if (document.getElementById('trackMapRotationCtrl')) {
+            return {
+                ctrl: null,
+                sliders: [
+                    document.getElementById('trackMapRotationSlider'),
+                    document.getElementById('trackMapDrawerRotationSlider'),
+                ].filter(Boolean),
+                inputs: [
+                    document.getElementById('trackMapRotationInput'),
+                    document.getElementById('trackMapDrawerRotationInput'),
+                ].filter(Boolean),
+            };
         }
 
-        // Keep the primary references for _resetZoomState compatibility
-        this._rotationSlider = this._rotationSliders[0] || null;
-        this._rotationInput = this._rotationInputs[0] || null;
+        const ctrl = document.createElement('div');
+        ctrl.className = 'track-map-rotation-ctrl';
 
+        const label = document.createElement('i');
+        label.className = 'bi bi-arrow-repeat track-map-rotation-label';
+
+        const slider = document.createElement('input');
+        slider.type = 'range';
+        slider.className = 'track-map-rotation-slider';
+        slider.min = 0;
+        slider.max = 359;
+        slider.value = 0;
+        slider.step = 1;
+
+        const input = document.createElement('input');
+        input.type = 'number';
+        input.className = 'track-map-rotation-input';
+        input.min = 0;
+        input.max = 359;
+        input.value = 0;
+        input.step = 1;
+
+        ctrl.appendChild(label);
+        ctrl.appendChild(slider);
+        ctrl.appendChild(input);
+
+        return { ctrl, sliders: [slider], inputs: [input] };
+    }
+
+    _wireRotationControls() {
         const syncAll = (deg) => {
             this._rotation = deg;
             this._rotationSliders.forEach(s => s.value = deg);
             this._rotationInputs.forEach(i => i.value = deg);
             this._applyTransform();
+            if (this._resetBtn) {
+                this._resetBtn.style.display = deg !== 0 ? '' : 'none';
+            }
         };
 
         this._rotationSliders.forEach(slider => {
@@ -858,9 +866,10 @@ class TrackMap {
 
         this._rotationInputs.forEach(input => {
             input.addEventListener('input', () => {
-                let v = parseInt(input.value, 10);
-                if (isNaN(v)) return;
-                syncAll(((v % 360) + 360) % 360);
+                const v = parseInt(input.value, 10);
+                if (!Number.isNaN(v)) {
+                    syncAll(((v % 360) + 360) % 360);
+                }
             });
         });
     }

--- a/apps/frontend/js/trackMap.js
+++ b/apps/frontend/js/trackMap.js
@@ -115,7 +115,14 @@ class TrackMap {
         // Touch pinch state
         this._lastPinchDist = 0;
 
+        // -- Rotation state --
+        this._rotation = 0;
+        this._rotationSlider = null;
+        this._rotationInput = null;
+        this._rotationCtrl = null;
+
         this._initZoomControls();
+        this._initRotationControls();
 
         // rAF loop
         this._rafId = null;
@@ -322,6 +329,7 @@ class TrackMap {
         this._unpinPopup();
         this._resetZoomState();
         this.container.appendChild(this._resetBtn);
+        if (this._rotationCtrl) this.container.appendChild(this._rotationCtrl);
     }
 
     /** Reset internal state (e.g. on session change). */
@@ -358,6 +366,7 @@ class TrackMap {
         this._wrapper.appendChild(this.canvas);
         this.container.appendChild(this._wrapper);
         this.container.appendChild(this._resetBtn);
+        if (this._rotationCtrl) this.container.appendChild(this._rotationCtrl);
 
         // Attach mouse/touch events for interaction
         this._initCanvasInteraction();
@@ -783,6 +792,79 @@ class TrackMap {
         });
     }
 
+    _initRotationControls() {
+        // Prefer controls already in the HTML (eng-view card header + drawer header).
+        // Fall back to creating them in the container (fullscreen page).
+        const existing = document.getElementById('trackMapRotationCtrl');
+        if (existing) {
+            this._rotationCtrl = null; // lives in header, not managed by teardown
+            this._rotationSliders = [
+                document.getElementById('trackMapRotationSlider'),
+                document.getElementById('trackMapDrawerRotationSlider'),
+            ].filter(Boolean);
+            this._rotationInputs = [
+                document.getElementById('trackMapRotationInput'),
+                document.getElementById('trackMapDrawerRotationInput'),
+            ].filter(Boolean);
+        } else {
+            const ctrl = document.createElement('div');
+            ctrl.className = 'track-map-rotation-ctrl';
+
+            const label = document.createElement('i');
+            label.className = 'bi bi-arrow-repeat track-map-rotation-label';
+
+            const slider = document.createElement('input');
+            slider.type = 'range';
+            slider.className = 'track-map-rotation-slider';
+            slider.min = 0;
+            slider.max = 359;
+            slider.value = 0;
+            slider.step = 1;
+
+            const input = document.createElement('input');
+            input.type = 'number';
+            input.className = 'track-map-rotation-input';
+            input.min = 0;
+            input.max = 359;
+            input.value = 0;
+            input.step = 1;
+
+            ctrl.appendChild(label);
+            ctrl.appendChild(slider);
+            ctrl.appendChild(input);
+            this._rotationCtrl = ctrl;
+            this.container.appendChild(ctrl);
+
+            this._rotationSliders = [slider];
+            this._rotationInputs = [input];
+        }
+
+        // Keep the primary references for _resetZoomState compatibility
+        this._rotationSlider = this._rotationSliders[0] || null;
+        this._rotationInput = this._rotationInputs[0] || null;
+
+        const syncAll = (deg) => {
+            this._rotation = deg;
+            this._rotationSliders.forEach(s => s.value = deg);
+            this._rotationInputs.forEach(i => i.value = deg);
+            this._applyTransform();
+        };
+
+        this._rotationSliders.forEach(slider => {
+            slider.addEventListener('input', () => {
+                syncAll(parseInt(slider.value, 10));
+            });
+        });
+
+        this._rotationInputs.forEach(input => {
+            input.addEventListener('input', () => {
+                let v = parseInt(input.value, 10);
+                if (isNaN(v)) return;
+                syncAll(((v % 360) + 360) % 360);
+            });
+        });
+    }
+
     _getTouchDist(touches) {
         const dx = touches[0].clientX - touches[1].clientX;
         const dy = touches[0].clientY - touches[1].clientY;
@@ -818,14 +900,17 @@ class TrackMap {
     _applyTransform() {
         if (!this._wrapper) return;
         this._wrapper.style.transform =
-            'translate(' + this._panX + 'px, ' + this._panY + 'px) scale(' + this._zoom + ')';
+            'translate(' + this._panX + 'px, ' + this._panY + 'px) rotate(' + this._rotation + 'deg) scale(' + this._zoom + ')';
     }
 
     _resetZoomState() {
         this._zoom = 1;
         this._panX = 0;
         this._panY = 0;
+        this._rotation = 0;
         if (this._resetBtn) this._resetBtn.style.display = 'none';
+        if (this._rotationSliders) this._rotationSliders.forEach(s => s.value = 0);
+        if (this._rotationInputs) this._rotationInputs.forEach(i => i.value = 0);
     }
 
     /** Reset zoom and pan to default. */

--- a/lib/web_server/server.py
+++ b/lib/web_server/server.py
@@ -446,6 +446,14 @@ class BaseWebServer:
             '/tyre-icons/wet.svg': {
                 'file': 'tyre-icons/wet_tyre.svg',
                 'mimetype': 'image/svg+xml'
+            },
+            '/overlays/track-temperature.svg': {
+                'file': 'overlays/track-temperature.svg',
+                'mimetype': 'image/svg+xml'
+            },
+            '/overlays/air-temperature.svg': {
+                'file': 'overlays/air-temperature.svg',
+                'mimetype': 'image/svg+xml'
             }
         }
 


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

1. Make reference driver configurable. Click the star next to a driver's name to set that as ref.
2. collapsible upper section. When collapsed, minimal data is shown.
3. socketio reconnect fixes
4. track map rotation
5. fix status header using 2 rows when there was enough width to fit everything in one

---

## 📂 Type of change

<!-- Check all that apply: -->

- [x] Bug fix 🐞
- [ ] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
<paste result here>
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [ ] My code follows project style conventions
* [ ] All new and existing tests pass
* [ ] I have added relevant documentation/comments
* [ ] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Enhance the engineering view with a collapsible session overview header, configurable reference driver selection, and improved track map controls and layout behavior.

New Features:
- Allow users to pin any driver as the reference driver for lap comparisons, persisted across sessions and integrated into the track map and rejoin calculations.
- Add rotation controls for the track map, available both in the main engineering view and the fullscreen track map page.
- Introduce a collapsible upper session overview section with a compact summary bar that shows key session info when collapsed.

Bug Fixes:
- Adjust race status header layout so title, summary, and actions stay on a single row when space allows, only wrapping to two rows on narrow screens.
- Improve Socket.IO client configuration for the fullscreen track map to handle reconnections more robustly and reuse the shared initialization logic.

Enhancements:
- Refine engineering view styling, including updated global data section background and responsive behavior for header content.
- Expose clear-reference controls in the UI and keep prediction lap inputs in sync between expanded and collapsed states.