### PR TITLE
feat(ipc): add bidirectional sync/async DEALER routing

### DIFF
--- a/lib/ipc/router_dealer/SEQUENCE_DIAGRAM.mmd
+++ b/lib/ipc/router_dealer/SEQUENCE_DIAGRAM.mmd
@@ -1,0 +1,63 @@
+%%{init: {
+  "theme": "base",
+  "themeVariables": {
+    "primaryColor": "#1e1e2e",
+    "primaryTextColor": "#ffffff",
+    "primaryBorderColor": "#888",
+    "lineColor": "#ffffff",
+    "secondaryColor": "#2a2a40",
+    "tertiaryColor": "#3a3a55",
+    "background": "#0f0f17",
+    "actorBkg": "#1e1e2e",
+    "actorTextColor": "#ffffff",
+    "actorBorder": "#888",
+    "signalColor": "#ffffff",
+    "signalTextColor": "#ffffff",
+    "labelBoxBkgColor": "#222233",
+    "labelTextColor": "#ffffff"
+  }
+}}%%
+
+sequenceDiagram
+    participant CT as Coroutine caller
+    participant DS as DEALER socket
+    participant RL as recv_loop task
+    participant R as IpcRouter
+    participant RD as Remote DEALER
+
+    Note over RL: started via dealer.start or auto spawn
+
+    rect rgb(40, 60, 90)
+        Note over CT,RD: OUTBOUND SEND
+
+        CT->>CT: acquire send_lock and create Future
+        CT->>DS: send_multipart [dest, REPLY_REQUIRED, topic, payload]
+        CT->>CT: await Future with timeout
+
+        DS->>R: forward to destination
+        R->>RD: deliver message
+
+        RD->>RD: handler runs and produces result
+        RD->>R: reply
+        R->>DS: [sender_id, reply_payload]
+
+        RL->>DS: recv_multipart
+        RL->>CT: resolve Future with reply
+
+        CT->>CT: return decoded payload
+        CT->>CT: release send_lock
+    end
+
+    rect rgb(40, 90, 60)
+        Note over RD,CT: INBOUND COMMAND DISPATCH
+
+        RD->>R: [my_id, target_id, reply_flag, topic, payload]
+        R->>DS: [sender_id, reply_flag, topic, payload]
+
+        RL->>DS: recv_multipart
+        RL->>RL: handler processes data
+
+        alt reply_flag == REPLY_REQUIRED
+            RL->>DS: send_multipart [sender_id, reply_payload]
+        end
+    end

--- a/lib/ipc/router_dealer/dealer/async_client.py
+++ b/lib/ipc/router_dealer/dealer/async_client.py
@@ -24,7 +24,7 @@
 
 import asyncio
 import logging
-from typing import Optional
+from typing import Callable, Dict, Optional
 
 import orjson
 import zmq
@@ -41,12 +41,12 @@ _NO_REPLY       = b"\x00"
 
 class IpcDealerAsync:
     """
-    Async ZeroMQ DEALER client for sending routed commands.
+    Async ZeroMQ DEALER client — bidirectional.
 
     Connects to an IpcRouter with a fixed ZMQ identity. ZMQ handles TCP
     reconnection internally — no reconnect loop is needed.
 
-    Supports two modes:
+    Outbound modes:
 
     **Fire-and-forget** — send and return immediately::
 
@@ -56,9 +56,27 @@ class IpcDealerAsync:
 
         stats = await dealer.send("hud", "get-stats", {})
 
+    Inbound (optional): register handlers via ``route(topic)`` and call
+    ``await dealer.start()`` to spawn the background receive loop. Inbound
+    frames arrive as ``[sender_id, reply_flag, topic, payload]``; replies to
+    a prior outbound ``send()`` arrive as ``[sender_id, reply_payload]`` and
+    are demuxed by frame count.
+
+    Notes:
+      - Only one outbound ``send()`` may be in-flight at a time (protocol has
+        no correlation ID). Enforced by an internal lock.
+      - Async handlers should be ``async def``; sync handlers must be fast —
+        anything that blocks stalls the recv loop.
+
     Usage::
 
         dealer = IpcDealerAsync(port=53836, identity="backend")
+
+        @dealer.route("ping")
+        async def on_ping(data: dict) -> dict:
+            return {"status": "ok", "echo": data}
+
+        await dealer.start()  # only needed if you registered routes
 
         await dealer.fire("hud", "hud-toggle-notification", {"oid": "mfd"})
         stats = await dealer.send("hud", "get-stats", {})
@@ -93,6 +111,11 @@ class IpcDealerAsync:
         self._send_lock = asyncio.Lock()
         self.stats = EventCounter()
 
+        self._routes: Dict[str, Callable[[dict], object]] = {}
+        self._pending_reply: Optional[asyncio.Future] = None
+        self._recv_task: Optional[asyncio.Task] = None
+        self._running = False
+
         self._connect()
 
     # ---------------------------------------------------------
@@ -111,6 +134,111 @@ class IpcDealerAsync:
         endpoint = f"tcp://{self.host}:{self.port}"
         self.socket.connect(endpoint)
         self.logger.debug("IpcDealerAsync [%s] connected to %s", self.identity, endpoint)
+
+    # ---------------------------------------------------------
+    # Inbound routing
+    # ---------------------------------------------------------
+    def route(self, topic: str):
+        """Decorator to register a handler for a topic string."""
+        def decorator(func: Callable[[dict], object]):
+            self._routes[topic] = func
+            return func
+        return decorator
+
+    async def start(self) -> None:
+        """
+        Spawn the background receive loop. Required only if inbound routing
+        is needed (i.e. handlers were registered via ``route()``).
+
+        Idempotent: calling twice has no effect.
+        """
+        if self._recv_task is not None and not self._recv_task.done():
+            return
+        self._running = True
+        self._recv_task = asyncio.create_task(self._recv_loop())
+
+    async def _recv_loop(self) -> None:
+        """
+        Single reader for the DEALER socket. Demuxes by frame count:
+          - 2 frames → reply to a pending outbound send()
+          - 4 frames → unsolicited inbound command → dispatch to handler
+        """
+        try:
+            while self._running:
+                try:
+                    frames = await self.socket.recv_multipart()
+                except zmq.ZMQError as e:
+                    if not self._running:
+                        return
+                    self.stats.track_event("__ERROR__", "recv_failed")
+                    self.logger.warning(
+                        "IpcDealerAsync [%s] recv error: %s", self.identity, e
+                    )
+                    continue
+
+                if len(frames) == 2:
+                    # Reply to a pending send()
+                    pending = self._pending_reply
+                    if pending is not None and not pending.done():
+                        pending.set_result(frames)
+                    else:
+                        self.stats.track_event("__DROP__", "unexpected_reply")
+                    continue
+
+                if len(frames) >= 4:
+                    await self._handle_inbound(frames)
+                    continue
+
+                self.stats.track_event("__DROP__", "short_frame")
+        except asyncio.CancelledError:
+            return
+
+    async def _handle_inbound(self, frames: list) -> None:
+        sender_id, reply_flag, topic_bytes, payload_bytes = (
+            frames[0], frames[1], frames[2], frames[3]
+        )
+        wants_reply = (reply_flag == _REPLY_REQUIRED)
+        topic = topic_bytes.decode("utf-8", errors="replace")
+        total_size = sum(len(f) for f in frames)
+
+        self.stats.track_packet("__INCOMING__", topic, total_size)
+
+        try:
+            data = orjson.loads(payload_bytes)
+        except (ValueError, TypeError):
+            self.stats.track_event("__DROP__", "invalid_json")
+            if wants_reply:
+                await self._send_reply(sender_id, {"status": "error", "reason": "invalid payload"})
+            return
+
+        handler = self._routes.get(topic)
+        if handler is None:
+            self.stats.track_event("__DROP__", f"unrouted_{topic}")
+            if wants_reply:
+                await self._send_reply(sender_id, {"status": "error", "reason": f"unknown topic: {topic}"})
+            return
+
+        try:
+            result = handler(data)
+            if asyncio.iscoroutine(result):
+                result = await result
+            self.stats.track_event("__HANDLER_OK__", topic)
+            if wants_reply:
+                reply = result if isinstance(result, dict) else {"status": "ok"}
+                await self._send_reply(sender_id, reply)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            self.stats.track_event("__HANDLER_ERR__", topic)
+            self.logger.exception("Handler error for topic %r: %s", topic, e)
+            if wants_reply:
+                await self._send_reply(sender_id, {"status": "error", "reason": str(e)})
+
+    async def _send_reply(self, sender_id: bytes, reply: dict) -> None:
+        try:
+            await self.socket.send_multipart([sender_id, orjson.dumps(reply)])
+            self.stats.track_event("__REPLY__", reply.get("status", "data"))
+        except zmq.ZMQError as e:
+            self.stats.track_event("__ERROR__", "reply_send_failed")
+            self.logger.warning("IpcDealerAsync [%s] failed to send reply: %s", self.identity, e)
 
     # ---------------------------------------------------------
     # Fire-and-forget
@@ -161,33 +289,41 @@ class IpcDealerAsync:
         total_size = len(dest_identity) + len(topic) + len(payload)
 
         async with self._send_lock:
-            try:
-                await self.socket.send_multipart(
-                    [dest_identity.encode(), _REPLY_REQUIRED, topic.encode(), payload]
-                )
-                self.stats.track_packet("__OUTGOING__", topic, total_size)
-            except zmq.ZMQError as e:
-                self.stats.track_event("__ERROR__", "send_failed")
-                self.logger.warning(
-                    "IpcDealerAsync [%s] send error to %r: %s", self.identity, dest_identity, e
-                )
-                return {"status": "error", "reason": str(e)}
+            # Ensure the recv loop is running so replies can be delivered.
+            if self._recv_task is None or self._recv_task.done():
+                self._running = True
+                self._recv_task = asyncio.create_task(self._recv_loop())
+
+            loop = asyncio.get_event_loop()
+            future: asyncio.Future = loop.create_future()
+            self._pending_reply = future
 
             try:
-                frames = await asyncio.wait_for(
-                    self.socket.recv_multipart(),
-                    timeout=self.ACK_TIMEOUT,
-                )
-            except asyncio.TimeoutError:
-                self.stats.track_event("__ERROR__", "reply_timeout")
-                self.logger.warning(
-                    "IpcDealerAsync [%s] reply timeout for topic %r to %r",
-                    self.identity, topic, dest_identity,
-                )
-                return {"status": "error", "reason": "ack timeout"}
-            except zmq.ZMQError as e:
-                self.stats.track_event("__ERROR__", "recv_failed")
-                return {"status": "error", "reason": str(e)}
+                try:
+                    await self.socket.send_multipart(
+                        [dest_identity.encode(), _REPLY_REQUIRED, topic.encode(), payload]
+                    )
+                    self.stats.track_packet("__OUTGOING__", topic, total_size)
+                except zmq.ZMQError as e:
+                    self.stats.track_event("__ERROR__", "send_failed")
+                    self.logger.warning(
+                        "IpcDealerAsync [%s] send error to %r: %s", self.identity, dest_identity, e
+                    )
+                    return {"status": "error", "reason": str(e)}
+
+                try:
+                    frames = await asyncio.wait_for(future, timeout=self.ACK_TIMEOUT)
+                except asyncio.TimeoutError:
+                    self.stats.track_event("__ERROR__", "reply_timeout")
+                    self.logger.warning(
+                        "IpcDealerAsync [%s] reply timeout for topic %r to %r",
+                        self.identity, topic, dest_identity,
+                    )
+                    return {"status": "error", "reason": "ack timeout"}
+                except asyncio.CancelledError:
+                    return {"status": "error", "reason": "cancelled"}
+            finally:
+                self._pending_reply = None
 
         if not frames:
             return {"status": "error", "reason": "empty reply"}
@@ -204,6 +340,21 @@ class IpcDealerAsync:
     # Shutdown / stats
     # ---------------------------------------------------------
     async def close(self) -> None:
+        self._running = False
+
+        # Fail any in-flight send() so the awaiter unblocks immediately.
+        pending = self._pending_reply
+        if pending is not None and not pending.done():
+            pending.set_exception(asyncio.CancelledError("dealer closed"))
+
+        if self._recv_task is not None:
+            self._recv_task.cancel()
+            try:
+                await self._recv_task
+            except (asyncio.CancelledError, Exception):  # pylint: disable=broad-exception-caught
+                pass
+            self._recv_task = None
+
         if self.socket:
             try:
                 self.socket.close(linger=0)

--- a/lib/ipc/router_dealer/dealer/async_client.py
+++ b/lib/ipc/router_dealer/dealer/async_client.py
@@ -360,6 +360,12 @@ class IpcDealerAsync:
                 self.socket.close(linger=0)
             except Exception:  # pylint: disable=broad-exception-caught
                 pass
+
+        try:
+            self._ctx.term()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
         self.logger.debug("IpcDealerAsync [%s] closed", self.identity)
 
     def get_stats(self) -> dict:

--- a/lib/ipc/router_dealer/dealer/async_client.py
+++ b/lib/ipc/router_dealer/dealer/async_client.py
@@ -39,29 +39,6 @@ _NO_REPLY       = b"\x00"
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
-class _ReplyCoordinator:
-    """Encapsulates the one-in-flight reply future for IpcDealerAsync."""
-
-    def __init__(self) -> None:
-        self._future: Optional[asyncio.Future] = None
-
-    def new_waiter(self) -> asyncio.Future:
-        loop = asyncio.get_running_loop()
-        fut = loop.create_future()
-        self._future = fut
-        return fut
-
-    def deliver(self, frames: list) -> bool:
-        if self._future is not None and not self._future.done():
-            self._future.set_result(frames)
-            return True
-        return False
-
-    def cancel(self, exc: Exception) -> None:
-        if self._future is not None and not self._future.done():
-            self._future.set_exception(exc)
-
-
 class IpcDealerAsync:
     """
     Async ZeroMQ DEALER client — bidirectional.
