### PR TITLE
feat(telemetry): autosave on suspicious SESSION_START events

### DIFF
--- a/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
@@ -221,7 +221,8 @@ class DataPerDriver:
                include_tyre_wear_prediction : Optional[bool] = False,
                selected_pit_stop_lap : Optional[int] = None,
                include_race_ctrl_msgs : Optional[bool] = False,
-               driver_info_dict: Optional[Dict[int, dict]] = None) -> Dict[str, Any]:
+               driver_info_dict: Optional[Dict[int, dict]] = None,
+               position_override: Optional[int] = None) -> Dict[str, Any]:
         """Get a JSON representation of this DataPerDriver object
 
         Args:
@@ -230,6 +231,7 @@ class DataPerDriver:
             selected_pit_stop_lap (Optional[int]): The lap number of the selected pit stop
             include_race_ctrl_msgs (Optional[bool]): Whether to include race control messages
             driver_info_dict (Optional[Dict[int, dict]]): Dictionary of driver info
+            position_override (Optional[int]): Override track position (e.g. penalty-adjusted). Uses live position if None.
 
         Returns:
             Dict[str, Any]: The JSON dict
@@ -241,7 +243,7 @@ class DataPerDriver:
             final_json["index"] = index
         final_json["is-player"] = self.m_driver_info.is_player
         final_json["driver-name"] = self.m_driver_info.name
-        final_json["track-position"] = self.m_driver_info.position
+        final_json["track-position"] = position_override if position_override is not None else self.m_driver_info.position
         final_json["team"] = self.m_driver_info.team
         final_json["telemetry-settings"] = str(self.m_driver_info.telemetry_setting)
         final_json["current-lap"] = self.m_lap_info.m_current_lap

--- a/apps/backend/state_mgmt_layer/intf/writers/manual_save.py
+++ b/apps/backend/state_mgmt_layer/intf/writers/manual_save.py
@@ -36,16 +36,18 @@ class ManualSaveRsp:
     Manual save response class.
     """
 
-    def __init__(self, logger: logging.Logger, session_state: SessionState):
+    def __init__(self, logger: logging.Logger, session_state: SessionState, reason: str = "Manual"):
         """Get the drivers list and prepare the rsp fields
 
         Args:
             logger (logging.Logger): Logger
             session_state_ref (TelState.SessionState): Reference to the session state
+            reason (str, optional): Reason for the save. Defaults to "Manual".
         """
 
         self.m_logger: logging.Logger = logger
         self.m_session_state: SessionState = session_state
+        self.m_reason: str = reason
         self.m_data_available = self.m_session_state.is_data_available
         self.m_event_str = self.m_session_state.getEventInfoStr()
         if self.m_data_available:
@@ -71,7 +73,7 @@ class ManualSaveRsp:
 
         # Construct output filename using timestamp
         timestamp_str = now.strftime("%Y_%m_%d_%H_%M_%S")
-        final_json_file_name = f"{self.m_event_str}Manual_{timestamp_str}.json"
+        final_json_file_name = f"{self.m_event_str}_{self.m_reason}_{timestamp_str}.json"
 
         # Build final classification JSON
         final_json = self.m_session_state.buildFinalClassificationJSON()

--- a/apps/backend/state_mgmt_layer/intf/writers/manual_save.py
+++ b/apps/backend/state_mgmt_layer/intf/writers/manual_save.py
@@ -73,7 +73,8 @@ class ManualSaveRsp:
 
         # Construct output filename using timestamp
         timestamp_str = now.strftime("%Y_%m_%d_%H_%M_%S")
-        final_json_file_name = f"{self.m_event_str}_{self.m_reason}_{timestamp_str}.json"
+        # event_str is already suffixed with an underscore
+        final_json_file_name = f"{self.m_event_str}{self.m_reason}_{timestamp_str}.json"
 
         # Build final classification JSON
         final_json = self.m_session_state.buildFinalClassificationJSON()

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -49,6 +49,7 @@ from lib.f1_types import (ActualTyreCompound, CarStatusData, F1Utils,
 from lib.inter_task_communicator import (AsyncInterTaskCommunicator,
                                          SessionChangeNotification,
                                          TyreDeltaMessage)
+from lib.logger import PngLogger
 from lib.openf1 import MostRecentPoleLap
 from lib.overtake_analyzer import (OvertakeAnalyzer, OvertakeAnalyzerMode,
                                    OvertakeRecord)
@@ -111,18 +112,19 @@ class SessionInfo:
         "m_game_year",
         "m_packet_format",
         "m_most_recent_pole_lap",
+        "m_chequered_flag",
     )
 
