### PR TITLE
Auto-hide HUD overlays when game is in a menu

### DIFF
--- a/apps/backend/state_mgmt_layer/intf/readers/periodic_update_data.py
+++ b/apps/backend/state_mgmt_layer/intf/readers/periodic_update_data.py
@@ -44,6 +44,7 @@ class PeriodicUpdateData(BaseAPI):
 
         self.m_session_info = session_state.m_session_info
         self.m_wdt_status = session_state.m_connected_to_sim
+        self.m_in_menu = session_state.m_in_menu
         # TODO: evaluate if this is needed
         self.m_track_length = self.m_session_info.m_packet_session.m_trackLength if self.m_session_info.m_packet_session else None
         self.m_driver_list_rsp = DriversListRsp(
@@ -105,6 +106,7 @@ class PeriodicUpdateData(BaseAPI):
             "player-pit-window" : self._getValueOrDefaultValue(self.m_driver_list_rsp.m_next_pit_stop_window, None),
             "spectator-car-index" : self._getValueOrDefaultValue(self.m_session_info.m_spectator_car_index, None),
             "wdt-status" : self.m_wdt_status,
+            "in-menu" : self.m_in_menu,
         }
 
         if str(self.m_session_info.m_session_type) == "Time Trial":

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -326,6 +326,7 @@ class SessionState:
         'm_connected_to_sim',
         'm_race_ctrl',
         'm_flashback_occurred',
+        'm_in_menu',
     )
 
     def __init__(self,
@@ -368,6 +369,7 @@ class SessionState:
 
         self.m_custom_markers_history = CustomMarkersHistory()
         self.m_connected_to_sim: bool = False
+        self.m_in_menu: bool = True
 
         self.m_race_ctrl: SessionRaceControlManager = SessionRaceControlManager()
         self.m_flashback_occurred: bool = False
@@ -426,6 +428,16 @@ class SessionState:
         Set the race as completed.
         """
         self.m_race_completed = True
+
+    def setInMenu(self, in_menu: bool) -> None:
+        """Set whether the player is currently in a menu (no periodic packets flowing).
+
+        Args:
+            in_menu (bool): True if in menu, False if in an active session
+        """
+        if in_menu != self.m_in_menu:
+            self.m_logger.info("In-menu status: [%s]->[%s]", self.m_in_menu, in_menu)
+            self.m_in_menu = in_menu
 
     def setConnectedToSim(self, connected: bool) -> None:
         """Set whether the client is connected to the simulator. Based on WDT

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -52,6 +52,8 @@ from lib.wdt import WatchDogTimerAsync
 
 # -------------------------------------- UTIL CLASSES ------------------------------------------------------------------
 
+_MENU_SILENCE_THRESHOLD_SEC = 3.0
+
 @dataclass
 class UdpActionCodes:
     custom_marker: Optional[int] = None
@@ -202,6 +204,7 @@ class F1TelemetryHandler:
         )
 
         self.m_manager_task: Optional[asyncio.Task] = None
+        self._menu_silence_task: Optional[asyncio.Task] = None
         self.registerCallbacks()
 
     def getTask(self, name: Optional[str] = "Game Telemetry Listener Task") -> asyncio.Task:
@@ -240,12 +243,26 @@ class F1TelemetryHandler:
         """
         await self.m_manager.run()
 
+    def _kick_periodic_packet_timer(self) -> None:
+        """Reset the menu-silence timer. Called on every periodic (non-EVENT) packet."""
+        if self._menu_silence_task:
+            self._menu_silence_task.cancel()
+        self.m_session_state_ref.setInMenu(False)
+        self._menu_silence_task = asyncio.create_task(self._menu_silence_cb())
+
+    async def _menu_silence_cb(self) -> None:
+        """Fires after silence threshold with no periodic packets — player is in a menu."""
+        await asyncio.sleep(_MENU_SILENCE_THRESHOLD_SEC)
+        self.m_session_state_ref.setInMenu(True)
+
     async def stop(self) -> None:
         """
         Stop the telemetry manager and watchdog timer.
         """
         if self.m_manager_task:
             self.m_manager_task.cancel()
+        if self._menu_silence_task:
+            self._menu_silence_task.cancel()
         self.m_wdt.stop()
         self.m_logger.debug("Telemetry handler stopped. manager and wdt stopped.")
 
@@ -284,6 +301,7 @@ class F1TelemetryHandler:
                 packet (PacketSessionData): The session data telemetry packet.
             """
 