@@ -135,7 +112,7 @@ class IpcDealerAsync:
         self.stats = EventCounter()
 
         self._routes: Dict[str, Callable[[dict], object]] = {}
-        self._replies = _ReplyCoordinator()
+        self._pending_reply: Optional[asyncio.Future] = None
         self._recv_task: Optional[asyncio.Task] = None
 
         self._connect()
@@ -157,9 +134,6 @@ class IpcDealerAsync:
         self.socket.connect(endpoint)
         self.logger.debug("IpcDealerAsync [%s] connected to %s", self.identity, endpoint)
 
-    # ---------------------------------------------------------
-    # Recv loop lifecycle
-    # ---------------------------------------------------------
     def _ensure_recv_loop(self) -> None:
         if self._recv_task is None or self._recv_task.done():
             self._recv_task = asyncio.create_task(self._recv_loop())
@@ -195,14 +169,14 @@ class IpcDealerAsync:
                     frames = await self.socket.recv_multipart()
                 except zmq.ZMQError as e:
                     self.stats.track_event("__ERROR__", "recv_failed")
-                    self.logger.warning(
-                        "IpcDealerAsync [%s] recv error: %s", self.identity, e
-                    )
+                    self.logger.warning("IpcDealerAsync [%s] recv error: %s", self.identity, e)
                     continue
 
                 if len(frames) == 2:
-                    # Reply to a pending send()
-                    if not self._replies.deliver(frames):
+                    pending = self._pending_reply
+                    if pending is not None and not pending.done():
+                        pending.set_result(frames)
+                    else:
                         self.stats.track_event("__DROP__", "unexpected_reply")
                     continue
 
@@ -215,14 +189,10 @@ class IpcDealerAsync:
             return
 
     async def _handle_inbound(self, frames: list) -> None:
-        sender_id, reply_flag, topic_bytes, payload_bytes = (
-            frames[0], frames[1], frames[2], frames[3]
-        )
+        sender_id, reply_flag, topic_bytes, payload_bytes = frames[0], frames[1], frames[2], frames[3]
         wants_reply = (reply_flag == _REPLY_REQUIRED)
         topic = topic_bytes.decode("utf-8", errors="replace")
-        total_size = sum(len(f) for f in frames)
-
-        self.stats.track_packet("__INCOMING__", topic, total_size)
+        self.stats.track_packet("__INCOMING__", topic, sum(len(f) for f in frames))
 
         try:
             data = orjson.loads(payload_bytes)
@@ -245,8 +215,7 @@ class IpcDealerAsync:
                 result = await result
             self.stats.track_event("__HANDLER_OK__", topic)
             if wants_reply:
-                reply = result if isinstance(result, dict) else {"status": "ok"}
-                await self._send_reply(sender_id, reply)
+                await self._send_reply(sender_id, result if isinstance(result, dict) else {"status": "ok"})
         except Exception as e:  # pylint: disable=broad-exception-caught
             self.stats.track_event("__HANDLER_ERR__", topic)
             self.logger.exception("Handler error for topic %r: %s", topic, e)
@@ -268,27 +237,18 @@ class IpcDealerAsync:
         """
         Send a command and return immediately — no reply is awaited.
 
-        Use for high-frequency or best-effort commands where the sender does not
-        need confirmation that the recipient processed the message.
-
         Args:
             dest_identity: ZMQ identity of the target DEALER (e.g. ``"hud"``).
             topic: Command topic string.
             data: Payload dict (JSON-serialisable).
         """
         payload = orjson.dumps(data)
-        total_size = len(dest_identity) + len(topic) + len(payload)
-
         try:
-            await self.socket.send_multipart(
-                [dest_identity.encode(), _NO_REPLY, topic.encode(), payload]
-            )
-            self.stats.track_packet("__FIRE__", topic, total_size)
+            await self.socket.send_multipart([dest_identity.encode(), _NO_REPLY, topic.encode(), payload])
+            self.stats.track_packet("__FIRE__", topic, len(dest_identity) + len(topic) + len(payload))
         except zmq.ZMQError as e:
             self.stats.track_event("__ERROR__", "fire_failed")
-            self.logger.warning(
-                "IpcDealerAsync [%s] fire error to %r: %s", self.identity, dest_identity, e
-            )
+            self.logger.warning("IpcDealerAsync [%s] fire error to %r: %s", self.identity, dest_identity, e)
 
     # ---------------------------------------------------------
     # Request-response (awaits reply)
@@ -307,38 +267,35 @@ class IpcDealerAsync:
             Returns an error dict without raising on timeout or send failure.
         """
         payload = orjson.dumps(data)
-        total_size = len(dest_identity) + len(topic) + len(payload)
 
         async with self._send_lock:
             self._ensure_recv_loop()
-            future = self._replies.new_waiter()
+
+            future: asyncio.Future = asyncio.get_running_loop().create_future()
+            self._pending_reply = future
 
             try:
                 try:
                     await self.socket.send_multipart(
                         [dest_identity.encode(), _REPLY_REQUIRED, topic.encode(), payload]
                     )
-                    self.stats.track_packet("__OUTGOING__", topic, total_size)
+                    self.stats.track_packet("__OUTGOING__", topic, len(dest_identity) + len(topic) + len(payload))
                 except zmq.ZMQError as e:
                     self.stats.track_event("__ERROR__", "send_failed")
-                    self.logger.warning(
-                        "IpcDealerAsync [%s] send error to %r: %s", self.identity, dest_identity, e
-                    )
+                    self.logger.warning("IpcDealerAsync [%s] send error to %r: %s", self.identity, dest_identity, e)
                     return {"status": "error", "reason": str(e)}
 
                 try:
                     frames = await asyncio.wait_for(future, timeout=self.ACK_TIMEOUT)
                 except asyncio.TimeoutError:
                     self.stats.track_event("__ERROR__", "reply_timeout")
-                    self.logger.warning(
-                        "IpcDealerAsync [%s] reply timeout for topic %r to %r",
-                        self.identity, topic, dest_identity,
-                    )
+                    self.logger.warning("IpcDealerAsync [%s] reply timeout for topic %r to %r",
+                                        self.identity, topic, dest_identity)
                     return {"status": "error", "reason": "ack timeout"}
                 except asyncio.CancelledError:
                     return {"status": "error", "reason": "cancelled"}
             finally:
-                self._replies.cancel(Exception("send completed"))
+                self._pending_reply = None
 
         if not frames:
             return {"status": "error", "reason": "empty reply"}
@@ -355,7 +312,9 @@ class IpcDealerAsync:
     # Shutdown / stats
     # ---------------------------------------------------------
     async def close(self) -> None:
-        self._replies.cancel(asyncio.CancelledError("dealer closed"))
+        pending = self._pending_reply
+        if pending is not None and not pending.done():
+            pending.set_exception(asyncio.CancelledError("dealer closed"))
 
         if self._recv_task is not None:
             self._recv_task.cancel()

--- a/lib/ipc/router_dealer/dealer/async_client.py
+++ b/lib/ipc/router_dealer/dealer/async_client.py
@@ -39,6 +39,29 @@ _NO_REPLY       = b"\x00"
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
+class _ReplyCoordinator:
+    """Encapsulates the one-in-flight reply future for IpcDealerAsync."""
+
+    def __init__(self) -> None:
+        self._future: Optional[asyncio.Future] = None
+
+    def new_waiter(self) -> asyncio.Future:
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        self._future = fut
+        return fut
+
+    def deliver(self, frames: list) -> bool:
+        if self._future is not None and not self._future.done():
+            self._future.set_result(frames)
+            return True
+        return False
+
+    def cancel(self, exc: Exception) -> None:
+        if self._future is not None and not self._future.done():
+            self._future.set_exception(exc)
+
+
 class IpcDealerAsync:
     """
     Async ZeroMQ DEALER client — bidirectional.
@@ -112,9 +135,8 @@ class IpcDealerAsync:
         self.stats = EventCounter()
 
         self._routes: Dict[str, Callable[[dict], object]] = {}
-        self._pending_reply: Optional[asyncio.Future] = None
+        self._replies = _ReplyCoordinator()
         self._recv_task: Optional[asyncio.Task] = None
-        self._running = False
 
         self._connect()
 
@@ -136,6 +158,13 @@ class IpcDealerAsync:
         self.logger.debug("IpcDealerAsync [%s] connected to %s", self.identity, endpoint)
 
     # ---------------------------------------------------------
+    # Recv loop lifecycle
+    # ---------------------------------------------------------
+    def _ensure_recv_loop(self) -> None:
+        if self._recv_task is None or self._recv_task.done():
+            self._recv_task = asyncio.create_task(self._recv_loop())
+
+    # ---------------------------------------------------------
     # Inbound routing
     # ---------------------------------------------------------
     def route(self, topic: str):
@@ -152,10 +181,7 @@ class IpcDealerAsync:
 
         Idempotent: calling twice has no effect.
         """
-        if self._recv_task is not None and not self._recv_task.done():
-            return
-        self._running = True
-        self._recv_task = asyncio.create_task(self._recv_loop())
+        self._ensure_recv_loop()
 
     async def _recv_loop(self) -> None:
         """