-    def __init__(self, settings: PngSettings, logger: logging.Logger) -> None:
+    def __init__(self, settings: PngSettings, logger: PngLogger) -> None:
         """
         Init the SessionInfo object fields to None
 
         Args:
             settings (PngSettings): App Settings
-            logger (logging.Logger): Logger
+            logger (PngLogger): Logger
         """
 
-        self.m_logger: logging.Logger = logger
+        self.m_logger: PngLogger = logger
         self.m_formula: Optional[PacketSessionData.FormulaType] = None
         self.m_track : Optional[TrackID] = None
         self.m_track_len: Optional[int] = None
@@ -143,6 +145,7 @@ class SessionInfo:
         self.m_game_year : Optional[int] = None
         self.m_packet_format : Optional[int] = None
         self.m_most_recent_pole_lap : Optional[MostRecentPoleLap] = None
+        self.m_chequered_flag : Optional[bool] = False
 
         # Initialize the pit time loss dicts
         track_name_to_enum = {str(member): member for member in TrackID}
@@ -204,7 +207,7 @@ class SessionInfo:
         self.m_packet_format = None
         self.m_pit_time_loss = None
         self.m_most_recent_pole_lap = None
-
+        self.m_chequered_flag = False
         # Dont clear the pit loss dicts. they are static
 
     @property
@@ -329,13 +332,13 @@ class SessionState:
     )
 
     def __init__(self,
-                 logger: logging.Logger,
+                 logger: PngLogger,
                  settings: PngSettings,
                  ver_str: str) -> None:
         """Init the DriverData object
 
         Args:
-            logger (logging.Logger): Logger
+            logger (PngLogger): Logger
             settings (PngSettings): Settings
             ver_str (str): Version string
         """
@@ -1055,6 +1058,14 @@ class SessionState:
         if msg := race_ctrl_event_msg_factory(packet, lap_number=lap_num):
             self.m_race_ctrl.add_message(msg)
 
+    def setChequeredFlagState(self, flag_val: bool) -> None:
+        """Set the chequered flag status
+
+        Args:
+            flag_val (bool): The value to set for the chequered flag status
+        """
+        self.m_session_info.m_chequered_flag = flag_val
+
     ##### Public Getters #####
 
     def getDriverInfoJsonByIndex(self, index: int) -> Optional[Dict[str, Any]]:
@@ -1388,6 +1399,26 @@ class SessionState:
 
         return  (0 <= index < len(self.m_driver_data)) and \
                 (self.m_driver_data[index] and self.m_driver_data[index].is_valid)
+
+    def shouldSaveJustInCase(self, session_uid: int) -> str:
+        """Determines whether to save the data just in case based on the session UID and internal heuristics
+
+        Args:
+            session_uid (int): The session UID
+
+        Returns:
+            str: Reason
+        """
+
+        if self.m_session_info.m_chequered_flag:
+            return "Chequered flag waved"
+
+        # TODO: check if sufficient amount of laps have passed, in case chequered flag event is missed
+
+        # TODO: remove logs
+        self.m_logger.silent("Should not save. curr UID: %s, incoming UID: %s",
+                             self.m_session_info.m_session_uid, session_uid)
+        return None
 
     ##### Internal Helpers #####
 

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -23,7 +23,6 @@
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
 import json
-import logging
 import time
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -740,6 +740,21 @@ class SessionState:
 
         self.setRaceCompleted()
 
