### PR TITLE
feat(telemetry): hot-reload UDP forwarding targets at runtime

### DIFF
--- a/apps/backend/intf_layer/ipc/__init__.py
+++ b/apps/backend/intf_layer/ipc/__init__.py
@@ -31,8 +31,8 @@ from apps.backend.telemetry_layer import F1TelemetryHandler
 from lib.ipc import IpcServerAsync, IpcPublisherAsync, IpcDealerAsync
 from lib.child_proc_mgmt import report_ipc_port_from_child
 
-from .command_handlers import (handleGetStats, handleManualSave, handleHeartbeatMissed, handleShutdown,
-                               handleUdpActionCodeChange)
+from .command_handlers import (handleForwardingConfigChange, handleGetStats, handleManualSave,
+                               handleHeartbeatMissed, handleShutdown, handleUdpActionCodeChange)
 from ..telemetry_web_server import TelemetryWebServer
 
 # -------------------------------------- FUNCTIONS ---------------------------------------------------------------------
@@ -84,6 +84,10 @@ def registerIpcTask(
     @server.on("udp-action-code-change")
     async def _handle_udp_action_code_change(args: dict):
         return await handleUdpActionCodeChange(args, logger, telemetry_handler)
+
+    @server.on("forwarding-config-change")
+    async def _handle_forwarding_config_change(args: dict):
+        return await handleForwardingConfigChange(args, logger, telemetry_handler)
 
     @server.on_get_stats
     async def _handle_get_stats(_args: dict):

--- a/apps/backend/intf_layer/ipc/command_handlers.py
+++ b/apps/backend/intf_layer/ipc/command_handlers.py
@@ -90,13 +90,45 @@ async def handleForwardingConfigChange(
         msg: dict,
         logger: logging.Logger,
         telemetry_handler: F1TelemetryHandler) -> dict:
-    """Handle forwarding-config-change command — update targets without restarting the backend."""
+    """Handle forwarding-config-change command: update targets without restarting the backend."""
 
-    targets = [tuple(t) for t in msg.get('targets', [])]
+    raw_targets = msg.get('targets', [])
+    if not isinstance(raw_targets, list):
+        return {'status': 'failure', 'message': 'Invalid targets payload: expected a list'}
+
+    targets = []
+    for idx, target in enumerate(raw_targets):
+        if not isinstance(target, (list, tuple)) or len(target) != 2:
+            return {
+                'status': 'failure',
+                'message': f'Invalid target at index {idx}: expected [host, port]'
+            }
+
+        host, port = target
+        if not isinstance(host, str) or not host.strip():
+            return {
+                'status': 'failure',
+                'message': f'Invalid host at index {idx}: expected non-empty string'
+            }
+
+        if not isinstance(port, int) or isinstance(port, bool):
+            return {
+                'status': 'failure',
+                'message': f'Invalid port at index {idx}: expected integer'
+            }
+
+        if port < 1 or port > 65535:
+            return {
+                'status': 'failure',
+                'message': f'Invalid port at index {idx}: expected 1-65535'
+            }
+
+        targets.append((host, port))
+
     logger.info("Received forwarding config change. Targets: %s", targets)
     try:
         telemetry_handler.update_forwarding_targets(targets)
-    except OSError as e:
+    except (OSError, TypeError, ValueError) as e:
         logger.error("Failed to update forwarding targets: %s", e)
         return {'status': 'failure', 'message': str(e)}
     return {'status': 'success'}

--- a/apps/backend/intf_layer/ipc/command_handlers.py
+++ b/apps/backend/intf_layer/ipc/command_handlers.py
@@ -86,6 +86,21 @@ async def handleHeartbeatMissed(count: int, logger: logging.Logger) -> dict:
     # running atexit handlers or flushing stdio buffers from parent.
     os._exit(PNG_LOST_CONN_TO_PARENT)
 
+async def handleForwardingConfigChange(
+        msg: dict,
+        logger: logging.Logger,
+        telemetry_handler: F1TelemetryHandler) -> dict:
+    """Handle forwarding-config-change command — update targets without restarting the backend."""
+
+    targets = [tuple(t) for t in msg.get('targets', [])]
+    logger.info("Received forwarding config change. Targets: %s", targets)
+    try:
+        telemetry_handler.update_forwarding_targets(targets)
+    except OSError as e:
+        logger.error("Failed to update forwarding targets: %s", e)
+        return {'status': 'failure', 'message': str(e)}
+    return {'status': 'success'}
+
 async def handleUdpActionCodeChange(
         msg: dict,
         logger: logging.Logger,

--- a/apps/backend/telemetry_layer/telemetry_forwarder.py
+++ b/apps/backend/telemetry_layer/telemetry_forwarder.py
@@ -35,36 +35,36 @@ from lib.packet_forwarder import AsyncUDPForwarder
 def setupForwarder(forwarding_targets: List[Tuple[str, int]],
                    tasks: List[asyncio.Task],
                    shutdown_event: asyncio.Event,
-                   logger: logging.Logger) -> None:
-    """Init the forwarding thread, if targets are defined
+                   logger: logging.Logger) -> AsyncUDPForwarder:
+    """Init the forwarding task and return the forwarder so targets can be updated at runtime.
 
     Args:
-        forwarding_targets (List[Tuple[str, int]]): Forwarding Targets list
+        forwarding_targets (List[Tuple[str, int]]): Initial forwarding targets (may be empty)
         tasks (List[asyncio.Task]): List of tasks
         shutdown_event (asyncio.Event): Shutdown event
         logger (logging.Logger): Logger
+
+    Returns:
+        AsyncUDPForwarder: The forwarder instance (call update_targets() to change destinations)
     """
 
-    # Register the task only if targets are defined
-    if forwarding_targets:
-        tasks.append(asyncio.create_task(udpForwardingTask(forwarding_targets, shutdown_event, logger),
-                                         name="UDP Forwarder Task"))
-    else:
-        logger.debug("No forwarding targets defined. Not registering task.")
+    udp_forwarder = AsyncUDPForwarder(forwarding_targets, logger)
+    tasks.append(asyncio.create_task(udpForwardingTask(udp_forwarder, shutdown_event, logger),
+                                     name="UDP Forwarder Task"))
+    logger.debug("UDP Forwarder task registered. Initial targets=%s", forwarding_targets)
+    return udp_forwarder
 
-async def udpForwardingTask(forwarding_targets: List[Tuple[str, int]],
+async def udpForwardingTask(udp_forwarder: AsyncUDPForwarder,
                             shutdown_event: asyncio.Event,
                             logger: logging.Logger) -> None:
     """UDP Forwarding Task
 
     Args:
-        forwarding_targets (List[Tuple[str, int]]): Forwarding Targets list
+        udp_forwarder (AsyncUDPForwarder): Forwarder instance (shared with IPC handler for hot-reload)
         shutdown_event (asyncio.Event): Shutdown event
         logger (logging.Logger): Logger
     """
 
-    udp_forwarder = AsyncUDPForwarder(forwarding_targets, logger)
-    logger.info("Initialised forwarder. Targets=%s", forwarding_targets)
     while not shutdown_event.is_set():
         if packet := await AsyncInterTaskCommunicator().receive("packet-forward"):
             await udp_forwarder.forward(packet)

--- a/apps/backend/telemetry_layer/telemetry_handler.py
+++ b/apps/backend/telemetry_layer/telemetry_handler.py
@@ -27,7 +27,7 @@ SOFTWARE.
 import asyncio
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Awaitable, Callable, Coroutine, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Coroutine, Dict, List, Optional, Tuple
 
 from apps.backend.state_mgmt_layer import SessionState
 from apps.backend.state_mgmt_layer.intf import ManualSaveRsp
@@ -47,6 +47,7 @@ from lib.inter_task_communicator import (
     HudPrevPageMfdNotification, HudToggleNotification, ITCMessage,
     TyreDeltaNotificationMessageCollection)
 from lib.logger import PngLogger
+from lib.packet_forwarder import AsyncUDPForwarder
 from lib.save_to_disk import save_json_to_file
 from lib.telemetry_manager import AsyncF1TelemetryManager, telemetry_transport_factory
 from lib.wdt import WatchDogTimerAsync
@@ -181,6 +182,7 @@ class F1TelemetryHandler:
         self.m_udp_action_stats: EventCounter = EventCounter()
 
         self.m_should_forward: bool = bool(settings.Forwarding.forwarding_targets)
+        self.m_udp_forwarder: Optional[AsyncUDPForwarder] = None
         self.m_version: str = ver_str
         self.m_wdt: WatchDogTimerAsync = WatchDogTimerAsync(
             status_callback=self.m_session_state_ref.setConnectedToSim,
@@ -239,6 +241,25 @@ class F1TelemetryHandler:
         """
         self.m_udp_action_codes.update(key, val)
         self.m_logger.debug("Updated UDP action code %s to %s", key, val)
+
+    def set_udp_forwarder(self, forwarder: AsyncUDPForwarder) -> None:
+        """Wire the forwarder instance created by setupForwarder into this handler.
+
+        Args:
+            forwarder (AsyncUDPForwarder): Forwarder to use for hot-reload target updates
+        """
+        self.m_udp_forwarder = forwarder
+
+    def update_forwarding_targets(self, targets: List[Tuple[str, int]]) -> None:
+        """Update forwarding destinations at runtime without restarting the backend.
+
+        Args:
+            targets (List[Tuple[str, int]]): Complete new list of (host, port) destinations
+        """
+        self.m_should_forward = bool(targets)
+        if self.m_udp_forwarder:
+            self.m_udp_forwarder.update_targets(targets)
+        self.m_logger.info("Updated forwarding targets: %s", targets)
 
     async def run(self):
         """

--- a/apps/backend/telemetry_layer/telemetry_layer_init.py
+++ b/apps/backend/telemetry_layer/telemetry_layer_init.py
@@ -73,10 +73,11 @@ def initTelemetryLayer(
             raise PngTelemetryPortInUseError() from e
         raise  # Re-raise if it's a different OSError
 
-    setupForwarder(
+    udp_forwarder = setupForwarder(
         forwarding_targets=settings.Forwarding.forwarding_targets,
         tasks=tasks,
         shutdown_event=shutdown_event,
         logger=logger
     )
+    handler.set_udp_forwarder(udp_forwarder)
     return handler

--- a/apps/launcher/subsystems/backend_mgr.py
+++ b/apps/launcher/subsystems/backend_mgr.py
@@ -158,6 +158,12 @@ class BackendAppMgr(PngAppMgrBase):
         else:
             self.debug_log(f"{self.DISPLAY_NAME} UDP action codes NO CHANGE")
 
+        # Update forwarding targets if changed — no restart needed
+        if self.curr_settings.diff(new_settings, {"Forwarding": []}):
+            self.send_forwarding_config_change(new_settings.Forwarding.forwarding_targets)
+        else:
+            self.debug_log(f"{self.DISPLAY_NAME} Forwarding targets NO CHANGE")
+
         if restart_required_fields_diff := self.curr_settings.diff(new_settings, {
             "Network": [
                 "telemetry_port",
@@ -175,7 +181,6 @@ class BackendAppMgr(PngAppMgrBase):
             ],
             "Logging" : [],
             "Privacy" : [],
-            "Forwarding" : [],
             "StreamOverlay" : [],
             "TimeLossInPitsF1": [],
             "TimeLossInPitsF2": [],
@@ -239,6 +244,14 @@ class BackendAppMgr(PngAppMgrBase):
         rsp = ipc_client.request("udp-action-code-change", {"action_code_field": action_code_field, "value": value})
         if not rsp or rsp.get("status") != "success":
             self.error_log(f"Failed to change UDP action code: {rsp}")
+
+    def send_forwarding_config_change(self, targets):
+        """Send updated forwarding targets to the backend without restarting it."""
+        self.debug_log(f"Sending forwarding config change to backend. Targets: {targets}")
+        ipc_client = IpcClientSync(self.ipc_port)
+        rsp = ipc_client.request("forwarding-config-change", {"targets": [list(t) for t in targets]})
+        if not rsp or rsp.get("status") != "success":
+            self.error_log(f"Failed to update forwarding config: {rsp}")
         else:
             self.debug_log(f"Change UDP action code response: {rsp}")
 

--- a/apps/launcher/subsystems/backend_mgr.py
+++ b/apps/launcher/subsystems/backend_mgr.py
@@ -253,7 +253,7 @@ class BackendAppMgr(PngAppMgrBase):
         if not rsp or rsp.get("status") != "success":
             self.error_log(f"Failed to update forwarding config: {rsp}")
         else:
-            self.debug_log(f"Change UDP action code response: {rsp}")
+            self.debug_log(f"Forwarding config change response: {rsp}")
 
     def start_stop_callback(self):
         """Start or stop the backend application."""

--- a/lib/packet_forwarder.py
+++ b/lib/packet_forwarder.py
@@ -25,8 +25,7 @@
 import asyncio
 import socket
 from logging import Logger
-from types import MappingProxyType
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 # -------------------------------------- GLOBALS -----------------------------------------------------------------------
 
@@ -45,40 +44,58 @@ class AsyncUDPTransport:
         self.m_sockets: Dict[Tuple[str, int], socket.socket] = {}
         self.m_logger = logger
 
-        # Only attempt to create sockets if addresses are provided
-        if forward_addresses:
-            for destination in forward_addresses:
-                try:
-                    # Create UDP socket
-                    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                    sock.setblocking(False)  # Non-blocking socket
-
-                    # Connect the socket to the destination (doesn't send data)
-                    sock.connect(destination)
-
-                    # Store socket
-                    self.m_sockets[destination] = sock
-                except OSError as e:
-                    if self.m_logger:
-                        self.m_logger.error("Error creating socket to %s: %s", destination, e)
-                    # Clean up any sockets created so far
-                    self.close()
-                    raise
-
-        # Freeze the dictionaries after initialization
-        self.m_sockets = MappingProxyType(self.m_sockets)
+        for destination in forward_addresses:
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                sock.setblocking(False)
+                sock.connect(destination)
+                self.m_sockets[destination] = sock
+            except OSError as e:
+                if self.m_logger:
+                    self.m_logger.error("Error creating socket to %s: %s", destination, e)
+                self.close()
+                raise
 
     def close(self) -> None:
-        """
-        Safely close all sockets.
-        """
-        for destination, sock in self.m_sockets.items():
+        """Safely close all sockets."""
+        for destination, sock in list(self.m_sockets.items()):
             try:
                 sock.close()
             except OSError as e:
                 if self.m_logger:
                     self.m_logger.error("Error closing socket to %s: %s", destination, e)
+
+    def update_targets(self, new_targets: List[Tuple[str, int]]) -> None:
+        """Update forwarding destinations without restarting the task.
+
+        This method is intentionally synchronous — no await means asyncio's cooperative
+        scheduler cannot interleave it with concurrent send() calls, so no lock is needed.
+        Any in-flight sock_sendall on a removed socket will raise OSError, which
+        _send_to_destination already catches and logs.
+
+        :param new_targets: The complete new list of (host, port) destinations.
+        """
+        new_set: Set[Tuple[str, int]] = set(new_targets)
+        old_set: Set[Tuple[str, int]] = set(self.m_sockets.keys())
+
+        for dest in new_set - old_set:
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                sock.setblocking(False)
+                sock.connect(dest)
+                self.m_sockets[dest] = sock
+            except OSError as e:
+                if self.m_logger:
+                    self.m_logger.error("Error creating socket to %s: %s", dest, e)
                 raise
+
+        for dest in old_set - new_set:
+            old_sock = self.m_sockets.pop(dest)
+            try:
+                old_sock.close()
+            except OSError as e:
+                if self.m_logger:
+                    self.m_logger.error("Error closing socket to %s: %s", dest, e)
 
     async def send(self, data: bytes, destination: Tuple[str, int]) -> None:
         """
@@ -87,12 +104,12 @@ class AsyncUDPTransport:
         :param data: Bytes to send
         :param destination: Destination (IP, Port)
         """
-        if destination not in self.m_sockets:
-            raise ValueError(f"No pre-initialized socket for destination {destination}")
+        sock: Optional[socket.socket] = self.m_sockets.get(destination)
+        if sock is None:
+            return
 
-        # Send asynchronously using the socket
         loop = asyncio.get_running_loop()
-        await loop.sock_sendall(self.m_sockets[destination], data)
+        await loop.sock_sendall(sock, data)
 
 class AsyncUDPForwarder:
     def __init__(self, forward_addresses: List[Tuple[str, int]], logger: Logger = None):
@@ -133,6 +150,14 @@ class AsyncUDPForwarder:
         except OSError as e:
             if self.m_logger:
                 self.m_logger.error("Error forwarding packet to %s: %s", destination, e)
+
+    def update_targets(self, new_targets: List[Tuple[str, int]]) -> None:
+        """Update forwarding destinations at runtime without restarting.
+
+        :param new_targets: The complete new list of (host, port) destinations.
+        """
+        self.m_forward_addresses = new_targets
+        self.m_transport.update_targets(new_targets)
 
     def close(self) -> None:
         """Safely close the transport."""

--- a/lib/packet_forwarder.py
+++ b/lib/packet_forwarder.py
@@ -46,24 +46,36 @@ class AsyncUDPTransport:
 
         for destination in forward_addresses:
             try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                sock.setblocking(False)
-                sock.connect(destination)
-                self.m_sockets[destination] = sock
-            except OSError as e:
-                if self.m_logger:
-                    self.m_logger.error("Error creating socket to %s: %s", destination, e)
+                self._open_socket(destination)
+            except OSError:
                 self.close()
                 raise
 
+    def _open_socket(self, destination: Tuple[str, int]) -> None:
+        """Open a non-blocking UDP socket for destination and add it to m_sockets."""
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.setblocking(False)
+            sock.connect(destination)
+            self.m_sockets[destination] = sock
+        except OSError as e:
+            if self.m_logger:
+                self.m_logger.error("Error creating socket to %s: %s", destination, e)
+            raise
+
+    def _close_socket(self, destination: Tuple[str, int]) -> None:
+        """Pop destination from m_sockets and close its socket."""
+        sock = self.m_sockets.pop(destination)
+        try:
+            sock.close()
+        except OSError as e:
+            if self.m_logger:
+                self.m_logger.error("Error closing socket to %s: %s", destination, e)
+
     def close(self) -> None:
         """Safely close all sockets."""
-        for destination, sock in list(self.m_sockets.items()):
-            try:
-                sock.close()
-            except OSError as e:
-                if self.m_logger:
-                    self.m_logger.error("Error closing socket to %s: %s", destination, e)
+        for destination in list(self.m_sockets.keys()):
+            self._close_socket(destination)
 
     def update_targets(self, new_targets: List[Tuple[str, int]]) -> None:
         """Update forwarding destinations without restarting the task.
@@ -79,23 +91,10 @@ class AsyncUDPTransport:
         old_set: Set[Tuple[str, int]] = set(self.m_sockets.keys())
 
         for dest in new_set - old_set:
-            try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                sock.setblocking(False)
-                sock.connect(dest)
-                self.m_sockets[dest] = sock
-            except OSError as e:
-                if self.m_logger:
-                    self.m_logger.error("Error creating socket to %s: %s", dest, e)
-                raise
+            self._open_socket(dest)
 
         for dest in old_set - new_set:
-            old_sock = self.m_sockets.pop(dest)
-            try:
-                old_sock.close()
-            except OSError as e:
-                if self.m_logger:
-                    self.m_logger.error("Error closing socket to %s: %s", dest, e)
+            self._close_socket(dest)
 
     async def send(self, data: bytes, destination: Tuple[str, int]) -> None:
         """

--- a/lib/packet_forwarder.py
+++ b/lib/packet_forwarder.py
@@ -25,7 +25,7 @@
 import asyncio
 import logging
 import socket
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 # -------------------------------------- GLOBALS -----------------------------------------------------------------------
 
@@ -33,19 +33,17 @@ from typing import Dict, List, Set, Tuple
 
 class AsyncUDPTransport:
     """Abstraction layer for UDP transport management."""
-    def __init__(self, forward_addresses: List[Tuple[str, int]], logger: logging.Logger = None):
+
+    def __init__(self, forward_addresses: List[Tuple[str, int]], logger: logging.Logger):
         """
         Initialize transports for known destinations synchronously.
 
         :param forward_addresses: List of (IP, Port) tuples to initialize transports for
-        :param logger: Logger
+        :param logger: Logger (must be provided by caller)
         """
+        assert logger is not None, "Logger must be provided to AsyncUDPTransport"
         self.m_transports: Dict[Tuple[str, int], asyncio.DatagramTransport] = {}
         self.m_sockets: Dict[Tuple[str, int], socket.socket] = {}
-        if logger is None:
-            logger = logging.getLogger(__name__)
-            logger.addHandler(logging.NullHandler())
-            logger.propagate = False
         self.m_logger = logger
 
         for destination in forward_addresses:
@@ -84,11 +82,6 @@ class AsyncUDPTransport:
     def update_targets(self, new_targets: List[Tuple[str, int]]) -> None:
         """Update forwarding destinations without restarting the task.
 
-        This method is intentionally synchronous — no await means asyncio's cooperative
-        scheduler cannot interleave it with concurrent send() calls, so no lock is needed.
-        Any in-flight sock_sendall on a removed socket will raise OSError, which
-        _send_to_destination already catches and logs.
-
         :param new_targets: The complete new list of (host, port) destinations.
         """
         new_set: Set[Tuple[str, int]] = set(new_targets)
@@ -107,11 +100,15 @@ class AsyncUDPTransport:
         :param data: Bytes to send
         :param destination: Destination (IP, Port)
         """
+        sock = self.m_sockets.get(destination)
+        if sock is None:
+            raise ValueError(f"Destination socket not configured: {destination}")
+
         loop = asyncio.get_running_loop()
-        await loop.sock_sendall(self.m_sockets[destination], data)
+        await loop.sock_sendall(sock, data)
 
 class AsyncUDPForwarder:
-    def __init__(self, forward_addresses: List[Tuple[str, int]], logger: logging.Logger = None):
+    def __init__(self, forward_addresses: List[Tuple[str, int]], logger: Optional[logging.Logger] = None):
         """
         Initializes the AsyncUDPForwarder with forwarding destinations.
 
@@ -122,8 +119,6 @@ class AsyncUDPForwarder:
         self.m_forward_addresses = forward_addresses
         if logger is None:
             logger = logging.getLogger(__name__)
-            logger.addHandler(logging.NullHandler())
-            logger.propagate = False
         self.m_transport = AsyncUDPTransport(forward_addresses, logger)
         self.m_logger = logger
 
@@ -143,7 +138,7 @@ class AsyncUDPForwarder:
 
     async def _send_to_destination(self, data: bytes, destination: Tuple[str, int]) -> None:
         """
-        Send data to a single destination and handle potential OS-level errors.
+        Send data to a single destination and handle potential errors.
 
         :param data: The data to send
         :param destination: The destination (IP, Port)
@@ -152,6 +147,8 @@ class AsyncUDPForwarder:
             await self.m_transport.send(data, destination)
         except OSError as e:
             self.m_logger.error("Error forwarding packet to %s: %s", destination, e)
+        except ValueError as e:
+            self.m_logger.warning("Skipping forward to %s: %s", destination, e)
 
     def update_targets(self, new_targets: List[Tuple[str, int]]) -> None:
         """Update forwarding destinations at runtime without restarting.

--- a/lib/packet_forwarder.py
+++ b/lib/packet_forwarder.py
@@ -23,9 +23,9 @@
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
 import asyncio
+import logging
 import socket
-from logging import Logger
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Set, Tuple
 
 # -------------------------------------- GLOBALS -----------------------------------------------------------------------
 
@@ -33,7 +33,7 @@ from typing import Dict, List, Optional, Set, Tuple
 
 class AsyncUDPTransport:
     """Abstraction layer for UDP transport management."""
-    def __init__(self, forward_addresses: List[Tuple[str, int]], logger: Logger = None):
+    def __init__(self, forward_addresses: List[Tuple[str, int]], logger: logging.Logger = None):
         """
         Initialize transports for known destinations synchronously.
 
@@ -42,6 +42,10 @@ class AsyncUDPTransport:
         """
         self.m_transports: Dict[Tuple[str, int], asyncio.DatagramTransport] = {}
         self.m_sockets: Dict[Tuple[str, int], socket.socket] = {}
+        if logger is None:
+            logger = logging.getLogger(__name__)
+            logger.addHandler(logging.NullHandler())
+            logger.propagate = False
         self.m_logger = logger
 
         for destination in forward_addresses:
@@ -58,9 +62,9 @@ class AsyncUDPTransport:
             sock.setblocking(False)
             sock.connect(destination)
             self.m_sockets[destination] = sock
+            self.m_logger.debug("Opened UDP socket to %s", destination)
         except OSError as e:
-            if self.m_logger:
-                self.m_logger.error("Error creating socket to %s: %s", destination, e)
+            self.m_logger.error("Error creating socket to %s: %s", destination, e)
             raise
 
     def _close_socket(self, destination: Tuple[str, int]) -> None:
@@ -68,9 +72,9 @@ class AsyncUDPTransport:
         sock = self.m_sockets.pop(destination)
         try:
             sock.close()
+            self.m_logger.debug("Closed UDP socket to %s", destination)
         except OSError as e:
-            if self.m_logger:
-                self.m_logger.error("Error closing socket to %s: %s", destination, e)
+            self.m_logger.error("Error closing socket to %s: %s", destination, e)
 
     def close(self) -> None:
         """Safely close all sockets."""
@@ -103,15 +107,11 @@ class AsyncUDPTransport:
         :param data: Bytes to send
         :param destination: Destination (IP, Port)
         """
-        sock: Optional[socket.socket] = self.m_sockets.get(destination)
-        if sock is None:
-            return
-
         loop = asyncio.get_running_loop()
-        await loop.sock_sendall(sock, data)
+        await loop.sock_sendall(self.m_sockets[destination], data)
 
 class AsyncUDPForwarder:
-    def __init__(self, forward_addresses: List[Tuple[str, int]], logger: Logger = None):
+    def __init__(self, forward_addresses: List[Tuple[str, int]], logger: logging.Logger = None):
         """
         Initializes the AsyncUDPForwarder with forwarding destinations.
 
@@ -120,6 +120,10 @@ class AsyncUDPForwarder:
         :param logger: Logger
         """
         self.m_forward_addresses = forward_addresses
+        if logger is None:
+            logger = logging.getLogger(__name__)
+            logger.addHandler(logging.NullHandler())
+            logger.propagate = False
         self.m_transport = AsyncUDPTransport(forward_addresses, logger)
         self.m_logger = logger
 
@@ -147,8 +151,7 @@ class AsyncUDPForwarder:
         try:
             await self.m_transport.send(data, destination)
         except OSError as e:
-            if self.m_logger:
-                self.m_logger.error("Error forwarding packet to %s: %s", destination, e)
+            self.m_logger.error("Error forwarding packet to %s: %s", destination, e)
 
     def update_targets(self, new_targets: List[Tuple[str, int]]) -> None:
         """Update forwarding destinations at runtime without restarting.

--- a/tests/tests_udp_forwarder.py
+++ b/tests/tests_udp_forwarder.py
@@ -125,3 +125,97 @@ class TestAsyncUDPForwarder(F1TelemetryUnitTestsBase):
                 mock_send.assert_any_call(self.test_data, self.forward_addresses[1])
 
         asyncio.run(async_test())
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+class TestAsyncUDPForwarderUpdateTargets(F1TelemetryUnitTestsBase):
+    """Tests for runtime target updates via update_targets()."""
+
+    def setUp(self):
+        self.addr_a = ('127.0.0.1', 21212)
+        self.addr_b = ('127.0.0.1', 21213)
+        self.addr_c = ('127.0.0.1', 21214)
+        self.test_data = bytes(range(64))
+
+    def test_update_targets_add_to_empty(self):
+        """Forwarder starts empty; adding a target makes it forward."""
+        async def async_test():
+            with patch("lib.packet_forwarder.AsyncUDPTransport.send", new_callable=AsyncMock) as mock_send:
+                forwarder = AsyncUDPForwarder([])
+                await forwarder.forward(self.test_data)
+                mock_send.assert_not_called()
+
+                forwarder.update_targets([self.addr_a])
+                await forwarder.forward(self.test_data)
+                mock_send.assert_called_once_with(self.test_data, self.addr_a)
+
+        asyncio.run(async_test())
+
+    def test_update_targets_add_to_existing(self):
+        """Adding a second target results in both being forwarded to."""
+        async def async_test():
+            with patch("lib.packet_forwarder.AsyncUDPTransport.send", new_callable=AsyncMock) as mock_send:
+                forwarder = AsyncUDPForwarder([self.addr_a])
+                forwarder.update_targets([self.addr_a, self.addr_b])
+                await forwarder.forward(self.test_data)
+                self.assertEqual(mock_send.call_count, 2)
+                mock_send.assert_any_call(self.test_data, self.addr_a)
+                mock_send.assert_any_call(self.test_data, self.addr_b)
+
+        asyncio.run(async_test())
+
+    def test_update_targets_remove_target(self):
+        """Removing a target stops forwarding to it."""
+        async def async_test():
+            with patch("lib.packet_forwarder.AsyncUDPTransport.send", new_callable=AsyncMock) as mock_send:
+                forwarder = AsyncUDPForwarder([self.addr_a, self.addr_b])
+                forwarder.update_targets([self.addr_a])
+                await forwarder.forward(self.test_data)
+                mock_send.assert_called_once_with(self.test_data, self.addr_a)
+
+        asyncio.run(async_test())
+
+    def test_update_targets_replace_all(self):
+        """Replacing all targets forwards only to the new set."""
+        async def async_test():
+            with patch("lib.packet_forwarder.AsyncUDPTransport.send", new_callable=AsyncMock) as mock_send:
+                forwarder = AsyncUDPForwarder([self.addr_a])
+                forwarder.update_targets([self.addr_b, self.addr_c])
+                await forwarder.forward(self.test_data)
+                self.assertEqual(mock_send.call_count, 2)
+                mock_send.assert_any_call(self.test_data, self.addr_b)
+                mock_send.assert_any_call(self.test_data, self.addr_c)
+
+        asyncio.run(async_test())
+
+    def test_update_targets_empty_list_disables_forwarding(self):
+        """Setting an empty target list stops all forwarding."""
+        async def async_test():
+            with patch("lib.packet_forwarder.AsyncUDPTransport.send", new_callable=AsyncMock) as mock_send:
+                forwarder = AsyncUDPForwarder([self.addr_a])
+                forwarder.update_targets([])
+                await forwarder.forward(self.test_data)
+                mock_send.assert_not_called()
+
+        asyncio.run(async_test())
+
+    def test_update_targets_unchanged_targets_reuse_socket(self):
+        """Targets that remain across an update keep their socket object."""
+        async def async_test():
+            with patch("lib.packet_forwarder.socket.socket") as mock_sock_cls:
+                mock_sock = MagicMock()
+                mock_sock.connect = MagicMock()
+                mock_sock.setblocking = MagicMock()
+                mock_sock_cls.return_value = mock_sock
+
+                forwarder = AsyncUDPForwarder([self.addr_a])
+                socket_after_init = forwarder.m_transport.m_sockets[self.addr_a]
+
+                # Update: keep addr_a, add addr_b
+                forwarder.update_targets([self.addr_a, self.addr_b])
+                socket_after_update = forwarder.m_transport.m_sockets[self.addr_a]
+
+                self.assertIs(socket_after_init, socket_after_update,
+                              "Unchanged target should reuse its existing socket")
+
+        asyncio.run(async_test())

--- a/tests/tests_udp_forwarder.py
+++ b/tests/tests_udp_forwarder.py
@@ -32,7 +32,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from tests_base import F1TelemetryUnitTestsBase
 
-from lib.packet_forwarder import AsyncUDPForwarder
+from lib.packet_forwarder import AsyncUDPForwarder, AsyncUDPTransport
 
 # ----------------------------------------------------------------------------------------------------------------------
 
@@ -126,6 +126,18 @@ class TestAsyncUDPForwarder(F1TelemetryUnitTestsBase):
 
         asyncio.run(async_test())
 
+    def test_missing_destination_is_handled(self):
+        async def async_test():
+            forwarder = AsyncUDPForwarder(self.forward_addresses)
+            missing_addr = ('10.0.0.1', 9999)
+
+            try:
+                await forwarder._send_to_destination(self.test_data, missing_addr)  # pylint: disable=protected-access
+            except Exception as e:
+                self.fail(f"Unexpected exception for missing destination: {e}")
+
+        asyncio.run(async_test())
+
 # ----------------------------------------------------------------------------------------------------------------------
 
 class TestAsyncUDPForwarderUpdateTargets(F1TelemetryUnitTestsBase):
@@ -203,10 +215,17 @@ class TestAsyncUDPForwarderUpdateTargets(F1TelemetryUnitTestsBase):
         """Targets that remain across an update keep their socket object."""
         async def async_test():
             with patch("lib.packet_forwarder.socket.socket") as mock_sock_cls:
-                mock_sock = MagicMock()
-                mock_sock.connect = MagicMock()
-                mock_sock.setblocking = MagicMock()
-                mock_sock_cls.return_value = mock_sock
+                mock_sock_a = MagicMock()
+                mock_sock_a.connect = MagicMock()
+                mock_sock_a.setblocking = MagicMock()
+                mock_sock_a.close = MagicMock()
+
+                mock_sock_b = MagicMock()
+                mock_sock_b.connect = MagicMock()
+                mock_sock_b.setblocking = MagicMock()
+                mock_sock_b.close = MagicMock()
+
+                mock_sock_cls.side_effect = [mock_sock_a, mock_sock_b]
 
                 forwarder = AsyncUDPForwarder([self.addr_a])
                 socket_after_init = forwarder.m_transport.m_sockets[self.addr_a]
@@ -217,5 +236,57 @@ class TestAsyncUDPForwarderUpdateTargets(F1TelemetryUnitTestsBase):
 
                 self.assertIs(socket_after_init, socket_after_update,
                               "Unchanged target should reuse its existing socket")
+                self.assertEqual(mock_sock_cls.call_count, 2)
+                mock_sock_a.close.assert_not_called()
+
+        asyncio.run(async_test())
+
+
+class TestAsyncUDPForwarderRaceHandling(F1TelemetryUnitTestsBase):
+    """Tests for race-like timing windows between send() and target updates."""
+
+    def setUp(self):
+        self.addr_a = ('127.0.0.1', 21212)
+        self.test_data = bytes(range(32))
+
+    def test_transport_send_raises_when_target_removed_before_execution(self):
+        """If target is removed before send() executes, transport raises ValueError."""
+        async def async_test():
+            transport = AsyncUDPTransport([self.addr_a], logger=MagicMock())
+            try:
+                pending_send = transport.send(self.test_data, self.addr_a)
+                transport.update_targets([])
+
+                with self.assertRaises(ValueError):
+                    await pending_send
+            finally:
+                transport.close()
+
+        asyncio.run(async_test())
+
+    def test_forwarder_handles_hot_swap_while_send_pending(self):
+        """Forwarder swallows ValueError when target disappears during a pending send."""
+        async def async_test():
+            logger = MagicMock()
+            forwarder = AsyncUDPForwarder([self.addr_a], logger=logger)
+            try:
+                release_send = asyncio.Event()
+                original_send = forwarder.m_transport.send
+
+                async def delayed_send(data, destination):
+                    await release_send.wait()
+                    return await original_send(data, destination)
+
+                forwarder.m_transport.send = delayed_send
+
+                task = asyncio.create_task(forwarder.forward(self.test_data))
+                await asyncio.sleep(0)
+                forwarder.update_targets([])
+                release_send.set()
+                await task
+
+                logger.warning.assert_called()
+            finally:
+                forwarder.close()
 
         asyncio.run(async_test())

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -84,7 +84,7 @@ from tests_tyre_wear_extrapolator import (
     TestTyreWearExtrapolatorWithMissingLaps,
     TestTyreWearExtrapolatorWithNonRacingLaps,
     TestTyreWearExtrapolatorWithSCGaps)
-from tests_udp_forwarder import TestAsyncUDPForwarder
+from tests_udp_forwarder import TestAsyncUDPForwarder, TestAsyncUDPForwarderUpdateTargets
 from tests_version import TestGetVersion, TestIsUpdateAvailable
 
 from tests.ipc import (TestIpcParentChild, TestIpcPubSub, TestIpcPubSubAsync,


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

UDP forwarder config changes should happen dynamically in runtime, without having to restart the core
Adding support to the core, lib and the subsystem manager for this.

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [ ] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
<paste result here>
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [ ] My code follows project style conventions
* [ ] All new and existing tests pass
* [ ] I have added relevant documentation/comments
* [ ] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Enable UDP forwarding targets to be updated dynamically at runtime without restarting the backend or forwarder tasks.

New Features:
- Allow AsyncUDPForwarder and AsyncUDPTransport to update forwarding destinations via a new update_targets API.
- Expose a new IPC command and backend handler to apply forwarding config changes from the launcher while the backend is running.

Enhancements:
- Ensure UDP forwarder and transport use default module loggers when none are provided and improve logging around socket lifecycle and forwarding target updates.
- Refactor backend telemetry forwarder setup to return a shared AsyncUDPForwarder instance wired into the telemetry handler for hot-reload support.
- Update backend manager settings handling so changes to forwarding targets no longer require a backend restart.

Tests:
- Add unit tests covering AsyncUDPForwarder.update_targets behavior, including adding, removing, replacing, disabling, and reusing sockets for unchanged targets.