@@ -164,12 +190,10 @@ class IpcDealerAsync:
           - 4 frames → unsolicited inbound command → dispatch to handler
         """
         try:
-            while self._running:
+            while True:
                 try:
                     frames = await self.socket.recv_multipart()
                 except zmq.ZMQError as e:
-                    if not self._running:
-                        return
                     self.stats.track_event("__ERROR__", "recv_failed")
                     self.logger.warning(
                         "IpcDealerAsync [%s] recv error: %s", self.identity, e
@@ -178,10 +202,7 @@ class IpcDealerAsync:
 
                 if len(frames) == 2:
                     # Reply to a pending send()
-                    pending = self._pending_reply
-                    if pending is not None and not pending.done():
-                        pending.set_result(frames)
-                    else:
+                    if not self._replies.deliver(frames):
                         self.stats.track_event("__DROP__", "unexpected_reply")
                     continue
 
@@ -289,14 +310,8 @@ class IpcDealerAsync:
         total_size = len(dest_identity) + len(topic) + len(payload)
 
         async with self._send_lock:
-            # Ensure the recv loop is running so replies can be delivered.
-            if self._recv_task is None or self._recv_task.done():
-                self._running = True
-                self._recv_task = asyncio.create_task(self._recv_loop())
-
-            loop = asyncio.get_event_loop()
-            future: asyncio.Future = loop.create_future()
-            self._pending_reply = future
+            self._ensure_recv_loop()
+            future = self._replies.new_waiter()
 
             try:
                 try:
@@ -323,7 +338,7 @@ class IpcDealerAsync:
                 except asyncio.CancelledError:
                     return {"status": "error", "reason": "cancelled"}
             finally:
-                self._pending_reply = None
+                self._replies.cancel(Exception("send completed"))
 
         if not frames:
             return {"status": "error", "reason": "empty reply"}
@@ -340,12 +355,7 @@ class IpcDealerAsync:
     # Shutdown / stats
     # ---------------------------------------------------------
     async def close(self) -> None:
-        self._running = False
-
-        # Fail any in-flight send() so the awaiter unblocks immediately.
-        pending = self._pending_reply
-        if pending is not None and not pending.done():
-            pending.set_exception(asyncio.CancelledError("dealer closed"))
+        self._replies.cancel(asyncio.CancelledError("dealer closed"))
 
         if self._recv_task is not None:
             self._recv_task.cancel()

--- a/lib/ipc/router_dealer/dealer/client.py
+++ b/lib/ipc/router_dealer/dealer/client.py
@@ -213,6 +213,11 @@ class IpcDealerClient:
         except Exception:  # pylint: disable=broad-exception-caught
             pass
 
+        try:
+            self._ctx.term()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
         self.logger.debug("IpcDealerClient [%s] stopped", self.identity)
 
     def _send_reply(self, sender_id: bytes, reply: dict) -> None:

--- a/lib/ipc/router_dealer/dealer/client.py
+++ b/lib/ipc/router_dealer/dealer/client.py
@@ -23,6 +23,7 @@
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
 import logging
+import threading
 from typing import Callable, Dict, Optional
 
 import orjson
@@ -35,11 +36,16 @@ from lib.event_counter import EventCounter
 _REPLY_REQUIRED = b"\x01"
 _NO_REPLY       = b"\x00"
 
+# Sentinel pushed through the pipe to tell the loop to exit cleanly.
+_CMD_STOP  = b"\xff"
+_CMD_FIRE  = b"\x00"
+_CMD_SEND  = b"\x01"
+
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
 class IpcDealerClient:
     """
-    Synchronous ZeroMQ DEALER client for receiving routed commands.
+    Synchronous ZeroMQ DEALER client — bidirectional.
 
     Connects to an IpcRouter with a fixed ZMQ identity. Incoming frames arrive as:
         [sender_id, reply_flag, topic, payload]
@@ -52,6 +58,22 @@ class IpcDealerClient:
     sends back the handler's return value (or an error dict on exception).
     If fire-and-forget, no reply is sent.
 
+    Outbound commands:
+
+    **Fire-and-forget**::
+
+        client.fire("backend", "notify", {"msg": "hello"})
+
+    **Request-response** (blocks caller thread until reply or timeout)::
+
+        reply = client.send("backend", "get-stats", {}, timeout=2.0)
+
+    ``send()`` is safe to call from any thread *except* the loop thread itself
+    (deadlock). Only one outbound ``send()`` may be in-flight at a time.
+
+    ZMQ sockets are not thread-safe, so outbound sends are marshalled through
+    an inproc PAIR pipe that the loop thread drains alongside the DEALER socket.
+
     Usage::
 
         client = IpcDealerClient(port=53836, identity="hud")
@@ -59,14 +81,14 @@ class IpcDealerClient:
         @client.route("hud-toggle-notification")
         def on_toggle(data: dict):
             overlays_mgr.toggle(data["oid"])
-            # no return value needed for fire-and-forget
 
         @client.route("get-stats")
         def on_get_stats(data: dict) -> dict:
-            return overlays_mgr.get_stats()  # returned to sender
+            return overlays_mgr.get_stats()
 
         threading.Thread(target=client.start, daemon=True).start()
         # ... later:
+        reply = client.send("backend", "query", {})
         client.close()
     """
 
@@ -96,6 +118,26 @@ class IpcDealerClient:
 
         self._ctx = zmq.Context()
         self.socket: Optional[zmq.Socket] = None
+
+        # Inproc PAIR pipe: caller thread → loop thread for outbound sends.
+        # Use id(self) so multiple instances in the same process don't collide.
+        self._pipe_addr = f"inproc://dealer-pipe-{id(self)}"
+        self._pipe_write: zmq.Socket = self._ctx.socket(zmq.PAIR)
+        self._pipe_write.setsockopt(zmq.LINGER, 0)
+        self._pipe_write.bind(self._pipe_addr)
+
+        self._pipe_read: zmq.Socket = self._ctx.socket(zmq.PAIR)
+        self._pipe_read.setsockopt(zmq.LINGER, 0)
+        self._pipe_read.connect(self._pipe_addr)
+
+        # Serialises all writes to _pipe_write (ZMQ sockets are not thread-safe).
+        self._pipe_lock = threading.Lock()
+        # Serialises concurrent send() callers (only one in-flight at a time).
+        self._send_lock = threading.Lock()
+        # Slot for the loop thread to deposit a send() reply.
+        self._reply_slot: Optional[dict] = None
+        self._reply_event = threading.Event()
+
         self._create_and_connect()
 
     # ---------------------------------------------------------
@@ -126,6 +168,83 @@ class IpcDealerClient:
         return decorator
 
     # ---------------------------------------------------------
+    # Outbound: fire-and-forget
+    # ---------------------------------------------------------
+    def fire(self, dest_identity: str, topic: str, data: dict) -> None:
+        """
+        Send a command and return immediately — no reply is awaited.
+
+        Thread-safe. May be called from any thread including before start().
+
+        Args:
+            dest_identity: ZMQ identity of the target DEALER.
+            topic: Command topic string.
+            data: Payload dict (JSON-serialisable).
+        """
+        payload = orjson.dumps(data)
+        # Push to pipe: [_CMD_FIRE, dest, topic, payload]
+        with self._pipe_lock:
+            try:
+                self._pipe_write.send_multipart(
+                    [_CMD_FIRE, dest_identity.encode(), topic.encode(), payload],
+                    flags=zmq.NOBLOCK,
+                )
+            except zmq.ZMQError as e:
+                self.stats.track_event("__ERROR__", "fire_pipe_failed")
+                self.logger.warning("IpcDealerClient [%s] fire pipe error: %s", self.identity, e)
+
+    # ---------------------------------------------------------
+    # Outbound: request-response
+    # ---------------------------------------------------------
+    def send(
+        self,
+        dest_identity: str,
+        topic: str,
+        data: dict,
+        timeout: float = 2.0,
+    ) -> dict:
+        """
+        Send a command and block until a reply arrives or timeout elapses.
+
+        Safe to call from any thread *except* the loop thread (deadlock).
+        Only one send() may be in-flight at a time.
+
+        Args:
+            dest_identity: ZMQ identity of the target DEALER.
+            topic: Command topic string.
+            data: Payload dict (JSON-serialisable).
+            timeout: Seconds to wait for a reply (default 2.0).
+
+        Returns:
+            Reply dict from the remote handler, or an error dict on timeout/failure.
+        """
+        payload = orjson.dumps(data)
+
+        with self._send_lock:
+            self._reply_event.clear()
+            self._reply_slot = None
+
+            with self._pipe_lock:
+                try:
+                    self._pipe_write.send_multipart(
+                        [_CMD_SEND, dest_identity.encode(), topic.encode(), payload],
+                        flags=zmq.NOBLOCK,
+                    )
+                except zmq.ZMQError as e:
+                    self.stats.track_event("__ERROR__", "send_pipe_failed")
+                    return {"status": "error", "reason": str(e)}
+
+            signalled = self._reply_event.wait(timeout=timeout)
+            if not signalled:
+                self.stats.track_event("__ERROR__", "reply_timeout")
+                return {"status": "error", "reason": "ack timeout"}
+
+            reply = self._reply_slot
+            self._reply_slot = None
+
+        return reply if reply is not None else {"status": "error", "reason": "empty reply"}
+
+    # ---------------------------------------------------------
     # Main receive loop
     # ---------------------------------------------------------
     def start(self) -> None:
@@ -133,6 +252,10 @@ class IpcDealerClient:
         self._running = True
         poller = zmq.Poller()
         poller.register(self.socket, zmq.POLLIN)
+        poller.register(self._pipe_read, zmq.POLLIN)
+
+        # Flag: we just posted an outbound send() and are waiting for the 2-frame reply.
+        awaiting_reply = False
 
         while self._running:
             try:
@@ -144,8 +267,64 @@ class IpcDealerClient:
                 self._create_and_connect()
                 poller = zmq.Poller()
                 poller.register(self.socket, zmq.POLLIN)
+                poller.register(self._pipe_read, zmq.POLLIN)
                 continue
 
+            # ---- drain the pipe (outbound send requests from caller threads) ----
+            if self._pipe_read in events:
+                try:
+                    pipe_frames = self._pipe_read.recv_multipart(flags=zmq.NOBLOCK)
+                except zmq.Again:
+                    pass
+                except zmq.ZMQError as e:
+                    self.stats.track_event("__ERROR__", "pipe_recv_failed")
+                    self.logger.warning("IpcDealerClient [%s] pipe recv error: %s", self.identity, e)
+                else:
+                    cmd = pipe_frames[0] if pipe_frames else None
+
+                    if cmd == _CMD_STOP:
+                        break
+
+                    if cmd == _CMD_FIRE and len(pipe_frames) == 4:
+                        _, dest, topic_b, payload_b = pipe_frames  # pylint: disable=unbalanced-tuple-unpacking
+                        try:
+                            self.socket.send_multipart(
+                                [dest, _NO_REPLY, topic_b, payload_b],
+                                flags=zmq.NOBLOCK,
+                            )
+                            self.stats.track_packet(
+                                "__FIRE__",
+                                topic_b.decode("utf-8", errors="replace"),
+                                len(dest) + len(topic_b) + len(payload_b),
+                            )
+                        except zmq.ZMQError as e:
+                            self.stats.track_event("__ERROR__", "fire_send_failed")
+                            self.logger.warning(
+                                "IpcDealerClient [%s] fire send error: %s", self.identity, e
+                            )
+
+                    if cmd == _CMD_SEND and len(pipe_frames) == 4:
+                        _, dest, topic_b, payload_b = pipe_frames  # pylint: disable=unbalanced-tuple-unpacking
+                        try:
+                            self.socket.send_multipart(
+                                [dest, _REPLY_REQUIRED, topic_b, payload_b],
+                                flags=zmq.NOBLOCK,
+                            )
+                            self.stats.track_packet(
+                                "__OUTGOING__",
+                                topic_b.decode("utf-8", errors="replace"),
+                                len(dest) + len(topic_b) + len(payload_b),
+                            )
+                            awaiting_reply = True
+                        except zmq.ZMQError as e:
+                            self.stats.track_event("__ERROR__", "send_failed")
+                            self.logger.warning(
+                                "IpcDealerClient [%s] send error: %s", self.identity, e
+                            )
+                            self._reply_slot = {"status": "error", "reason": str(e)}
+                            self._reply_event.set()
+
+            # ---- process inbound from the DEALER socket ----
             if self.socket not in events:
                 continue
 
@@ -160,9 +339,26 @@ class IpcDealerClient:
                 self._create_and_connect()
                 poller = zmq.Poller()
                 poller.register(self.socket, zmq.POLLIN)
+                poller.register(self._pipe_read, zmq.POLLIN)
+                if awaiting_reply:
+                    awaiting_reply = False
+                    self._reply_slot = {"status": "error", "reason": "socket reconnected"}
+                    self._reply_event.set()
                 continue
 
-            # Router delivers: [sender_id, reply_flag, topic, payload]
+            # 2-frame reply to an outbound send()
+            if len(frames) == 2 and awaiting_reply:
+                awaiting_reply = False
+                try:
+                    reply = orjson.loads(frames[-1])
+                except (ValueError, TypeError):
+                    reply = {"status": "error", "reason": "invalid reply payload"}
+                self.stats.track_event("__REPLY__", reply.get("status", "data"))
+                self._reply_slot = reply
+                self._reply_event.set()
+                continue
+
+            # 4-frame inbound command
             if len(frames) < 4:
                 self.stats.track_event("__DROP__", "short_frame")
                 continue
@@ -203,13 +399,26 @@ class IpcDealerClient:
                 if wants_reply:
                     self._send_reply(sender_id, {"status": "error", "reason": str(e)})
 
+        # ---- loop exit cleanup ----
         try:
             poller.unregister(self.socket)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        try:
+            poller.unregister(self._pipe_read)
         except Exception:  # pylint: disable=broad-exception-caught
             pass
 
         try:
             self.socket.close(linger=0)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        try:
+            self._pipe_read.close(linger=0)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        try:
+            self._pipe_write.close(linger=0)
         except Exception:  # pylint: disable=broad-exception-caught
             pass
 
@@ -237,6 +446,12 @@ class IpcDealerClient:
     def close(self) -> None:
         """Signal the receive loop to stop."""
         self._running = False
+        # Wake the loop immediately via the pipe so it doesn't wait for the 100ms poll.
+        with self._pipe_lock:
+            try:
+                self._pipe_write.send_multipart([_CMD_STOP], flags=zmq.NOBLOCK)
+            except zmq.ZMQError:
+                pass
 
     def get_stats(self) -> dict:
         return self.stats.get_stats()

--- a/lib/ipc/router_dealer/dealer/client.py
+++ b/lib/ipc/router_dealer/dealer/client.py
@@ -116,6 +116,9 @@ class IpcDealerClient:
         self._running = False
         self.stats = EventCounter()
 
+        # Set when the loop thread starts; used by send() to detect deadlock-prone misuse.
+        self._loop_thread_id: Optional[int] = None
+
         self._ctx = zmq.Context()
         self.socket: Optional[zmq.Socket] = None
 
@@ -156,6 +159,12 @@ class IpcDealerClient:
         endpoint = f"tcp://{self.host}:{self.port}"
         self.socket.connect(endpoint)
         self.logger.debug("IpcDealerClient [%s] connected to %s", self.identity, endpoint)
+
+    def _rebuild_poller(self) -> zmq.Poller:
+        poller = zmq.Poller()
+        poller.register(self.socket, zmq.POLLIN)
+        poller.register(self._pipe_read, zmq.POLLIN)
+        return poller
 
     # ---------------------------------------------------------
     # Register handler
@@ -218,6 +227,12 @@ class IpcDealerClient:
         Returns:
             Reply dict from the remote handler, or an error dict on timeout/failure.
         """