+    def _computePenaltyAdjustedPositions(self) -> Dict[int, int]:
+        """Compute penalty-adjusted positions using total distance and accumulated time penalties.
+
+        Returns:
+            Dict[int, int]: Mapping of car index to penalty-adjusted position (1-based).
+                            Cars with no lap data are excluded.
+        """
+        entries = []
+        for index, driver in enumerate(self.m_driver_data):
+            if driver and driver.is_valid and driver.m_packet_copies.m_packet_lap_data:
+                lap_data = driver.m_packet_copies.m_packet_lap_data
+                entries.append((index, lap_data.m_totalDistance, lap_data.m_penalties))
+        entries.sort(key=lambda x: (-x[1], x[2]))
+        return {car_index: pos + 1 for pos, (car_index, _, _) in enumerate(entries)}
+
     def buildFinalClassificationJSON(self) -> Dict[str, Any]:
         """
         Constructs the final classification JSON from internal state.
@@ -766,6 +781,8 @@ class SessionState:
 
         speed_trap_records = []
         driver_info_dict = self._getRaceCtrlHelperDict() if self.m_save_race_ctrl_msgs else None
+        is_dummy = session_info.m_packet_final_classification is None
+        adjusted_positions = self._computePenaltyAdjustedPositions() if is_dummy else {}
 
         # --- Initialize optional structures
         if is_position_history_supported:
@@ -780,7 +797,8 @@ class SessionState:
                 # Add driver's classification info
                 final_json["classification-data"].append(driver.toJSON(index=index,
                                                                        include_race_ctrl_msgs=self.m_save_race_ctrl_msgs,
-                                                                       driver_info_dict=driver_info_dict))
+                                                                       driver_info_dict=driver_info_dict,
+                                                                       position_override=adjusted_positions.get(index)))
                 # Collect speed trap info
                 speed_trap_records.append(driver.getSpeedTrapRecordJSON())
 

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -1666,6 +1666,8 @@ class SessionState:
         """
         packet = PacketFinalClassificationData.from_values(None, 0, [])
         packet.m_numCars = self.m_num_active_cars
+        # Field values don't matter - buildFinalClassificationJSON only iterates over
+        # m_classificationData for its length; all real data comes from DataPerDriver.
         packet.m_classificationData = [self._getDummyFinalClassificationData() for _ in range(self.m_num_active_cars)]
         return packet
 

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -1418,6 +1418,34 @@ class SessionState:
         return  (0 <= index < len(self.m_driver_data)) and \
                 (self.m_driver_data[index] and self.m_driver_data[index].is_valid)
 
+    def isSuspiciousSessionStart(self, session_uid: int) -> bool:
+        """Check if the session start event is suspicious.
+
+        Args:
+            session_uid (int): The session UID
+
+        Returns:
+            bool: True if the session start event is suspicious, False otherwise
+        """
+
+        if self.m_session_info.m_chequered_flag:
+            self.m_logger.warning("Suspicious session start event message for session %d after CHEQUERED_FLAG event",
+                                    session_uid)
+            return True
+
+        driver = self.getDriverInfoByPosition(1)
+        if not driver:
+            self.m_logger.warning("Cannot find P1 driver in session %d", session_uid)
+
+        if driver.m_lap_info.m_current_lap >= self.m_session_info.m_total_laps:
+                self.m_logger.warning("Suspicious session start event message for session %d - "
+                                      "leader may have completed race",
+                                        session_uid, driver.m_lap_info.m_current_lap)
+                return True
+
+        self.m_logger.debug("SESSION_START for %d doesn't seem suspicious", session_uid)
+        return False
+
     ##### Internal Helpers #####
 
     def _getRaceCtrlHelperDict(self) -> Dict[str, Any]:

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -1418,26 +1418,6 @@ class SessionState:
         return  (0 <= index < len(self.m_driver_data)) and \
                 (self.m_driver_data[index] and self.m_driver_data[index].is_valid)
 
-    def shouldSaveJustInCase(self, session_uid: int) -> str:
-        """Determines whether to save the data just in case based on the session UID and internal heuristics
-
-        Args:
-            session_uid (int): The session UID
-
-        Returns:
-            str: Reason
-        """
-
-        if self.m_session_info.m_chequered_flag:
-            return "Chequered flag waved"
-
-        # TODO: check if sufficient amount of laps have passed, in case chequered flag event is missed
-
-        # TODO: remove logs
-        self.m_logger.silent("Should not save. curr UID: %s, incoming UID: %s",
-                             self.m_session_info.m_session_uid, session_uid)
-        return None
-
     ##### Internal Helpers #####
 
     def _getRaceCtrlHelperDict(self) -> Dict[str, Any]:

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -30,9 +30,10 @@ from datetime import datetime
 from typing import Any, Awaitable, Callable, Coroutine, Dict, List, Optional
 
 from apps.backend.state_mgmt_layer import SessionState