+            self._kick_periodic_packet_timer()
             if packet.m_sessionDuration == 0:
                 self.m_logger.info("Session duration is 0. clearing data structures. UID %d",
                                    packet.m_header.m_sessionUID)
@@ -302,6 +320,7 @@ class F1TelemetryHandler:
                 packet (PacketLapData): Lap Data packet
             """
 
+            self._kick_periodic_packet_timer()
             if self.m_session_state_ref.m_session_info.m_total_laps is not None:
                 self.m_session_state_ref.processLapDataUpdate(packet)
                 self.m_session_state_ref.setRaceOngoing()
@@ -339,6 +358,7 @@ class F1TelemetryHandler:
                 packet (PacketParticipantsData): The pariticpants info packet
             """
 
+            self._kick_periodic_packet_timer()
             self.m_session_state_ref.processParticipantsUpdate(packet)
 
         @self.m_manager.on_packet(F1PacketType.CAR_TELEMETRY)
@@ -349,6 +369,7 @@ class F1TelemetryHandler:
                 packet (PacketCarTelemetryData): The car telemetry update packet
             """
 
+            self._kick_periodic_packet_timer()
             self.m_session_state_ref.processCarTelemetryUpdate(packet)
             self.m_session_state_ref.setRaceOngoing()
 
@@ -360,6 +381,7 @@ class F1TelemetryHandler:
                 packet (PacketCarStatusData): The car status update packet
             """
 
+            self._kick_periodic_packet_timer()
             self.m_session_state_ref.processCarStatusUpdate(packet)
             self.m_session_state_ref.setRaceOngoing()
 
@@ -373,6 +395,7 @@ class F1TelemetryHandler:
                 packet - PacketCarStatusData object
             """
 
+            self._kick_periodic_packet_timer()
             if self.m_final_classification_processed:
                 self.m_logger.debug('Session UID %d final classification already processed.', packet.m_header.m_sessionUID)
                 return
@@ -407,6 +430,7 @@ class F1TelemetryHandler:
                 packet (PacketCarDamageData): The car damage update packet
             """
 
+            self._kick_periodic_packet_timer()
             self.m_session_state_ref.processCarDamageUpdate(packet)
             self.m_session_state_ref.setRaceOngoing()
 
@@ -418,6 +442,7 @@ class F1TelemetryHandler:
                 packet (PacketSessionHistoryData): The session history update packet
             """
 
+            self._kick_periodic_packet_timer()
             self.m_session_state_ref.processSessionHistoryUpdate(packet)
             self.m_session_state_ref.setRaceOngoing()
 
@@ -429,6 +454,7 @@ class F1TelemetryHandler:
                 packet (PacketTyreSetsData): The tyre history update packet
             """
 
+            self._kick_periodic_packet_timer()
             self.m_session_state_ref.processTyreSetsUpdate(packet)
             self.m_session_state_ref.setRaceOngoing()
 
@@ -440,6 +466,7 @@ class F1TelemetryHandler:
                 packet (PacketMotionData): The motion update packet
             """
 
+            self._kick_periodic_packet_timer()
             self.m_session_state_ref.processMotionUpdate(packet)
 
         # Register the car setup handler if and only if user has allowed this
@@ -453,6 +480,7 @@ class F1TelemetryHandler:
                     packet (PacketCarSetupData): The car setup update packet
                 """
 
+                self._kick_periodic_packet_timer()
                 self.m_session_state_ref.processCarSetupsUpdate(packet)
         else:
             self.m_logger.debug("Not processing car setups")