+        if self._loop_thread_id is not None and threading.get_ident() == self._loop_thread_id:
+            raise RuntimeError(
+                "IpcDealerClient.send() called from the loop thread; this will deadlock. "
+                "Use fire() or call send() from a different thread."
+            )
+
         payload = orjson.dumps(data)
 
         with self._send_lock:
@@ -245,16 +260,148 @@ class IpcDealerClient:
         return reply if reply is not None else {"status": "error", "reason": "empty reply"}
 
     # ---------------------------------------------------------
+    # Main receive loop — pipe and socket helpers
+    # ---------------------------------------------------------
+    def _handle_pipe_event(self, events: dict, awaiting_reply: bool) -> bool:
+        """Drain one command from the inproc pipe. Returns updated awaiting_reply."""
+        if self._pipe_read not in events:
+            return awaiting_reply
+
+        try:
+            pipe_frames = self._pipe_read.recv_multipart(flags=zmq.NOBLOCK)
+        except zmq.Again:
+            return awaiting_reply
+        except zmq.ZMQError as e:
+            self.stats.track_event("__ERROR__", "pipe_recv_failed")
+            self.logger.warning("IpcDealerClient [%s] pipe recv error: %s", self.identity, e)
+            return awaiting_reply
+
+        if not pipe_frames:
+            return awaiting_reply
+
+        cmd = pipe_frames[0]
+
+        if cmd == _CMD_STOP:
+            self._running = False
+            return awaiting_reply
+
+        if cmd == _CMD_FIRE and len(pipe_frames) == 4:
+            _, dest, topic_b, payload_b = pipe_frames  # pylint: disable=unbalanced-tuple-unpacking
+            self._send_fire(dest, topic_b, payload_b)
+            return awaiting_reply
+
+        if cmd == _CMD_SEND and len(pipe_frames) == 4:
+            _, dest, topic_b, payload_b = pipe_frames  # pylint: disable=unbalanced-tuple-unpacking
+            return self._send_request(dest, topic_b, payload_b)
+
+        return awaiting_reply
+
+    def _send_fire(self, dest: bytes, topic_b: bytes, payload_b: bytes) -> None:
+        try:
+            self.socket.send_multipart(
+                [dest, _NO_REPLY, topic_b, payload_b],
+                flags=zmq.NOBLOCK,
+            )
+            self.stats.track_packet(
+                "__FIRE__",
+                topic_b.decode("utf-8", errors="replace"),
+                len(dest) + len(topic_b) + len(payload_b),
+            )
+        except zmq.ZMQError as e:
+            self.stats.track_event("__ERROR__", "fire_send_failed")
+            self.logger.warning("IpcDealerClient [%s] fire send error: %s", self.identity, e)
+
+    def _send_request(self, dest: bytes, topic_b: bytes, payload_b: bytes) -> bool:
+        """Send a request frame. Returns True if now awaiting a reply, False on error."""
+        try:
+            self.socket.send_multipart(
+                [dest, _REPLY_REQUIRED, topic_b, payload_b],
+                flags=zmq.NOBLOCK,
+            )
+            self.stats.track_packet(
+                "__OUTGOING__",
+                topic_b.decode("utf-8", errors="replace"),
+                len(dest) + len(topic_b) + len(payload_b),
+            )
+            return True
+        except zmq.ZMQError as e:
+            self.stats.track_event("__ERROR__", "send_failed")
+            self.logger.warning("IpcDealerClient [%s] send error: %s", self.identity, e)
+            self._reply_slot = {"status": "error", "reason": str(e)}
+            self._reply_event.set()
+            return False
+
+    def _handle_dealer_frames(self, frames: list, awaiting_reply: bool) -> bool:
+        """Process frames received from the DEALER socket. Returns updated awaiting_reply."""
+        if len(frames) == 2 and awaiting_reply:
+            awaiting_reply = False
+            try:
+                reply = orjson.loads(frames[-1])
+            except (ValueError, TypeError):
+                reply = {"status": "error", "reason": "invalid reply payload"}
+            self.stats.track_event("__REPLY__", reply.get("status", "data"))
+            self._reply_slot = reply
+            self._reply_event.set()
+            return awaiting_reply
+
+        if len(frames) < 4:
+            self.stats.track_event("__DROP__", "short_frame")
+            return awaiting_reply
+
+        sender_id, reply_flag, topic_bytes, payload_bytes = (
+            frames[0], frames[1], frames[2], frames[3]
+        )
+        self._dispatch_inbound(sender_id, reply_flag, topic_bytes, payload_bytes)
+        return awaiting_reply
+
+    def _dispatch_inbound(
+        self,
+        sender_id: bytes,
+        reply_flag: bytes,
+        topic_bytes: bytes,
+        payload_bytes: bytes,
+    ) -> None:
+        wants_reply = (reply_flag == _REPLY_REQUIRED)
+        topic = topic_bytes.decode("utf-8", errors="replace")
+        total_size = len(sender_id) + len(topic_bytes) + len(payload_bytes)
+        self.stats.track_packet("__INCOMING__", topic, total_size)
+
+        try:
+            data = orjson.loads(payload_bytes)
+        except (ValueError, TypeError):
+            self.stats.track_event("__DROP__", "invalid_json")
+            if wants_reply:
+                self._send_reply(sender_id, {"status": "error", "reason": "invalid payload"})
+            return
+
+        handler = self._routes.get(topic)
+        if handler is None:
+            self.stats.track_event("__DROP__", f"unrouted_{topic}")
+            if wants_reply:
+                self._send_reply(sender_id, {"status": "error", "reason": f"unknown topic: {topic}"})
+            return
+
+        try:
+            result = handler(data)
+            self.stats.track_event("__HANDLER_OK__", topic)
+            if wants_reply:
+                reply = result if isinstance(result, dict) else {"status": "ok"}
+                self._send_reply(sender_id, reply)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            self.stats.track_event("__HANDLER_ERR__", topic)
+            self.logger.exception("Handler error for topic %r: %s", topic, e)
+            if wants_reply:
+                self._send_reply(sender_id, {"status": "error", "reason": str(e)})
+
+    # ---------------------------------------------------------
     # Main receive loop
     # ---------------------------------------------------------
     def start(self) -> None:
         """Blocking receive loop. Call in a daemon thread."""
         self._running = True
-        poller = zmq.Poller()
-        poller.register(self.socket, zmq.POLLIN)
-        poller.register(self._pipe_read, zmq.POLLIN)
+        self._loop_thread_id = threading.get_ident()
 
-        # Flag: we just posted an outbound send() and are waiting for the 2-frame reply.
+        poller = self._rebuild_poller()
         awaiting_reply = False
 
         while self._running:
@@ -265,66 +412,13 @@ class IpcDealerClient:
                     break
                 self.stats.track_event("__ERROR__", "poll_failed")
                 self._create_and_connect()
-                poller = zmq.Poller()
-                poller.register(self.socket, zmq.POLLIN)
-                poller.register(self._pipe_read, zmq.POLLIN)
+                poller = self._rebuild_poller()
                 continue
 
-            # ---- drain the pipe (outbound send requests from caller threads) ----
-            if self._pipe_read in events:
-                try:
-                    pipe_frames = self._pipe_read.recv_multipart(flags=zmq.NOBLOCK)
-                except zmq.Again:
-                    pass
-                except zmq.ZMQError as e:
-                    self.stats.track_event("__ERROR__", "pipe_recv_failed")
-                    self.logger.warning("IpcDealerClient [%s] pipe recv error: %s", self.identity, e)
-                else:
-                    cmd = pipe_frames[0] if pipe_frames else None
+            awaiting_reply = self._handle_pipe_event(events, awaiting_reply)
+            if not self._running:
+                break
 
-                    if cmd == _CMD_STOP:
-                        break
-
-                    if cmd == _CMD_FIRE and len(pipe_frames) == 4:
-                        _, dest, topic_b, payload_b = pipe_frames  # pylint: disable=unbalanced-tuple-unpacking
-                        try:
-                            self.socket.send_multipart(
-                                [dest, _NO_REPLY, topic_b, payload_b],
-                                flags=zmq.NOBLOCK,
-                            )
-                            self.stats.track_packet(
-                                "__FIRE__",
-                                topic_b.decode("utf-8", errors="replace"),
-                                len(dest) + len(topic_b) + len(payload_b),
-                            )
-                        except zmq.ZMQError as e:
-                            self.stats.track_event("__ERROR__", "fire_send_failed")
-                            self.logger.warning(
-                                "IpcDealerClient [%s] fire send error: %s", self.identity, e
-                            )
-
-                    if cmd == _CMD_SEND and len(pipe_frames) == 4:
-                        _, dest, topic_b, payload_b = pipe_frames  # pylint: disable=unbalanced-tuple-unpacking
-                        try:
-                            self.socket.send_multipart(
-                                [dest, _REPLY_REQUIRED, topic_b, payload_b],
-                                flags=zmq.NOBLOCK,
-                            )
-                            self.stats.track_packet(
-                                "__OUTGOING__",
-                                topic_b.decode("utf-8", errors="replace"),
-                                len(dest) + len(topic_b) + len(payload_b),
-                            )
-                            awaiting_reply = True
-                        except zmq.ZMQError as e:
-                            self.stats.track_event("__ERROR__", "send_failed")
-                            self.logger.warning(
-                                "IpcDealerClient [%s] send error: %s", self.identity, e
-                            )
-                            self._reply_slot = {"status": "error", "reason": str(e)}
-                            self._reply_event.set()
-
-            # ---- process inbound from the DEALER socket ----
             if self.socket not in events:
                 continue
 
@@ -337,69 +431,17 @@ class IpcDealerClient:
                     break
                 self.stats.track_event("__ERROR__", "recv_failed")
                 self._create_and_connect()
-                poller = zmq.Poller()
-                poller.register(self.socket, zmq.POLLIN)
-                poller.register(self._pipe_read, zmq.POLLIN)
+                poller = self._rebuild_poller()
                 if awaiting_reply:
                     awaiting_reply = False
                     self._reply_slot = {"status": "error", "reason": "socket reconnected"}
                     self._reply_event.set()
                 continue
 