+from apps.backend.state_mgmt_layer.intf import ManualSaveRsp
 from lib.button_debouncer import ButtonDebouncer
-from lib.event_counter import EventCounter
 from lib.config import CaptureSettings, OverlayId, PngSettings
+from lib.event_counter import EventCounter
 from lib.f1_types import (F1PacketType, PacketCarDamageData,
                           PacketCarSetupData, PacketCarStatusData,
                           PacketCarTelemetryData, PacketEventData,
@@ -200,6 +201,9 @@ class F1TelemetryHandler:
         )
 
         self.m_manager_task: Optional[asyncio.Task] = None
+        # Task handle because asyncio expects a handle to be saved,
+        # otherwise it is not guaranteed to be run to completion without being garbage collected
+        self.m_save_task: Optional[asyncio.Task] = None
         self.registerCallbacks()
 
     def getTask(self, name: Optional[str] = "Game Telemetry Listener Task") -> asyncio.Task:
@@ -245,6 +249,21 @@ class F1TelemetryHandler:
         if self.m_manager_task:
             self.m_manager_task.cancel()
         self.m_wdt.stop()
+        if self.m_save_task:
+            self.m_logger.debug("Waiting for save task to complete...")
+
+            try:
+                await asyncio.wait_for(self.m_save_task, timeout=5.0)
+                self.m_logger.debug("Save task completed.")
+
+            except asyncio.TimeoutError:
+                self.m_logger.debug("Save task timed out. Cancelling...")
+
+                self.m_save_task.cancel()
+                await asyncio.gather(self.m_save_task, return_exceptions=True)
+
+                self.m_logger.debug("Save task cancelled.")
+
         self.m_logger.debug("Telemetry handler stopped. manager and wdt stopped.")
 
     def getWatchdogTask(self) -> Coroutine:
@@ -316,7 +335,7 @@ class F1TelemetryHandler:
             event_handler: Dict[PacketEventData.EventPacketType, Callable[[PacketEventData], Awaitable[None]]] = {
                 PacketEventData.EventPacketType.BUTTON_STATUS: handleButtonStatus,
                 PacketEventData.EventPacketType.FASTEST_LAP: processFastestLapUpdate,
-                PacketEventData.EventPacketType.SESSION_STARTED: handeSessionStartEvent,
+                PacketEventData.EventPacketType.SESSION_STARTED: handleSessionStartEvent,
                 PacketEventData.EventPacketType.RETIREMENT: processRetirementEvent,
                 PacketEventData.EventPacketType.OVERTAKE: processOvertakeEvent,
                 PacketEventData.EventPacketType.COLLISION: processCollisionsEvent,
@@ -478,7 +497,7 @@ class F1TelemetryHandler:
 
         #     self.m_session_state_ref.processLapPositionsUpdate(packet)
 
-        async def handeSessionStartEvent(packet: PacketEventData) -> None:
+        async def handleSessionStartEvent(packet: PacketEventData) -> None:
             """
             Handle and process the session start event
 
@@ -490,7 +509,10 @@ class F1TelemetryHandler:
                 self.m_logger.warning("Suspicious session start event. Session UID %d. "
                                       "Data structures not cleared to avoid data loss. Reason: %s",
                                       packet.m_header.m_sessionUID, reason)
-                # TODO: save just in case
+                self.m_save_task = asyncio.create_task(self._saveJustInCaseData(packet.m_header.m_sessionUID),
+                                                       name="Just in case save task")
+
+
             self.m_last_session_uid = packet.m_header.m_sessionUID
             self.clearAllDataStructures(f"SESSION_START event - UID {packet.m_header.m_sessionUID}")
 
@@ -828,3 +850,16 @@ class F1TelemetryHandler:
             self.m_logger.info('UDP action %d pressed - %s', code, name)
             await coro()
 
+    async def _saveJustInCaseData(self, session_uid: int) -> None:
+        """Save data just in case when a suspicious session start event is received.
+
+        Args:
+            session_uid (int): The session UID for which the suspicious session start event was received.
+        """
+        try:
+            rsp = await ManualSaveRsp(logger=self.m_logger, session_state=self.m_session_state_ref).saveToDisk()
+            self.m_logger.info("Saving just in case data. Session UID %d. status=%s", session_uid, rsp)
+        except Exception as e:
+            self.m_logger.error("Error occurred while saving just in case data for session %d: %s", session_uid, str(e))
+
+        self.m_save_task = None

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -505,14 +505,7 @@ class F1TelemetryHandler:
                 packet (PacketEventData): The parsed object containing the session start packet's contents.
             """
 
-            if reason := self.m_session_state_ref.shouldSaveJustInCase(packet.m_header.m_sessionUID):
-                self.m_logger.warning("Suspicious session start event. Session UID %d. "
-                                      "Data structures not cleared to avoid data loss. Reason: %s",
-                                      packet.m_header.m_sessionUID, reason)
-                self.m_save_task = asyncio.create_task(self._saveJustInCaseData(packet.m_header.m_sessionUID),
-                                                       name="Just in case save task")
-
-
+            self._handleSuspiciousSessionStart(packet.m_header.m_sessionUID)
             self.m_last_session_uid = packet.m_header.m_sessionUID
             self.clearAllDataStructures(f"SESSION_START event - UID {packet.m_header.m_sessionUID}")
 
@@ -850,14 +843,38 @@ class F1TelemetryHandler:
             self.m_logger.info('UDP action %d pressed - %s', code, name)
             await coro()
 
-    async def _saveJustInCaseData(self, session_uid: int) -> None:
+    async def _handleSuspiciousSessionStart(self, session_uid: int) -> None:
+        """Save data just in case when a suspicious session start event is received.
+
+        Args:
+            session_uid (int): The session UID for which the suspicious session start event was received.
+        """
+
+        if (not self.m_save_task
+            and (
+                not self.m_final_classification_processed
+                or not self.m_session_state_ref.m_session_info.m_chequered_flag
+            )):
+            self.m_logger.warning("Suspicious session start event. Session UID %d. "
+                                    "Data structures not cleared to avoid data loss. "
+                                    "Final classification processed: %s "
+                                    "Chequered flag state: %s. Saving just in case data.",
+                                    session_uid, self.m_final_classification_processed,
+                                    self.m_session_state_ref.m_session_info.m_chequered_flag)
+            self.m_save_task = asyncio.create_task(self._saveJustInCaseDataTask(session_uid),
+                                                    name="Just in case save task")
+
+    async def _saveJustInCaseDataTask(self, session_uid: int) -> None:
         """Save data just in case when a suspicious session start event is received.
 
         Args:
             session_uid (int): The session UID for which the suspicious session start event was received.
         """
         try:
-            rsp = await ManualSaveRsp(logger=self.m_logger, session_state=self.m_session_state_ref).saveToDisk()
+            rsp = await ManualSaveRsp(
+                logger=self.m_logger,
+                session_state=self.m_session_state_ref,
+                reason="Just_in_case").saveToDisk()
             self.m_logger.info("Saving just in case data. Session UID %d. status=%s", session_uid, rsp)
         except Exception as e:
             self.m_logger.error("Error occurred while saving just in case data for session %d: %s", session_uid, str(e))

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -883,7 +883,7 @@ class F1TelemetryHandler:
                 session_state=self.m_session_state_ref,
                 reason="Just_in_case").saveToDisk()
             self.m_logger.info("Saving just in case data. Session UID %d. status=%s", session_uid, rsp)