@@ -465,6 +493,7 @@ class F1TelemetryHandler:
                 packet (PacketTimeTrialData): The time trial update packet
             """
 
+            self._kick_periodic_packet_timer()
             self.m_session_state_ref.processTimeTrialUpdate(packet)
 
         # We're not using this data, no need to waste CPU cycles processing it.

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -52,8 +52,6 @@ from lib.wdt import WatchDogTimerAsync
 
 # -------------------------------------- UTIL CLASSES ------------------------------------------------------------------
 
-_MENU_SILENCE_THRESHOLD_SEC = 3.0
-
 @dataclass
 class UdpActionCodes:
     custom_marker: Optional[int] = None
@@ -127,6 +125,7 @@ def setupTelemetryTask(
     )
     tasks.append(telemetry_server.getTask())
     tasks.append(asyncio.create_task(telemetry_server.getWatchdogTask(), name="Watchdog Timer Task"))
+    tasks.append(asyncio.create_task(telemetry_server.m_menu_wdt.run(), name="Menu Silence WDT Task"))
 
     return telemetry_server
 
@@ -186,6 +185,11 @@ class F1TelemetryHandler:
             status_callback=self.m_session_state_ref.setConnectedToSim,
             timeout=float(settings.Network.wdt_interval_sec),
         )
+        self.m_auto_hide_in_menu: bool = settings.HUD.auto_hide_in_menu
+        self.m_menu_wdt: WatchDogTimerAsync = WatchDogTimerAsync(
+            status_callback=lambda active: self.m_session_state_ref.setInMenu(not active),
+            timeout=float(settings.HUD.menu_silence_threshold_sec),
+        )
 
         self.m_udp_action_codes = UdpActionCodes(
             custom_marker=settings.Network.udp_custom_action_code,
@@ -204,7 +208,6 @@ class F1TelemetryHandler:
         )
 
         self.m_manager_task: Optional[asyncio.Task] = None
-        self._menu_silence_task: Optional[asyncio.Task] = None
         self.registerCallbacks()
 
     def getTask(self, name: Optional[str] = "Game Telemetry Listener Task") -> asyncio.Task:
@@ -244,16 +247,9 @@ class F1TelemetryHandler:
         await self.m_manager.run()
 
     def _kick_periodic_packet_timer(self) -> None:
-        """Reset the menu-silence timer. Called on every periodic (non-EVENT) packet."""
-        if self._menu_silence_task:
-            self._menu_silence_task.cancel()
-        self.m_session_state_ref.setInMenu(False)
-        self._menu_silence_task = asyncio.create_task(self._menu_silence_cb())
-
-    async def _menu_silence_cb(self) -> None:
-        """Fires after silence threshold with no periodic packets — player is in a menu."""
-        await asyncio.sleep(_MENU_SILENCE_THRESHOLD_SEC)
-        self.m_session_state_ref.setInMenu(True)
+        """Kick the menu-detection watchdog. Called on every periodic (non-EVENT) packet."""
+        if self.m_auto_hide_in_menu:
+            self.m_menu_wdt.kick()
 
     async def stop(self) -> None:
         """
@@ -261,9 +257,8 @@ class F1TelemetryHandler:
         """
         if self.m_manager_task:
             self.m_manager_task.cancel()
-        if self._menu_silence_task:
-            self._menu_silence_task.cancel()
         self.m_wdt.stop()
+        self.m_menu_wdt.stop()
         self.m_logger.debug("Telemetry handler stopped. manager and wdt stopped.")
 
     def getWatchdogTask(self) -> Coroutine:

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -185,7 +185,6 @@ class F1TelemetryHandler:
             status_callback=self.m_session_state_ref.setConnectedToSim,
             timeout=float(settings.Network.wdt_interval_sec),
         )
-        self.m_auto_hide_in_menu: bool = settings.HUD.auto_hide_in_menu
         self.m_menu_wdt: WatchDogTimerAsync = WatchDogTimerAsync(
             status_callback=lambda active: self.m_session_state_ref.setInMenu(not active),
             timeout=float(settings.HUD.menu_silence_threshold_sec),
@@ -248,8 +247,7 @@ class F1TelemetryHandler:
 
     def _kick_periodic_packet_timer(self) -> None:
         """Kick the menu-detection watchdog. Called on every periodic (non-EVENT) packet."""
-        if self.m_auto_hide_in_menu:
-            self.m_menu_wdt.kick()
+        self.m_menu_wdt.kick()
 
     async def stop(self) -> None:
         """

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -125,7 +125,7 @@ def setupTelemetryTask(
     )
     tasks.append(telemetry_server.getTask())
     tasks.append(asyncio.create_task(telemetry_server.getWatchdogTask(), name="Watchdog Timer Task"))
-    tasks.append(asyncio.create_task(telemetry_server.m_menu_wdt.run(), name="Menu Silence WDT Task"))
+    tasks.append(asyncio.create_task(telemetry_server.getMenuWatchdogTask(), name="Menu Silence WDT Task"))
 
     return telemetry_server
 