-            # 2-frame reply to an outbound send()
-            if len(frames) == 2 and awaiting_reply:
-                awaiting_reply = False
-                try:
-                    reply = orjson.loads(frames[-1])
-                except (ValueError, TypeError):
-                    reply = {"status": "error", "reason": "invalid reply payload"}
-                self.stats.track_event("__REPLY__", reply.get("status", "data"))
-                self._reply_slot = reply
-                self._reply_event.set()
-                continue
-
-            # 4-frame inbound command
-            if len(frames) < 4:
-                self.stats.track_event("__DROP__", "short_frame")
-                continue
-
-            sender_id, reply_flag, topic_bytes, payload_bytes = (
-                frames[0], frames[1], frames[2], frames[3]
-            )
-            wants_reply = (reply_flag == _REPLY_REQUIRED)
-            topic = topic_bytes.decode("utf-8", errors="replace")
-            total_size = sum(len(f) for f in frames)
-
-            self.stats.track_packet("__INCOMING__", topic, total_size)
-
-            try:
-                data = orjson.loads(payload_bytes)
-            except (ValueError, TypeError):
-                self.stats.track_event("__DROP__", "invalid_json")
-                if wants_reply:
-                    self._send_reply(sender_id, {"status": "error", "reason": "invalid payload"})
-                continue
-
-            handler = self._routes.get(topic)
-            if handler is None:
-                self.stats.track_event("__DROP__", f"unrouted_{topic}")
-                if wants_reply:
-                    self._send_reply(sender_id, {"status": "error", "reason": f"unknown topic: {topic}"})
-                continue
-
-            try:
-                result = handler(data)
-                self.stats.track_event("__HANDLER_OK__", topic)
-                if wants_reply:
-                    reply = result if isinstance(result, dict) else {"status": "ok"}
-                    self._send_reply(sender_id, reply)
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                self.stats.track_event("__HANDLER_ERR__", topic)
-                self.logger.exception("Handler error for topic %r: %s", topic, e)
-                if wants_reply:
-                    self._send_reply(sender_id, {"status": "error", "reason": str(e)})
+            awaiting_reply = self._handle_dealer_frames(frames, awaiting_reply)
 
         # ---- loop exit cleanup ----
+        self._loop_thread_id = None
         try:
             poller.unregister(self.socket)
         except Exception:  # pylint: disable=broad-exception-caught

--- a/lib/ipc/router_dealer/dealer/client.py
+++ b/lib/ipc/router_dealer/dealer/client.py
@@ -36,10 +36,10 @@ from lib.event_counter import EventCounter
 _REPLY_REQUIRED = b"\x01"
 _NO_REPLY       = b"\x00"
 
-# Sentinel pushed through the pipe to tell the loop to exit cleanly.
-_CMD_STOP  = b"\xff"
-_CMD_FIRE  = b"\x00"
-_CMD_SEND  = b"\x01"
+# Pipe command bytes — sent through the inproc PAIR pipe from caller threads to the loop thread.
+_PIPE_STOP  = b"\xff"
+_PIPE_FIRE  = b"\xfe"
+_PIPE_SEND  = b"\xfd"
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
@@ -160,12 +160,6 @@ class IpcDealerClient:
         self.socket.connect(endpoint)
         self.logger.debug("IpcDealerClient [%s] connected to %s", self.identity, endpoint)
 
-    def _rebuild_poller(self) -> zmq.Poller:
-        poller = zmq.Poller()
-        poller.register(self.socket, zmq.POLLIN)
-        poller.register(self._pipe_read, zmq.POLLIN)
-        return poller
-
     # ---------------------------------------------------------
     # Register handler
     # ---------------------------------------------------------
@@ -191,11 +185,10 @@ class IpcDealerClient:
             data: Payload dict (JSON-serialisable).
         """
         payload = orjson.dumps(data)
-        # Push to pipe: [_CMD_FIRE, dest, topic, payload]
         with self._pipe_lock:
             try:
                 self._pipe_write.send_multipart(
-                    [_CMD_FIRE, dest_identity.encode(), topic.encode(), payload],
+                    [_PIPE_FIRE, dest_identity.encode(), topic.encode(), payload],
                     flags=zmq.NOBLOCK,
                 )
             except zmq.ZMQError as e:
@@ -242,15 +235,14 @@ class IpcDealerClient:
             with self._pipe_lock:
                 try:
                     self._pipe_write.send_multipart(
-                        [_CMD_SEND, dest_identity.encode(), topic.encode(), payload],
+                        [_PIPE_SEND, dest_identity.encode(), topic.encode(), payload],
                         flags=zmq.NOBLOCK,
                     )
                 except zmq.ZMQError as e:
                     self.stats.track_event("__ERROR__", "send_pipe_failed")
                     return {"status": "error", "reason": str(e)}
 
-            signalled = self._reply_event.wait(timeout=timeout)
-            if not signalled:
+            if not self._reply_event.wait(timeout=timeout):
                 self.stats.track_event("__ERROR__", "reply_timeout")
                 return {"status": "error", "reason": "ack timeout"}
 
@@ -260,10 +252,10 @@ class IpcDealerClient:
         return reply if reply is not None else {"status": "error", "reason": "empty reply"}
 
     # ---------------------------------------------------------
-    # Main receive loop — pipe and socket helpers
+    # Loop helpers
     # ---------------------------------------------------------
     def _handle_pipe_event(self, events: dict, awaiting_reply: bool) -> bool:
-        """Drain one command from the inproc pipe. Returns updated awaiting_reply."""
+        """Drain one pipe command and act on it. Returns updated awaiting_reply."""
         if self._pipe_read not in events:
             return awaiting_reply
 
@@ -276,65 +268,58 @@ class IpcDealerClient:
             self.logger.warning("IpcDealerClient [%s] pipe recv error: %s", self.identity, e)
             return awaiting_reply
 
-        if not pipe_frames:
-            return awaiting_reply
+        cmd = pipe_frames[0] if pipe_frames else None
 
-        cmd = pipe_frames[0]
-
-        if cmd == _CMD_STOP:
+        if cmd == _PIPE_STOP:
             self._running = False
-            return awaiting_reply
 
-        if cmd == _CMD_FIRE and len(pipe_frames) == 4:
+        elif cmd == _PIPE_FIRE and len(pipe_frames) == 4:
             _, dest, topic_b, payload_b = pipe_frames  # pylint: disable=unbalanced-tuple-unpacking
-            self._send_fire(dest, topic_b, payload_b)
-            return awaiting_reply
+            try:
+                self.socket.send_multipart([dest, _NO_REPLY, topic_b, payload_b], flags=zmq.NOBLOCK)
+                self.stats.track_packet("__FIRE__", topic_b.decode("utf-8", errors="replace"),
+                                        len(dest) + len(topic_b) + len(payload_b))
+            except zmq.ZMQError as e:
+                self.stats.track_event("__ERROR__", "fire_send_failed")
+                self.logger.warning("IpcDealerClient [%s] fire send error: %s", self.identity, e)
 
-        if cmd == _CMD_SEND and len(pipe_frames) == 4:
+        elif cmd == _PIPE_SEND and len(pipe_frames) == 4:
             _, dest, topic_b, payload_b = pipe_frames  # pylint: disable=unbalanced-tuple-unpacking
-            return self._send_request(dest, topic_b, payload_b)
+            try:
+                self.socket.send_multipart([dest, _REPLY_REQUIRED, topic_b, payload_b], flags=zmq.NOBLOCK)
+                self.stats.track_packet("__OUTGOING__", topic_b.decode("utf-8", errors="replace"),
+                                        len(dest) + len(topic_b) + len(payload_b))
+                awaiting_reply = True
+            except zmq.ZMQError as e:
+                self.stats.track_event("__ERROR__", "send_failed")
+                self.logger.warning("IpcDealerClient [%s] send error: %s", self.identity, e)
+                self._reply_slot = {"status": "error", "reason": str(e)}
+                self._reply_event.set()
 
         return awaiting_reply
 
-    def _send_fire(self, dest: bytes, topic_b: bytes, payload_b: bytes) -> None:
-        try:
-            self.socket.send_multipart(
-                [dest, _NO_REPLY, topic_b, payload_b],
-                flags=zmq.NOBLOCK,
-            )
-            self.stats.track_packet(
-                "__FIRE__",
-                topic_b.decode("utf-8", errors="replace"),
-                len(dest) + len(topic_b) + len(payload_b),
-            )
-        except zmq.ZMQError as e:
-            self.stats.track_event("__ERROR__", "fire_send_failed")
-            self.logger.warning("IpcDealerClient [%s] fire send error: %s", self.identity, e)
+    def _handle_dealer_event(self, events: dict, awaiting_reply: bool) -> bool:
+        """Receive and dispatch one frame batch from the DEALER socket. Returns updated awaiting_reply."""
+        if self.socket not in events:
+            return awaiting_reply
 
-    def _send_request(self, dest: bytes, topic_b: bytes, payload_b: bytes) -> bool:
-        """Send a request frame. Returns True if now awaiting a reply, False on error."""
         try:
-            self.socket.send_multipart(
-                [dest, _REPLY_REQUIRED, topic_b, payload_b],
-                flags=zmq.NOBLOCK,
-            )
-            self.stats.track_packet(
-                "__OUTGOING__",
-                topic_b.decode("utf-8", errors="replace"),
-                len(dest) + len(topic_b) + len(payload_b),
-            )
-            return True
-        except zmq.ZMQError as e:
-            self.stats.track_event("__ERROR__", "send_failed")
-            self.logger.warning("IpcDealerClient [%s] send error: %s", self.identity, e)
-            self._reply_slot = {"status": "error", "reason": str(e)}
-            self._reply_event.set()
-            return False
+            frames = self.socket.recv_multipart(flags=zmq.NOBLOCK)
+        except zmq.Again:
+            return awaiting_reply
+        except zmq.ZMQError:
+            if not self._running:
+                return awaiting_reply
+            self.stats.track_event("__ERROR__", "recv_failed")
+            self._create_and_connect()
+            if awaiting_reply:
+                self._reply_slot = {"status": "error", "reason": "socket reconnected"}
+                self._reply_event.set()
+                awaiting_reply = False
+            return awaiting_reply
 
-    def _handle_dealer_frames(self, frames: list, awaiting_reply: bool) -> bool:
-        """Process frames received from the DEALER socket. Returns updated awaiting_reply."""
+        # 2-frame reply to a pending send()
         if len(frames) == 2 and awaiting_reply:
-            awaiting_reply = False
             try:
                 reply = orjson.loads(frames[-1])
             except (ValueError, TypeError):
@@ -342,29 +327,17 @@ class IpcDealerClient:
             self.stats.track_event("__REPLY__", reply.get("status", "data"))
             self._reply_slot = reply
             self._reply_event.set()
-            return awaiting_reply
+            return False
 
+        # 4-frame inbound command
         if len(frames) < 4:
             self.stats.track_event("__DROP__", "short_frame")
             return awaiting_reply
 
-        sender_id, reply_flag, topic_bytes, payload_bytes = (
-            frames[0], frames[1], frames[2], frames[3]
-        )
-        self._dispatch_inbound(sender_id, reply_flag, topic_bytes, payload_bytes)
-        return awaiting_reply
-
-    def _dispatch_inbound(
-        self,
-        sender_id: bytes,
-        reply_flag: bytes,
-        topic_bytes: bytes,
-        payload_bytes: bytes,
-    ) -> None:
+        sender_id, reply_flag, topic_bytes, payload_bytes = frames[0], frames[1], frames[2], frames[3]
         wants_reply = (reply_flag == _REPLY_REQUIRED)
         topic = topic_bytes.decode("utf-8", errors="replace")
-        total_size = len(sender_id) + len(topic_bytes) + len(payload_bytes)
-        self.stats.track_packet("__INCOMING__", topic, total_size)
+        self.stats.track_packet("__INCOMING__", topic, sum(len(f) for f in frames))
 
         try:
             data = orjson.loads(payload_bytes)
@@ -372,26 +345,27 @@ class IpcDealerClient:
             self.stats.track_event("__DROP__", "invalid_json")
             if wants_reply:
                 self._send_reply(sender_id, {"status": "error", "reason": "invalid payload"})
-            return
+            return awaiting_reply
 
         handler = self._routes.get(topic)
         if handler is None:
             self.stats.track_event("__DROP__", f"unrouted_{topic}")
             if wants_reply:
                 self._send_reply(sender_id, {"status": "error", "reason": f"unknown topic: {topic}"})
-            return
+            return awaiting_reply
 
         try:
             result = handler(data)
             self.stats.track_event("__HANDLER_OK__", topic)
             if wants_reply:
-                reply = result if isinstance(result, dict) else {"status": "ok"}
-                self._send_reply(sender_id, reply)
+                self._send_reply(sender_id, result if isinstance(result, dict) else {"status": "ok"})
         except Exception as e:  # pylint: disable=broad-exception-caught
             self.stats.track_event("__HANDLER_ERR__", topic)
             self.logger.exception("Handler error for topic %r: %s", topic, e)
             if wants_reply:
                 self._send_reply(sender_id, {"status": "error", "reason": str(e)})
+
+        return awaiting_reply
 
     # ---------------------------------------------------------
     # Main receive loop
@@ -401,7 +375,9 @@ class IpcDealerClient:
         self._running = True
         self._loop_thread_id = threading.get_ident()
 
-        poller = self._rebuild_poller()
+        poller = zmq.Poller()
+        poller.register(self.socket, zmq.POLLIN)
+        poller.register(self._pipe_read, zmq.POLLIN)
         awaiting_reply = False
 
         while self._running:
@@ -412,75 +388,41 @@ class IpcDealerClient:
                     break
                 self.stats.track_event("__ERROR__", "poll_failed")
                 self._create_and_connect()
-                poller = self._rebuild_poller()
+                poller = zmq.Poller()
+                poller.register(self.socket, zmq.POLLIN)
+                poller.register(self._pipe_read, zmq.POLLIN)
                 continue
 
             awaiting_reply = self._handle_pipe_event(events, awaiting_reply)
-            if not self._running:
-                break
+            awaiting_reply = self._handle_dealer_event(events, awaiting_reply)
 
-            if self.socket not in events:
-                continue
-
-            try:
-                frames = self.socket.recv_multipart(flags=zmq.NOBLOCK)
-            except zmq.Again:
-                continue
-            except zmq.ZMQError:
-                if not self._running:
-                    break
-                self.stats.track_event("__ERROR__", "recv_failed")
-                self._create_and_connect()
-                poller = self._rebuild_poller()
-                if awaiting_reply:
-                    awaiting_reply = False
-                    self._reply_slot = {"status": "error", "reason": "socket reconnected"}
-                    self._reply_event.set()
-                continue
-
-            awaiting_reply = self._handle_dealer_frames(frames, awaiting_reply)
-
-        # ---- loop exit cleanup ----
         self._loop_thread_id = None
-        try:
-            poller.unregister(self.socket)
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
-        try:
-            poller.unregister(self._pipe_read)
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
-
-        try:
-            self.socket.close(linger=0)
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
-        try:
-            self._pipe_read.close(linger=0)
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
-        try:
-            self._pipe_write.close(linger=0)
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
-
-        try:
-            self._ctx.term()
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
-
+        self._close_sockets(poller)
         self.logger.debug("IpcDealerClient [%s] stopped", self.identity)
 
     def _send_reply(self, sender_id: bytes, reply: dict) -> None:
         try:
-            self.socket.send_multipart(
-                [sender_id, orjson.dumps(reply)],
-                flags=zmq.NOBLOCK,
-            )
+            self.socket.send_multipart([sender_id, orjson.dumps(reply)], flags=zmq.NOBLOCK)
             self.stats.track_event("__REPLY__", reply.get("status", "data"))
         except zmq.ZMQError as e:
             self.stats.track_event("__ERROR__", "reply_send_failed")
             self.logger.warning("IpcDealerClient [%s] failed to send reply: %s", self.identity, e)
+
+    def _close_sockets(self, poller: zmq.Poller) -> None:
+        for sock in (self.socket, self._pipe_read):
+            try:
+                poller.unregister(sock)
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+        for sock in (self.socket, self._pipe_read, self._pipe_write):
+            try:
+                sock.close(linger=0)
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+        try:
+            self._ctx.term()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
 
     # ---------------------------------------------------------
     # Shutdown / stats
@@ -488,10 +430,9 @@ class IpcDealerClient:
     def close(self) -> None:
         """Signal the receive loop to stop."""
         self._running = False
-        # Wake the loop immediately via the pipe so it doesn't wait for the 100ms poll.
         with self._pipe_lock:
             try:
-                self._pipe_write.send_multipart([_CMD_STOP], flags=zmq.NOBLOCK)
+                self._pipe_write.send_multipart([_PIPE_STOP], flags=zmq.NOBLOCK)
             except zmq.ZMQError:
                 pass
 

--- a/lib/ipc/router_dealer/dealer/client.py
+++ b/lib/ipc/router_dealer/dealer/client.py
@@ -220,11 +220,8 @@ class IpcDealerClient:
         Returns:
             Reply dict from the remote handler, or an error dict on timeout/failure.
         """