-        except Exception as e:
+        except Exception as e: # pylint: disable=broad-exception-caught
             self.m_logger.error("Error occurred while saving just in case data for session %d: %s", session_uid, str(e))
 
         self.m_save_task = None

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -850,21 +850,24 @@ class F1TelemetryHandler:
             session_uid (int): The session UID for which the suspicious session start event was received.
         """
 
+        self.m_logger.info("SESSION_START event received. %d", session_uid)
+
+        if not self.m_capture_settings.suspicious_session_start_autosave:
+            return
+
         if not self._shouldSaveData():
             return
 
-        if (self.m_capture_settings.suspicious_session_start_autosave
-            and not self.m_save_task
-            and (
-                not self.m_final_classification_processed
-                or not self.m_session_state_ref.m_session_info.m_chequered_flag
-            )):
-            self.m_logger.warning("Suspicious session start event. Session UID %d. "
-                                    "Data structures not cleared to avoid data loss. "
-                                    "Final classification processed: %s "
-                                    "Chequered flag state: %s. Saving just in case data.",
-                                    session_uid, self.m_final_classification_processed,
-                                    self.m_session_state_ref.m_session_info.m_chequered_flag)
+        if self.m_final_classification_processed:
+            self.m_logger.debug("Final classification already processed for this session. "
+                                "Not treating this session start as suspicious.")
+            return
+
+        if self.m_save_task:
+            self.m_logger.debug("A save task is already running.")
+            return
+
+        if self.m_session_state_ref.isSuspiciousSessionStart(session_uid):
             self.m_save_task = asyncio.create_task(self._saveJustInCaseDataTask(session_uid),
                                                     name="Just in case save task")
 

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -850,7 +850,11 @@ class F1TelemetryHandler:
             session_uid (int): The session UID for which the suspicious session start event was received.
         """
 