@@ -267,6 +267,14 @@ class F1TelemetryHandler:
         Coroutine: The watchdog task.
         """
         return self.m_wdt.run()
+
+    def getMenuWatchdogTask(self) -> Coroutine:
+        """Get the menu-silence watchdog task.
+
+        Returns:
+            Coroutine: The menu silence watchdog task.
+        """
+        return self.m_menu_wdt.run()
 
     def registerCallbacks(self) -> None:
         """

--- a/apps/hud/ui/infra/overlays_mgr.py
+++ b/apps/hud/ui/infra/overlays_mgr.py
@@ -63,7 +63,7 @@ class OverlaysMgr:
         self.running = False
         self.rate_limiter = RateLimiter(interval_ms=settings.Display.refresh_interval)
         self._local_wdt_ok: bool = False
-        self._core_wdt_ok: bool = False
+        self._auto_hide_in_menu: bool = settings.HUD.auto_hide_in_menu
         self.wdt = WatchDogTimerSync(
             status_callback=self._wdt_status_callback,
             timeout=settings.Display.wdt_timeout,
@@ -208,7 +208,7 @@ class OverlaysMgr:
             self.wdt.kick()
         self._prep_race_table_data(data)
         self.window_manager.broadcast_data('race_table_update', data)
-        self._handle_core_wdt_status(data)
+        self._handle_in_menu_status(data)
 
     def stream_overlays_update(self, data):
         """Handle the stream overlay update event"""
@@ -434,16 +434,18 @@ class OverlaysMgr:
         self._local_wdt_ok = active
         self._update_telemetry_active()
 
-    def _handle_core_wdt_status(self, data: Dict[str, Any]):
-        """Handle core watchdog status (core receiving sim data)."""
-        self._core_wdt_ok = data.get("wdt-status", False)
-        self._update_telemetry_active()
+    def _handle_in_menu_status(self, data: Dict[str, Any]):
+        """Hide overlays when backend reports in-menu state; restore when session resumes."""
+        if not self._auto_hide_in_menu:
+            return
+        if data.get("in-menu", False):
+            self._set_telemetry_active(False)
+        else:
+            self._update_telemetry_active()
 
     def _update_telemetry_active(self):
-        """Set telemetry active only when both local and core WDT are satisfied."""
-        local_ok = True if self.wdt is None else self._local_wdt_ok
-        combined = local_ok and self._core_wdt_ok
-        self._set_telemetry_active(combined)
+        """Set telemetry active state based on local WDT."""
+        self._set_telemetry_active(True if self.wdt is None else self._local_wdt_ok)
 
     def _prep_race_table_data(self, data: Dict[str, Any]):
         """Prepare race table data for overlays."""

--- a/apps/launcher/subsystems/backend_mgr.py
+++ b/apps/launcher/subsystems/backend_mgr.py
@@ -180,6 +180,9 @@ class BackendAppMgr(PngAppMgrBase):
             "TimeLossInPitsF1": [],
             "TimeLossInPitsF2": [],
             "Prediction": [],
+            "HUD": [
+                "menu_silence_threshold_sec",
+            ],
         }):
             self.debug_log(f"{self.DISPLAY_NAME} Restart required fields change: "
                            f"{json.dumps(restart_required_fields_diff, indent=2)}")