-        if self._loop_thread_id is not None and threading.get_ident() == self._loop_thread_id:
-            raise RuntimeError(
-                "IpcDealerClient.send() called from the loop thread; this will deadlock. "
-                "Use fire() or call send() from a different thread."
-            )
+        assert self._loop_thread_id is None or threading.get_ident() != self._loop_thread_id, \
+            "IpcDealerClient.send() called from the loop thread — deadlock. Use fire() or a different thread."
 
         payload = orjson.dumps(data)
 

--- a/tests/ipc/tests_router_dealer.py
+++ b/tests/ipc/tests_router_dealer.py
@@ -510,3 +510,304 @@ class TestIpcRouterDealer(TestIPC):
 
         stats = self.router.get_stats()
         self.assertGreater(stats["uptime_seconds"], 0)
+
+    # ------------------------------------------------------------------
+    # IpcDealerAsync inbound routing — async dealer as receiver
+    # ------------------------------------------------------------------
+
+    def test_async_dealer_receives_fire_from_async_sender(self):
+        """fire() from one async dealer reaches the registered handler on another."""
+        received = []
+
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="async-recv-fire")
+
+            @receiver.route("press")
+            def on_press(data):
+                received.append(data)
+
+            await receiver.start()
+
+            sender = IpcDealerAsync(port=self.port, identity="async-send-fire")
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            await sender.fire("async-recv-fire", "press", {"btn": "mfd"})
+            # Give the recv loop time to dispatch
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            await sender.close()
+            await receiver.close()
+
+        self._run_async(run())
+        self.assertIn({"btn": "mfd"}, received)
+
+    def test_async_dealer_receives_send_and_replies_with_dict(self):
+        """send() to an async dealer receiver gets the handler's dict reply."""
+        STATS = {"laps": 7, "tyre": "hard"}
+
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="async-recv-send")
+
+            @receiver.route("get-stats")
+            def on_get_stats(_data):
+                return STATS
+
+            await receiver.start()
+
+            sender = IpcDealerAsync(port=self.port, identity="async-send-send")
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            reply = await sender.send("async-recv-send", "get-stats", {})
+
+            await sender.close()
+            await receiver.close()
+            return reply
+
+        reply = self._run_async(run())
+        self.assertEqual(reply, STATS)
+
+    def test_async_dealer_send_replies_with_ok_when_handler_returns_none(self):
+        """Handler returning None (or non-dict) yields a default ok reply."""
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="async-recv-none")
+
+            @receiver.route("ack")
+            def on_ack(_data):
+                return None
+
+            await receiver.start()
+
+            sender = IpcDealerAsync(port=self.port, identity="async-send-none")
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            reply = await sender.send("async-recv-none", "ack", {})
+
+            await sender.close()
+            await receiver.close()
+            return reply
+
+        reply = self._run_async(run())
+        self.assertEqual(reply.get("status"), "ok")
+
+    def test_async_dealer_supports_async_handler(self):
+        """Coroutine handlers are awaited and their return value sent back."""
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="async-recv-coro")
+
+            @receiver.route("slow")
+            async def on_slow(data):
+                await asyncio.sleep(0.01)
+                return {"echo": data, "via": "coro"}
+
+            await receiver.start()
+
+            sender = IpcDealerAsync(port=self.port, identity="async-send-coro")
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            reply = await sender.send("async-recv-coro", "slow", {"x": 1})
+
+            await sender.close()
+            await receiver.close()
+            return reply
+
+        reply = self._run_async(run())
+        self.assertEqual(reply.get("via"), "coro")
+        self.assertEqual(reply.get("echo"), {"x": 1})
+
+    def test_async_dealer_unknown_topic_sends_error_reply(self):
+        """Sending to a registered identity but unknown topic returns an error dict."""
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="async-recv-unknown")
+            # No routes registered.
+            await receiver.start()
+
+            sender = IpcDealerAsync(port=self.port, identity="async-send-unknown")
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            reply = await sender.send("async-recv-unknown", "no-such-topic", {})
+
+            await sender.close()
+            await receiver.close()
+            return reply
+
+        reply = self._run_async(run())
+        self.assertEqual(reply.get("status"), "error")
+        self.assertIn("unknown topic", reply.get("reason", ""))
+
+    def test_async_dealer_handler_exception_sends_error_reply(self):
+        """A raising handler must return an error reply, not crash the loop."""
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="async-recv-exc")
+
+            @receiver.route("crash")
+            def boom(_data):
+                raise RuntimeError("kaboom")
+
+            await receiver.start()
+
+            sender = IpcDealerAsync(port=self.port, identity="async-send-exc")
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            reply = await sender.send("async-recv-exc", "crash", {})
+
+            # Recv loop should still be alive after an exception — try again.
+            @receiver.route("ok")
+            def on_ok(_data):
+                return {"status": "ok", "after": "crash"}
+
+            reply2 = await sender.send("async-recv-exc", "ok", {})
+
+            await sender.close()
+            await receiver.close()
+            return reply, reply2
+
+        reply, reply2 = self._run_async(run())
+        self.assertEqual(reply.get("status"), "error")
+        self.assertIn("kaboom", reply.get("reason", ""))
+        self.assertEqual(reply2.get("after"), "crash")
+
+    def test_async_dealer_invalid_json_payload_sends_error_reply(self):
+        """A malformed inbound payload yields an error reply, no crash."""
+        import zmq as _zmq
+
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="async-recv-badjson")
+
+            @receiver.route("anything")
+            def on_anything(_data):
+                return {"status": "ok"}
+
+            await receiver.start()
+
+            # Send raw garbage bytes as payload using a hand-rolled DEALER.
+            ctx = _zmq.asyncio.Context()
+            raw = ctx.socket(_zmq.DEALER)
+            raw.setsockopt(_zmq.LINGER, 0)
+            raw.setsockopt(_zmq.IDENTITY, b"async-send-badjson")
+            raw.connect(f"tcp://127.0.0.1:{self.port}")
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            await raw.send_multipart([
+                b"async-recv-badjson", b"\x01", b"anything", b"not-json{{{",
+            ])
+            try:
+                frames = await asyncio.wait_for(
+                    raw.recv_multipart(), timeout=ACK_TIMEOUT
+                )
+            finally:
+                raw.close(linger=0)
+                ctx.term()
+
+            await receiver.close()
+            return frames
+
+        frames = self._run_async(run())
+        import orjson as _orjson
+        reply = _orjson.loads(frames[-1])
+        self.assertEqual(reply.get("status"), "error")
+        self.assertIn("invalid", reply.get("reason", ""))
+
+    def test_async_dealer_send_and_receive_interleaved(self):
+        """Async dealer simultaneously serves inbound and issues outbound sends."""
+        sync_received = []
+        bridge_received = []
+
+        # Sync client that the bridge will send to.
+        self._make_dealer_client("sync-peer", {
+            "from-bridge": lambda d: sync_received.append(d),
+        })
+
+        async def run():
+            bridge = IpcDealerAsync(port=self.port, identity="bridge")
+
+            @bridge.route("from-other")
+            def on_from_other(data):
+                bridge_received.append(data)
+                return {"status": "ok", "ack": data}
+
+            await bridge.start()
+
+            other = IpcDealerAsync(port=self.port, identity="other")
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            # Other sends to bridge while bridge sends to sync — interleaved.
+            other_task = asyncio.create_task(
+                other.send("bridge", "from-other", {"n": 1})
+            )
+            bridge_reply = await bridge.send("sync-peer", "from-bridge", {"n": 2})
+            other_reply = await other_task
+
+            await other.close()
+            await bridge.close()
+            return bridge_reply, other_reply
+
+        bridge_reply, other_reply = self._run_async(run())
+        time.sleep(PROPAGATION_DELAY)
+
+        self.assertEqual(bridge_reply.get("status"), "ok")
+        self.assertEqual(other_reply.get("ack"), {"n": 1})
+        self.assertIn({"n": 1}, bridge_received)
+        self.assertIn({"n": 2}, sync_received)
+
+    def test_async_dealer_close_cancels_recv_loop(self):
+        """close() cleanly cancels the background recv task."""
+        async def run():
+            dealer = IpcDealerAsync(port=self.port, identity="async-close-loop")
+
+            @dealer.route("noop")
+            def noop(_data):
+                return None
+
+            await dealer.start()
+            self.assertIsNotNone(dealer._recv_task)
+            self.assertFalse(dealer._recv_task.done())
+
+            await dealer.close()
+            return dealer
+
+        dealer = self._run_async(run())
+        self.assertIsNone(dealer._recv_task)
+
+    def test_async_dealer_close_while_send_in_flight_unblocks(self):
+        """close() while awaiting a reply must not hang — send() returns error."""
+        async def run():
+            dealer = IpcDealerAsync(port=self.port, identity="async-close-inflight")
+            dealer.ACK_TIMEOUT = 5.0  # we want close() to be the unblocker, not timeout
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            send_task = asyncio.create_task(
+                dealer.send("ghost-no-receiver", "press", {"x": 1})
+            )
+            # Let the send actually post and start awaiting the reply.
+            await asyncio.sleep(0.05)
+
+            # Close while the send is awaiting.
+            close_task = asyncio.create_task(dealer.close())
+
+            reply = await asyncio.wait_for(send_task, timeout=2.0)
+            await close_task
+            return reply
+
+        reply = self._run_async(run())
+        self.assertEqual(reply.get("status"), "error")
+
+    def test_async_dealer_send_only_does_not_require_explicit_start(self):
+        """Existing send-only callers (no start()) keep working — recv loop auto-spawns."""
+        received = []
+        self._make_dealer_client("hud-implicit", {
+            "ping": lambda d: received.append(d),
+        })
+
+        async def run():
+            dealer = IpcDealerAsync(port=self.port, identity="sender-implicit")
+            # Note: deliberately NOT calling dealer.start()
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            reply = await dealer.send("hud-implicit", "ping", {"v": 99})
+            await dealer.close()
+            return reply
+
+        reply = self._run_async(run())
+        time.sleep(PROPAGATION_DELAY)
+        self.assertEqual(reply.get("status"), "ok")
+        self.assertIn({"v": 99}, received)