-        if (not self.m_save_task
+        if not self._shouldSaveData():
+            return
+
+        if (self.m_capture_settings.suspicious_session_start_autosave
+            and not self.m_save_task
             and (
                 not self.m_final_classification_processed
                 or not self.m_session_state_ref.m_session_info.m_chequered_flag

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -322,6 +322,7 @@ class F1TelemetryHandler:
                 PacketEventData.EventPacketType.COLLISION: processCollisionsEvent,
                 PacketEventData.EventPacketType.FLASHBACK: handleFlashBackEvent,
                 PacketEventData.EventPacketType.START_LIGHTS: handleStartLightsEvent,
+                PacketEventData.EventPacketType.CHEQUERED_FLAG: handleChequeredFlagEvent,
             }.get(packet.m_eventCode)
 
             if event_handler:
@@ -485,6 +486,11 @@ class F1TelemetryHandler:
                 packet (PacketEventData): The parsed object containing the session start packet's contents.
             """
 
+            if reason := self.m_session_state_ref.shouldSaveJustInCase(packet.m_header.m_sessionUID):
+                self.m_logger.warning("Suspicious session start event. Session UID %d. "
+                                      "Data structures not cleared to avoid data loss. Reason: %s",
+                                      packet.m_header.m_sessionUID, reason)
+                # TODO: save just in case
             self.m_last_session_uid = packet.m_header.m_sessionUID
             self.clearAllDataStructures(f"SESSION_START event - UID {packet.m_header.m_sessionUID}")
 
@@ -632,6 +638,15 @@ class F1TelemetryHandler:
             """
             record: PacketEventData.Overtake = packet.mEventDetails
             self.m_session_state_ref.processOvertakeEvent(record)
+
+        async def handleChequeredFlagEvent(packet: PacketEventData) -> None:
+            """Handle the chequered flag event
+
+            Args:
+                packet (PacketEventData): The event packet
+            """
+            self.m_logger.info("Chequered flag waved. UID = %d", packet.m_header.m_sessionUID)
+            self.m_session_state_ref.setChequeredFlagState(flag_val=True)
 
     def clearAllDataStructures(self, reason: str) -> None:
         """Clear all the data structures

--- a/integration_test_cfg.json
+++ b/integration_test_cfg.json
@@ -17,7 +17,8 @@
         "post_quali_data_autosave": true,
         "post_fp_data_autosave": false,
         "post_tt_data_autosave": false,
-        "save_race_ctrl_msg": false
+        "save_race_ctrl_msg": false,
+        "suspicious_session_start_autosave": true
     },
     "Display": {
         "disable_browser_autoload": true,

--- a/lib/config/schema/capture.py
+++ b/lib/config/schema/capture.py
@@ -87,3 +87,20 @@ class CaptureSettings(ConfigDiffMixin, BaseModel):
             }
         }
     )
+    suspicious_session_start_autosave: bool = Field(
+        default=True,
+        description="Autosave on suspicious session start (new session detected before previous session ended cleanly)",
+        json_schema_extra={
+            "ui": {
+                "type" : "check_box",
+                "visible": True,
+                "ext_info": [
+                    "F1 25 has a bug where SESSION_START is sent just before FINAL_CLASSIFICATION, "
+                    "causing Pits n' Giggles to think a new session is starting and clear all data. "
+                    "When enabled, if a SESSION_START arrives after the chequered flag but before "
+                    "FINAL_CLASSIFICATION is processed, the current session data is saved to disk "
+                    "before clearing, preventing data loss."
+                ]
+            }
+        }
+    )

--- a/tests/tests_config/tests_capture_settings.py
+++ b/tests/tests_config/tests_capture_settings.py
@@ -132,3 +132,16 @@ class TestCaptureSettings(TestF1ConfigBase):
 
         with self.assertRaises(ValidationError):
             CaptureSettings(save_race_ctrl_msg="notaboolean")
+
+    def test_default_suspicious_session_start_autosave(self):
+        self.assertTrue(CaptureSettings().suspicious_session_start_autosave)
+
+    def test_boolean_validation_suspicious_session_start_autosave(self):
+        self.assertTrue(CaptureSettings(suspicious_session_start_autosave=True).suspicious_session_start_autosave)
+        self.assertFalse(CaptureSettings(suspicious_session_start_autosave=False).suspicious_session_start_autosave)
+        self.assertTrue(CaptureSettings(suspicious_session_start_autosave="True").suspicious_session_start_autosave)
+        self.assertFalse(CaptureSettings(suspicious_session_start_autosave="False").suspicious_session_start_autosave)
+
+    def test_invalid_suspicious_session_start_autosave_raises(self):
+        with self.assertRaises(ValidationError):
+            CaptureSettings(suspicious_session_start_autosave="notaboolean")


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

In F1 25, there is a bug where SESSION_START is erroneously sent just before FINAL_CLASSIFICATION.
This confuses pits n giggles into clearing its data. And by the time FINAL_CLASSIFICATION arrives, all data is lost

Now, suspicious SESSION_START events are checked for. If detected, we save the data "just in case"

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [ ] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
2026-05-06 21:12:32,073 [TEST] [runner.py:282] - ================================================================================
2026-05-06 21:12:32,073 [TEST] [runner.py:283] - Files processed:        31
2026-05-06 21:12:32,074 [TEST] [runner.py:284] - Telemetry sent:         31
2026-05-06 21:12:32,074 [TEST] [runner.py:285] - Telemetry failed:       0
2026-05-06 21:12:32,074 [TEST] [runner.py:286] - Endpoint checks passed: 806
2026-05-06 21:12:32,074 [TEST] [runner.py:287] - Endpoint checks failed: 0
2026-05-06 21:12:32,075 [TEST] [runner.py:294] - Telemetry success rate: 100.0%
2026-05-06 21:12:32,075 [TEST] [runner.py:298] - Endpoint success rate:  100.0%
2026-05-06 21:12:32,075 [TEST] [runner.py:300] - ================================================================================
2026-05-06 21:12:32,076 [TEST] [runner.py:404] - 
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [ ] My code follows project style conventions
* [ ] All new and existing tests pass
* [ ] I have added relevant documentation/comments
* [ ] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Add defensive autosave logic for suspicious SESSION_START events that may precede FINAL_CLASSIFICATION, and enrich final classification output with penalty-adjusted positions and chequered flag awareness.

New Features:
- Introduce configurable autosave on suspicious session start events, persisting session data before it can be cleared.
- Add chequered flag tracking and handling to session state and telemetry event processing.
- Include penalty-adjusted race positions in final classification JSON when no official final-classification packet is available.

Enhancements:
- Ensure just-in-case save tasks are tracked and gracefully awaited or cancelled during telemetry handler shutdown.
- Extend manual save filenames with a reason tag to distinguish manual vs. just-in-case saves.
- Update driver JSON serialization to support an overridable track position field based on adjusted classification logic.

Documentation:
- Document the suspicious_session_start_autosave option in the capture settings schema, including its rationale related to F1 25 SESSION_START/FINAL_CLASSIFICATION behavior.

Tests:
- Add configuration tests for the new suspicious_session_start_autosave capture setting, including defaults and boolean parsing.