--- a/apps/launcher/subsystems/hud_mgr/hud_mgr.py
+++ b/apps/launcher/subsystems/hud_mgr/hud_mgr.py
@@ -456,6 +456,7 @@ class HudAppMgr(PngAppMgrBase):
         if settings_requiring_restart := self.curr_settings.diff(new_settings, {
             "HUD": [
                 "enabled",
+                "auto_hide_in_menu",
                 "show_lap_timer",
                 "lap_timer_minimal",
                 "show_timing_tower",

--- a/lib/config/schema/hud/hud.py
+++ b/lib/config/schema/hud/hud.py
@@ -311,6 +311,38 @@ class HudSettings(ConfigDiffMixin, BaseModel):
         }
     )
 
+    # ============== AUTO-HIDE IN MENU ==============
+    auto_hide_in_menu: bool = Field(
+        default=True,
+        description="Auto-hide overlays when the game is in a menu",
+        json_schema_extra={
+            "ui": {
+                "type": "check_box",
+                "visible": True,
+                "group": "Auto-hide in Menu",
+            }
+        }
+    )
+    menu_silence_threshold_sec: float = Field(
+        default=3.0,
+        ge=1.0,
+        le=30.0,
+        description="Seconds of telemetry silence before overlays are hidden (menu detection threshold)",
+        json_schema_extra={
+            "ui": {
+                "type": "slider",
+                "visible": True,
+                "min": 1,
+                "max": 30,
+                "group": "Auto-hide in Menu",
+                "ext_info": [
+                    "How long (in seconds) the backend must receive no periodic telemetry packets "
+                    "before treating the game as being in a menu and hiding the overlays."
+                ],
+            }
+        }
+    )
+
     # ============== GLOBAL OVERLAY CONTROLS ==============
 
     overlays_opacity: int = Field(

--- a/lib/config/schema/hud/hud.py
+++ b/lib/config/schema/hud/hud.py
@@ -331,7 +331,7 @@ class HudSettings(ConfigDiffMixin, BaseModel):
         json_schema_extra={
             "ui": {
                 "type": "slider",
-                "visible": True,
+                "visible": False,
                 "min": 1,
                 "max": 30,
                 "group": "Auto-hide in Menu",

--- a/lib/telemetry_manager/manager.py
+++ b/lib/telemetry_manager/manager.py
@@ -72,6 +72,7 @@ class AsyncF1TelemetryManager:
         self.m_frame_gate: SessionFrameGate = SessionFrameGate(frame_gate_enabled)
 
         self.m_raw_packet_callback: Optional[Callable[[object], Awaitable[None]]] = None
+        self._last_session_uid: Optional[int] = None
 
     def on_packet(self, packet_type: F1PacketType):
         """Decorator to register a callback for a specific packet type
@@ -167,6 +168,12 @@ class AsyncF1TelemetryManager:
                 len(raw_packet)
             )
             return
+
+        uid = parsed_obj.m_header.m_sessionUID
+        if uid != self._last_session_uid:
+            self.m_logger.info("Session UID changed: %s -> %d (packet=%s)",
+                               self._last_session_uid, uid, parsed_obj.m_header.m_packetId)
+            self._last_session_uid = uid
 
         # Perform the registered callback
         try:

--- a/lib/telemetry_manager/manager.py
+++ b/lib/telemetry_manager/manager.py
@@ -72,7 +72,6 @@ class AsyncF1TelemetryManager:
         self.m_frame_gate: SessionFrameGate = SessionFrameGate(frame_gate_enabled)
 
         self.m_raw_packet_callback: Optional[Callable[[object], Awaitable[None]]] = None
-        self._last_session_uid: Optional[int] = None
 
     def on_packet(self, packet_type: F1PacketType):
         """Decorator to register a callback for a specific packet type
@@ -168,12 +167,6 @@ class AsyncF1TelemetryManager:
                 len(raw_packet)
             )
             return
-
-        uid = parsed_obj.m_header.m_sessionUID
-        if uid != self._last_session_uid:
-            self.m_logger.info("Session UID changed: %s -> %d (packet=%s)",
-                               self._last_session_uid, uid, parsed_obj.m_header.m_packetId)
-            self._last_session_uid = uid
 
         # Perform the registered callback
         try:

--- a/tests/tests_config/tests_hud_settings.py
+++ b/tests/tests_config/tests_hud_settings.py
@@ -85,6 +85,8 @@ class TestHudSettings(TestF1ConfigBase):
         self.assertEqual(settings.circuit_info_length, 800)
         self.assertEqual(settings.overlays_opacity, 100)
         self.assertEqual(settings.use_windowed_overlays, False)
+        self.assertTrue(settings.auto_hide_in_menu)
+        self.assertEqual(settings.menu_silence_threshold_sec, 3.0)
         # MFD pages has its own test case because the structure is a bit more complex
 
     def test_hud_overlay_speed_unit_validation(self):
@@ -833,4 +835,35 @@ class TestHudSettings(TestF1ConfigBase):
         with self.assertRaises(ValidationError):
             HudSettings(circuit_info_length=1501)
         HudSettings(circuit_info_length=1500)
+
+    def test_auto_hide_in_menu_validation(self):
+        """Test auto_hide_in_menu accepts booleans and rejects invalid types"""
+        self.assertTrue(HudSettings(auto_hide_in_menu=True).auto_hide_in_menu)
+        self.assertFalse(HudSettings(auto_hide_in_menu=False).auto_hide_in_menu)
+
+        with self.assertRaises(ValidationError):
+            HudSettings(auto_hide_in_menu="notabool")
+        with self.assertRaises(ValidationError):
+            HudSettings(auto_hide_in_menu=None)  # type: ignore
+
+    def test_menu_silence_threshold_sec_validation(self):
+        """Test menu_silence_threshold_sec boundary and type validation"""
+        # Valid values
+        self.assertEqual(HudSettings(menu_silence_threshold_sec=1.0).menu_silence_threshold_sec, 1.0)
+        self.assertEqual(HudSettings(menu_silence_threshold_sec=3.0).menu_silence_threshold_sec, 3.0)
+        self.assertEqual(HudSettings(menu_silence_threshold_sec=30.0).menu_silence_threshold_sec, 30.0)
+
+        # Below minimum
+        with self.assertRaises(ValidationError):
+            HudSettings(menu_silence_threshold_sec=0.9)
+
+        # Above maximum
+        with self.assertRaises(ValidationError):
+            HudSettings(menu_silence_threshold_sec=30.1)
+
+        # Invalid type
+        with self.assertRaises(ValidationError):
+            HudSettings(menu_silence_threshold_sec="fast")
+        with self.assertRaises(ValidationError):
+            HudSettings(menu_silence_threshold_sec=None)  # type: ignore
 


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Overlays now automatically hide when the player navigates to a menu and reappear when a session starts. The detection mechanism monitors periodic packet flow - all packet types except EVENT are only emitted during an active session, so 3 seconds of silence indicates the game is in a menu.

How it works:
A silence timer in F1TelemetryHandler resets on every periodic packet. When it fires, m_in_menu=True is set on SessionState and published via the existing race-table-update message. The HUD consumes this flag and drives overlay visibility through the existing set_telemetry_active mechanism.

UX behaviour:

Overlays hide ~3s after entering a menu; reappear immediately when a session starts
Pressing the toggle button while in a menu brings overlays back for that menu visit; they auto-hide again on the next menu visit
Returning from a menu restores all overlays to visible regardless of per-overlay toggle state (e.g. a manually hidden MFD will reappear) - predictable reset to a known good state
Configurable via HUD settings: auto_hide_in_menu (default: true) and menu_silence_threshold_sec (default: 3.0s, range 1–30s)

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [ ] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
================================================================================
2026-05-02 14:54:38,084 [TEST] [runner.py:281] - TEST STATISTICS
2026-05-02 14:54:38,084 [TEST] [runner.py:282] - ================================================================================
2026-05-02 14:54:38,084 [TEST] [runner.py:283] - Files processed:        31
2026-05-02 14:54:38,084 [TEST] [runner.py:284] - Telemetry sent:         31
2026-05-02 14:54:38,084 [TEST] [runner.py:285] - Telemetry failed:       0
2026-05-02 14:54:38,084 [TEST] [runner.py:286] - Endpoint checks passed: 806
2026-05-02 14:54:38,084 [TEST] [runner.py:287] - Endpoint checks failed: 0
2026-05-02 14:54:38,085 [TEST] [runner.py:294] - Telemetry success rate: 100.0%
2026-05-02 14:54:38,085 [TEST] [runner.py:298] - Endpoint success rate:  100.0%
2026-05-02 14:54:38,085 [TEST] [runner.py:300] - ================================================================================
2026-05-02 14:54:38,085 [TEST] [runner.py:404] - 
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [ ] My code follows project style conventions
* [ ] All new and existing tests pass
* [ ] I have added relevant documentation/comments
* [ ] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Auto-hide HUD overlays when the game is detected to be in a menu based on telemetry silence, and propagate this state from the backend to the HUD overlays.

New Features:
- Introduce HUD setting auto_hide_in_menu to control automatic hiding of overlays in menus, with a configurable menu_silence_threshold_sec delay.
- Detect in-menu state in the backend using a telemetry watchdog timer driven by periodic (non-EVENT) packets and expose this flag via race table updates.
- Auto-hide and restore HUD overlays in the UI based on the propagated in-menu flag without requiring user interaction.

Enhancements:
- Update telemetry handler and session state to track in-menu status separately from simulator connectivity.
- Adjust overlays manager logic to drive telemetry-active state from local watchdog only and react to in-menu status for visibility.
- Require backend restart when HUD menu silence threshold changes and HUD restart when auto_hide_in_menu changes.

Tests:
- Extend HUD settings tests to cover defaults and validation for auto_hide_in_menu and menu_silence_threshold_sec.