--- a/tests/ipc/tests_router_dealer.py
+++ b/tests/ipc/tests_router_dealer.py
@@ -1183,7 +1183,7 @@ class TestIpcRouterDealer(TestIPC):
         tmp_router = IpcRouter(port=0)
         free_port = tmp_router.port
         tmp_router.close()
-        time.sleep(0.05)
+        time.sleep(0.2)  # give OS time to release the port reliably
 
         client_a = IpcDealerClient(port=free_port, identity="pre-a")
         client_a.route("hi")(lambda d: {"got": d})
@@ -1202,7 +1202,10 @@ class TestIpcRouterDealer(TestIPC):
         # Start the router after both clients are already "connected" (ZMQ will buffer).
         router2 = IpcRouter(port=free_port)
         router2.run_in_thread()
-        time.sleep(PROPAGATION_DELAY)
+        # Wait for both dealer loops to start and reconnect to router2. ZMQ reconnect
+        # typically completes within 100-300ms; the ROUTER learns each identity on first
+        # frame, so we also need client_b's loop to be polling before we send to it.
+        time.sleep(0.5)
 
         reply = client_a.send("pre-b", "hi", {"n": 1})
         router2.close()

--- a/tests/ipc/tests_router_dealer.py
+++ b/tests/ipc/tests_router_dealer.py
@@ -811,3 +811,539 @@ class TestIpcRouterDealer(TestIPC):
         time.sleep(PROPAGATION_DELAY)
         self.assertEqual(reply.get("status"), "ok")
         self.assertIn({"v": 99}, received)
