### PR TITLE
feat(ipc): promote to 3-frame envelope with content_type in meta

### DIFF
--- a/lib/ipc/pubsub/publisher.py
+++ b/lib/ipc/pubsub/publisher.py
@@ -139,32 +139,30 @@ class IpcPublisherAsync:
         self._topic_message_ids[topic] = current
         return current
 
-    def _build_envelope(self, topic: str, data: dict) -> dict:
-        return {
-            "__meta__": {
-                "message_id": self._next_message_id(topic),
-                "send_ts_ns": time.time_ns(),
-            },
-            "__payload__": data,
-        }
+    def _build_envelope(self, topic: str, data: dict) -> tuple:
+        meta_bytes = orjson.dumps({
+            "message_id": self._next_message_id(topic),
+            "send_ts_ns": time.time_ns(),
+            "content_type": "json",
+        })
+        payload_bytes = orjson.dumps(data)
+        return meta_bytes, payload_bytes
 
     # ---------------------------------------------------------
     # Publish
     # ---------------------------------------------------------
     async def publish(self, topic: str, data: dict):
-        envelope = self._build_envelope(topic, data)
-
         if not self._connected:
             self.stats.track_event("__DROP__", "disconnected")
             self.stats.track_event("__DROP_TOPIC__", topic)
             return  # drop silently (ZeroMQ semantics)
 
         topic_bytes = topic.encode("utf-8")
-        payload = orjson.dumps(envelope)
-        total_size = len(topic_bytes) + len(payload)
+        meta_bytes, payload_bytes = self._build_envelope(topic, data)
+        total_size = len(topic_bytes) + len(meta_bytes) + len(payload_bytes)
 
         try:
-            self.socket.send_multipart([topic_bytes, payload], flags=zmq.DONTWAIT)
+            self.socket.send_multipart([topic_bytes, meta_bytes, payload_bytes], flags=zmq.DONTWAIT)
             self.stats.track_packet("__OUTGOING__", "__TOTAL__", total_size)
             self.stats.track_packet("__TOPIC_OUTGOING__", topic, total_size)
 

--- a/lib/ipc/pubsub/subscriber.py
+++ b/lib/ipc/pubsub/subscriber.py
@@ -50,15 +50,14 @@ class _IpcSubscriberStats:
         self.stats.track_event("__TOTAL__", "__MISSED__", count=count)
         self.stats.track_event(topic, "__MISSED__", count=count)
 
-    def _parse_envelope(self, payload: bytes) -> Tuple[dict, int, Optional[int]]:
-        message = orjson.loads(payload)
-        meta = message["__meta__"]
+    def _parse_envelope(self, meta_bytes: bytes, payload_bytes: bytes) -> Tuple[dict, int, Optional[int]]:
+        meta = orjson.loads(meta_bytes)
         send_ts_ns = meta.get("send_ts_ns")
 
         if not isinstance(send_ts_ns, int):
             send_ts_ns = None
 
-        return message["__payload__"], meta["message_id"], send_ts_ns
+        return orjson.loads(payload_bytes), meta["message_id"], send_ts_ns
 
     def _track_latency(
         self, topic: str, send_ts_ns: Optional[int], recv_ts_ns: Optional[int] = None
@@ -218,13 +217,13 @@ class IpcSubscriberSync(_IpcSubscriberStats):
                         recv_failed = True
                         break
 
-                    if len(frames) != 2:
+                    if len(frames) != 3:
                         self.stats.track_event("__DROP__", "invalid_frame_count")
                         continue
 
-                    topic_bytes, payload = frames
+                    topic_bytes, meta_bytes, payload_bytes = frames
                     topic = topic_bytes.decode()
-                    total_size = len(topic_bytes) + len(payload)
+                    total_size = len(topic_bytes) + len(meta_bytes) + len(payload_bytes)
 
                     self.stats.track_packet("__TOTAL__", "__PACKETS__", total_size)
                     self.stats.track_packet(topic, "__PACKETS__", total_size)
@@ -234,7 +233,7 @@ class IpcSubscriberSync(_IpcSubscriberStats):
                         continue
 
                     try:
-                        data, message_id, send_ts_ns = self._parse_envelope(payload)
+                        data, message_id, send_ts_ns = self._parse_envelope(meta_bytes, payload_bytes)
                         self._track_sequence(topic, message_id)
                         self._track_latency(topic, send_ts_ns, recv_ts_ns=time.time_ns())
                     except (ValueError, TypeError, KeyError):
@@ -409,13 +408,13 @@ class IpcSubscriberAsync(_IpcSubscriberStats):
                 poller = await self._reconnect(poller, e)
                 continue
 
-            if len(frames) != 2:
+            if len(frames) != 3:
                 self.stats.track_event("__DROP__", "invalid_frame_count")
                 continue
 
-            topic_bytes, payload = frames
+            topic_bytes, meta_bytes, payload_bytes = frames
             topic = topic_bytes.decode()
-            total_size = len(topic_bytes) + len(payload)
+            total_size = len(topic_bytes) + len(meta_bytes) + len(payload_bytes)
 
             self.stats.track_packet("__TOTAL__", "__PACKETS__", total_size)
             self.stats.track_packet(topic, "__PACKETS__", total_size)
@@ -428,7 +427,7 @@ class IpcSubscriberAsync(_IpcSubscriberStats):
                 continue
 
             try:
-                data, message_id, send_ts_ns = self._parse_envelope(payload)
+                data, message_id, send_ts_ns = self._parse_envelope(meta_bytes, payload_bytes)
                 self._track_sequence(topic, message_id)
                 self._track_latency(topic, send_ts_ns, recv_ts_ns=time.time_ns())
             except (ValueError, TypeError, KeyError):


### PR DESCRIPTION
## 📝 Description

Splits the 2-frame [topic | meta+payload JSON] wire format into a 3-frame [topic | meta JSON | payload bytes] multipart. Meta gains a content_type field to support future non-JSON payload dispatch.

Fixes #248

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [ ] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
<paste result here>
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [ ] My code follows project style conventions
* [ ] All new and existing tests pass
* [ ] I have added relevant documentation/comments
* [ ] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Adopt a three-frame ZeroMQ pub/sub envelope separating topic, metadata, and payload to support content-type-aware message handling.

New Features:
- Add a distinct metadata frame with a content_type field to published messages to enable future non-JSON payloads.

Enhancements:
- Adjust publisher and subscriber to send, receive, and size-account for three-part multipart messages instead of a combined two-frame envelope.