+
+    # ------------------------------------------------------------------
+    # IpcDealerClient outbound fire() / send()
+    # ------------------------------------------------------------------
+
+    def test_dealer_client_fire_delivers_to_async_receiver(self):
+        """IpcDealerClient.fire() reaches an IpcDealerAsync that has called start()."""
+        received = []
+
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="async-fire-recv")
+
+            @receiver.route("press")
+            def on_press(data):
+                received.append(data)
+
+            await receiver.start()
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            client = self._make_dealer_client("sync-fire-send", {})
+            time.sleep(PROPAGATION_DELAY)
+
+            client.fire("async-fire-recv", "press", {"btn": "x"})
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            await receiver.close()
+
+        self._run_async(run())
+        self.assertIn({"btn": "x"}, received)
+
+    def test_dealer_client_fire_delivers_to_sync_receiver(self):
+        """IpcDealerClient.fire() reaches another IpcDealerClient receiver."""
+        received = []
+
+        receiver = self._make_dealer_client("sync-recv-fire", {
+            "ping": lambda d: received.append(d),
+        })
+        sender = self._make_dealer_client("sync-send-fire", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        sender.fire("sync-recv-fire", "ping", {"v": 42})
+        time.sleep(PROPAGATION_DELAY * 3)
+
+        self.assertIn({"v": 42}, received)
+
+    def test_dealer_client_send_gets_reply_from_async_dealer(self):
+        """IpcDealerClient.send() → IpcDealerAsync handler returns dict → sync caller gets it."""
+        STATS = {"laps": 5, "tyre": "medium"}
+
+        # Run the async receiver in a background event loop so sync send() can be called
+        # from the test thread without deadlocking the event loop.
+        loop = asyncio.new_event_loop()
+        stop_event = threading.Event()
+        receiver_holder = []
+
+        async def async_main():
+            receiver = IpcDealerAsync(port=self.port, identity="async-send-reply")
+
+            @receiver.route("get-stats")
+            def on_get_stats(_data):
+                return STATS
+
+            await receiver.start()
+            receiver_holder.append(receiver)
+            # Wait until the test signals us to stop.
+            while not stop_event.is_set():
+                await asyncio.sleep(0.05)
+            await receiver.close()
+
+        loop_thread = threading.Thread(target=loop.run_until_complete, args=(async_main(),), daemon=True)
+        loop_thread.start()
+        time.sleep(PROPAGATION_DELAY)
+
+        client = self._make_dealer_client("sync-send-rpc", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        reply = client.send("async-send-reply", "get-stats", {})
+
+        stop_event.set()
+        loop_thread.join(timeout=2.0)
+        loop.close()
+
+        self.assertEqual(reply, STATS)
+
+    def test_dealer_client_send_gets_reply_from_sync_receiver(self):
+        """IpcDealerClient.send() → IpcDealerClient handler returns dict → caller gets it."""
+        receiver = self._make_dealer_client("sync-recv-rpc", {
+            "echo": lambda d: {"echoed": d},
+        })
+        sender = self._make_dealer_client("sync-send-rpc2", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        reply = sender.send("sync-recv-rpc", "echo", {"x": 7})
+        self.assertEqual(reply.get("echoed"), {"x": 7})
+
+    def test_dealer_client_send_timeout_on_no_receiver(self):
+        """IpcDealerClient.send() to a non-existent identity returns error dict, no hang."""
+        sender = self._make_dealer_client("sync-timeout-sender", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        reply = sender.send("ghost-identity", "press", {}, timeout=0.2)
+        self.assertEqual(reply.get("status"), "error")
+        self.assertIn("timeout", reply.get("reason", ""))
+
+    def test_dealer_client_send_unknown_topic_returns_error(self):
+        """Sending an unregistered topic to a sync receiver returns an error reply."""
+        receiver = self._make_dealer_client("sync-recv-unknown2", {})
+        sender = self._make_dealer_client("sync-send-unknown2", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        reply = sender.send("sync-recv-unknown2", "no-such-topic", {})
+        self.assertEqual(reply.get("status"), "error")
+        self.assertIn("unknown topic", reply.get("reason", ""))
+
+    def test_dealer_client_send_does_not_block_inbound_receive(self):
+        """
+        While one thread calls send(), the loop must still process inbound commands.
+        Verify by having an inbound fire arrive during an outbound send.
+        """
+        inbound_received = []
+
+        # This receiver also handles inbound messages from someone else.
+        receiver = self._make_dealer_client("sync-bidir-loop", {
+            "inbound": lambda d: inbound_received.append(d),
+            "echo": lambda d: {"echoed": d},
+        })
+        sender = self._make_dealer_client("sync-bidir-sender", {})
+        # A third party that fires at the receiver while the send is in-flight.
+        third = self._make_dealer_client("sync-bidir-third", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        # Fire the inbound message first (it'll sit in the DEALER socket queue).
+        third.fire("sync-bidir-loop", "inbound", {"from": "third"})
+        time.sleep(0.02)
+
+        # Now do a send — the loop must deliver the inbound fire AND the reply.
+        reply = sender.send("sync-bidir-loop", "echo", {"x": 1})
+        time.sleep(PROPAGATION_DELAY)
+
+        self.assertEqual(reply.get("echoed"), {"x": 1})
+        self.assertIn({"from": "third"}, inbound_received)
+
+    def test_dealer_client_concurrent_fire_calls_all_delivered(self):
+        """N concurrent fire() calls from multiple threads all arrive."""
+        N = 20
+        received = []
+        receiver = self._make_dealer_client("sync-concurrent-recv", {
+            "press": lambda d: received.append(d),
+        })
+        sender = self._make_dealer_client("sync-concurrent-send", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        threads = []
+        for i in range(N):
+            t = threading.Thread(target=sender.fire, args=("sync-concurrent-recv", "press", {"seq": i}))
+            threads.append(t)
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        time.sleep(PROPAGATION_DELAY * 3)
+        self.assertEqual(len(received), N)
+        for i in range(N):
+            self.assertIn({"seq": i}, received)
+
+    # ------------------------------------------------------------------
+    # Bidirectional exchange: sync ↔ async, both sides send and receive
+    # ------------------------------------------------------------------
+
+    def test_bidir_sync_sends_async_replies(self):
+        """Sync client calls send() → async dealer handles it → reply received."""
+        loop = asyncio.new_event_loop()
+        stop_event = threading.Event()
+
+        async def async_main():
+            async_dealer = IpcDealerAsync(port=self.port, identity="bidir-async-a")
+
+            @async_dealer.route("query")
+            def on_query(data):
+                return {"answer": data.get("q", "") + "-response"}
+
+            await async_dealer.start()
+            while not stop_event.is_set():
+                await asyncio.sleep(0.05)
+            await async_dealer.close()
+
+        loop_thread = threading.Thread(target=loop.run_until_complete, args=(async_main(),), daemon=True)
+        loop_thread.start()
+        time.sleep(PROPAGATION_DELAY)
+
+        sync_client = self._make_dealer_client("bidir-sync-a", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        reply = sync_client.send("bidir-async-a", "query", {"q": "hello"})
+
+        stop_event.set()
+        loop_thread.join(timeout=2.0)
+        loop.close()
+
+        self.assertEqual(reply.get("answer"), "hello-response")
+
+    def test_bidir_async_sends_sync_replies(self):
+        """Async dealer calls send() → sync client handles it → reply received."""
+        sync_client = self._make_dealer_client("bidir-sync-b", {
+            "ping": lambda d: {"pong": d.get("n", 0) * 2},
+        })
+
+        async def run():
+            async_dealer = IpcDealerAsync(port=self.port, identity="bidir-async-b")
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            reply = await async_dealer.send("bidir-sync-b", "ping", {"n": 21})
+            await async_dealer.close()
+            return reply
+
+        reply = self._run_async(run())
+        self.assertEqual(reply.get("pong"), 42)
+
+    def test_bidir_fire_both_directions(self):
+        """Both sides fire a message to each other; both arrive."""
+        sync_received = []
+        async_received = []
+
+        sync_client = self._make_dealer_client("bidir-fire-sync", {
+            "from-async": lambda d: sync_received.append(d),
+        })
+
+        async def run():
+            async_dealer = IpcDealerAsync(port=self.port, identity="bidir-fire-async")
+
+            @async_dealer.route("from-sync")
+            def on_from_sync(data):
+                async_received.append(data)
+
+            await async_dealer.start()
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            sync_client.fire("bidir-fire-async", "from-sync", {"dir": "s→a"})
+            await async_dealer.fire("bidir-fire-sync", "from-async", {"dir": "a→s"})
+            await asyncio.sleep(PROPAGATION_DELAY * 2)
+
+            await async_dealer.close()
+
+        self._run_async(run())
+        time.sleep(PROPAGATION_DELAY)
+
+        self.assertIn({"dir": "s→a"}, async_received)
+        self.assertIn({"dir": "a→s"}, sync_received)
+
+    def test_bidir_simultaneous_exchange(self):
+        """Both sides send to each other in parallel; all replies correct."""
+        async def run():
+            async_dealer = IpcDealerAsync(port=self.port, identity="bidir-sim-async")
+
+            @async_dealer.route("async-echo")
+            def on_async_echo(data):
+                return {"async_got": data}
+
+            await async_dealer.start()
+
+            sync_client = self._make_dealer_client("bidir-sim-sync", {
+                "sync-echo": lambda d: {"sync_got": d},
+            })
+            await asyncio.sleep(PROPAGATION_DELAY)
+            time.sleep(PROPAGATION_DELAY)
+
+            # Run both sends concurrently using a thread for the blocking sync send.
+            sync_reply_holder = []
+
+            def do_sync_send():
+                sync_reply_holder.append(
+                    sync_client.send("bidir-sim-async", "async-echo", {"from": "sync"})
+                )
+
+            t = threading.Thread(target=do_sync_send)
+            t.start()
+
+            async_reply = await async_dealer.send("bidir-sim-sync", "sync-echo", {"from": "async"})
+            t.join(timeout=5.0)
+
+            await async_dealer.close()
+            return async_reply, sync_reply_holder[0] if sync_reply_holder else None
+
+        async_reply, sync_reply = self._run_async(run())
+        self.assertEqual(async_reply.get("sync_got"), {"from": "async"})
+        self.assertIsNotNone(sync_reply)
+        self.assertEqual(sync_reply.get("async_got"), {"from": "sync"})
+
+    def test_bidir_rapid_back_and_forth(self):
+        """N sequential send/reply cycles between sync and async complete correctly."""
+        N = 10
+
+        sync_client = self._make_dealer_client("bidir-rapid-sync", {
+            "increment": lambda d: {"n": d["n"] + 1},
+        })
+
+        async def run():
+            async_dealer = IpcDealerAsync(port=self.port, identity="bidir-rapid-async")
+
+            @async_dealer.route("double")
+            def on_double(data):
+                return {"n": data["n"] * 2}
+
+            await async_dealer.start()
+            await asyncio.sleep(PROPAGATION_DELAY)
+            time.sleep(PROPAGATION_DELAY)
+
+            results = []
+            for i in range(N):
+                # Async → sync
+                r1 = await async_dealer.send("bidir-rapid-sync", "increment", {"n": i})
+                results.append(("async→sync", i, r1))
+                # Sync → async (from a thread to avoid blocking the event loop)
+                loop = asyncio.get_event_loop()
+                r2 = await loop.run_in_executor(
+                    None, sync_client.send, "bidir-rapid-async", "double", {"n": i}
+                )
+                results.append(("sync→async", i, r2))
+
+            await async_dealer.close()
+            return results
+
+        results = self._run_async(run())
+        self.assertEqual(len(results), N * 2)
+        for direction, i, reply in results:
+            if direction == "async→sync":
+                self.assertEqual(reply.get("n"), i + 1, f"increment({i}) failed: {reply}")
+            else:
+                self.assertEqual(reply.get("n"), i * 2, f"double({i}) failed: {reply}")
+
+    # ------------------------------------------------------------------
+    # Startup order tests
+    # ------------------------------------------------------------------
+
+    def test_dealer_connects_before_router(self):
+        """Sync client started before router; first send() succeeds once router is up."""
+        # Grab a free port by letting a temporary router bind and immediately close.
+        tmp_router = IpcRouter(port=0)
+        free_port = tmp_router.port
+        tmp_router.close()
+        time.sleep(0.2)  # give OS time to release the port
+
+        # Start client pointing at that port before any router is bound there.
+        client = IpcDealerClient(port=free_port, identity="early-client")
+        client.route("pong")(lambda _: {"pong": True})
+        t = threading.Thread(target=client.start, daemon=True)
+        t.start()
+        self._clients.append(client)
+        self._threads.append(t)
+
+        # Now bind the router — ZMQ will reconnect the client automatically.
+        router2 = IpcRouter(port=free_port)
+        router2.run_in_thread()
+        time.sleep(0.5)  # ZMQ reconnect typically completes within 100-300ms
+
+        async def run():
+            sender = IpcDealerAsync(port=free_port, identity="late-sender")
+            await asyncio.sleep(PROPAGATION_DELAY)
+            reply = await sender.send("early-client", "pong", {})
+            await sender.close()
+            return reply
+
+        reply = self._run_async(run())
+        router2.close()
+        self.assertEqual(reply.get("pong"), True)
+
+    def test_router_starts_after_both_dealers(self):
+        """Both dealers started before the router; messages flow once router is up."""
+        tmp_router = IpcRouter(port=0)
+        free_port = tmp_router.port
+        tmp_router.close()
+        time.sleep(0.05)
+
+        client_a = IpcDealerClient(port=free_port, identity="pre-a")
+        client_a.route("hi")(lambda d: {"got": d})
+        ta = threading.Thread(target=client_a.start, daemon=True)
+        ta.start()
+        self._clients.append(client_a)
+        self._threads.append(ta)
+
+        client_b = IpcDealerClient(port=free_port, identity="pre-b")
+        client_b.route("hi")(lambda d: {"got": d})
+        tb = threading.Thread(target=client_b.start, daemon=True)
+        tb.start()
+        self._clients.append(client_b)
+        self._threads.append(tb)
+
+        # Start the router after both clients are already "connected" (ZMQ will buffer).
+        router2 = IpcRouter(port=free_port)
+        router2.run_in_thread()
+        time.sleep(PROPAGATION_DELAY)
+
+        reply = client_a.send("pre-b", "hi", {"n": 1})
+        router2.close()
+        self.assertEqual(reply.get("got"), {"n": 1})
+
+    def test_dealer_reconnects_after_router_restart(self):
+        """Router closed and restarted on same port; dealer reconnects automatically."""
+        client = self._make_dealer_client("reconnect-client", {
+            "echo": lambda d: {"echoed": d},
+        })
+        time.sleep(PROPAGATION_DELAY)
+
+        # First send works.
+        async def run1():
+            sender = IpcDealerAsync(port=self.port, identity="reconnect-sender1")
+            await asyncio.sleep(PROPAGATION_DELAY)
+            r = await sender.send("reconnect-client", "echo", {"phase": 1})
+            await sender.close()
+            return r
+
+        r1 = self._run_async(run1())
+        self.assertEqual(r1.get("echoed"), {"phase": 1})
+
+        # Restart router on the same port.
+        old_port = self.port
+        self.router.close()
+        time.sleep(0.1)
+        self.router = IpcRouter(port=old_port)
+        self.router.run_in_thread()
+        time.sleep(PROPAGATION_DELAY)
+
+        async def run2():
+            sender = IpcDealerAsync(port=old_port, identity="reconnect-sender2")
+            await asyncio.sleep(PROPAGATION_DELAY)
+            r = await sender.send("reconnect-client", "echo", {"phase": 2})
+            await sender.close()
+            return r
+
+        r2 = self._run_async(run2())
+        self.assertEqual(r2.get("echoed"), {"phase": 2})
+
+    # ------------------------------------------------------------------
+    # Crash / recovery tests
+    # ------------------------------------------------------------------
+
+    def test_sync_dealer_crash_send_returns_error(self):
+        """Async dealer sends to a crashed sync client → send() times out, no exception."""
+        client = IpcDealerClient(port=self.port, identity="crash-sync-client")
+        client.route("noop")(lambda d: None)
+        t = threading.Thread(target=client.start, daemon=True)
+        t.start()
+        self._clients.append(client)
+        self._threads.append(t)
+        time.sleep(PROPAGATION_DELAY)
+
+        # Crash the client.
+        client._running = False
+        try:
+            client.socket.close(linger=0)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        time.sleep(0.05)
+
+        async def run():
+            sender = IpcDealerAsync(port=self.port, identity="crash-async-sender")
+            sender.ACK_TIMEOUT = 0.3
+            await asyncio.sleep(PROPAGATION_DELAY)
+            reply = await sender.send("crash-sync-client", "noop", {})
+            await sender.close()
+            return reply
+
+        reply = self._run_async(run())
+        self.assertEqual(reply.get("status"), "error")
+
+    def test_async_dealer_crash_send_returns_error(self):
+        """Sync client sends to a crashed async dealer → send() times out, no exception."""
+        async def setup():
+            dealer = IpcDealerAsync(port=self.port, identity="crash-async-dealer")
+
+            @dealer.route("noop")
+            def noop(_d):
+                return None
+
+            await dealer.start()
+            await asyncio.sleep(PROPAGATION_DELAY)
+            # Crash it.
+            dealer._running = False
+            if dealer._recv_task:
+                dealer._recv_task.cancel()
+            dealer.socket.close(linger=0)
+
+        self._run_async(setup())
+        time.sleep(0.05)
+
+        client = self._make_dealer_client("crash-sync-sender", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        reply = client.send("crash-async-dealer", "noop", {}, timeout=0.3)
+        self.assertEqual(reply.get("status"), "error")
+
+    def test_sync_dealer_crash_and_reconnect(self):
+        """Sync client crashes and reconnects with same identity; next send() succeeds."""
+        # Phase 1: healthy.
+        client1 = IpcDealerClient(port=self.port, identity="resilient-sync")
+        client1.route("echo")(lambda d: {"echoed": d})
+        t1 = threading.Thread(target=client1.start, daemon=True)
+        t1.start()
+        self._clients.append(client1)
+        self._threads.append(t1)
+        time.sleep(PROPAGATION_DELAY)
+
+        async def run_send(identity, data, timeout=ACK_TIMEOUT):
+            sender = IpcDealerAsync(port=self.port, identity=identity)
+            sender.ACK_TIMEOUT = timeout
+            await asyncio.sleep(PROPAGATION_DELAY)
+            r = await sender.send("resilient-sync", "echo", data)
+            await sender.close()
+            return r
+
+        r1 = self._run_async(run_send("resilient-sndr-1", {"phase": 1}))
+        self.assertEqual(r1.get("echoed"), {"phase": 1})
+
+        # Phase 2: crash.
+        client1._running = False
+        try:
+            client1.socket.close(linger=0)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+        time.sleep(0.05)
+
+        r2 = self._run_async(run_send("resilient-sndr-2", {"phase": 2}, timeout=0.3))
+        self.assertEqual(r2.get("status"), "error")
+
+        # Phase 3: new client reconnects with same identity.
+        client2 = IpcDealerClient(port=self.port, identity="resilient-sync")
+        client2.route("echo")(lambda d: {"echoed": d})
+        t2 = threading.Thread(target=client2.start, daemon=True)
+        t2.start()
+        self._clients.append(client2)
+        self._threads.append(t2)
+        time.sleep(PROPAGATION_DELAY)
+
+        r3 = self._run_async(run_send("resilient-sndr-3", {"phase": 3}))
+        self.assertEqual(r3.get("echoed"), {"phase": 3})


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Bidirectional dealer support

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [ ] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
<paste result here>
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [ ] My code follows project style conventions
* [ ] All new and existing tests pass
* [ ] I have added relevant documentation/comments
* [ ] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Add bidirectional routing support between synchronous and asynchronous ZeroMQ DEALER clients and extend test coverage for mixed-mode communication, startup ordering, and failure scenarios.

New Features:
- Enable IpcDealerClient to send outbound fire-and-forget and request-response commands via a thread-safe inproc pipe while still receiving routed commands.
- Add inbound routing to IpcDealerAsync so it can handle incoming commands and reply while also issuing outbound sends.

Enhancements:
- Improve shutdown, reconnection handling, and error propagation for both sync and async DEALER clients, including cancelling in-flight requests on close and handling malformed payloads.
- Document the router/DEALER request–reply and inbound command flows using a Mermaid sequence diagram for clearer protocol understanding.

Tests:
- Add extensive async and sync test coverage for dealer-to-dealer routing, bidirectional sync↔async interactions, concurrency, startup ordering, reconnection, and crash/recovery behavior.