### PR TITLE
feat(hud): make timing tower columns reorderable via config

### DIFF
--- a/apps/hud/ui/overlays/timing_tower/timing_tower.qml
+++ b/apps/hud/ui/overlays/timing_tower/timing_tower.qml
@@ -13,41 +13,56 @@ Window {
     readonly property int colHeaderHeight: 20
     readonly property int margins: 20
 
-    // Column toggle properties - set by Python
-    property bool showTeamLogos: true
-    property bool showTyreInfo: true
-    property bool showDeltas: true
-    property bool showErsDrsInfo: true
-    property bool showPens: true
-
-    property bool showBestLap: false
-    property bool showLastLap: false
-    property bool showWingDmg: false
-    property bool showSpeedTrap: false
-    property bool showFuel: false
-    property bool showDriverStatus: false
     property bool showColHeader: true
 
-    // Dynamic width calculation based on enabled columns
+    // Dynamic column order - set by Python as list of column ID strings
+    // Does not include team_logo (fixed position between pos and name)
+    property var columnOrder: []
+
+    // Column widths keyed by TimingTowerColId enum values
+    QtObject {
+        id: cols
+        readonly property int pos: 30
+        readonly property int team_logo: 25
+        readonly property int name: 120
+        readonly property int delta: 72
+        readonly property int tyre: 58
+        readonly property int ers_drs: 58
+        readonly property int pens: 44
+        readonly property int tl_warns: 32
+        readonly property int best_lap: 75
+        readonly property int last_lap: 72
+        readonly property int wing_dmg: 50
+        readonly property int speed_trap: 75
+        readonly property int fuel: 55
+        readonly property int driver_status: 95
+    }
+
+    // Dynamic width: fixed structural cols + optional team_logo + sum of enabled dynamic cols
     readonly property int baseWidth: {
-        var width = cols.pos + cols.name;
-        if (showTeamLogos) width += cols.team;
-        if (showDeltas) width += cols.delta;
-        if (showTyreInfo) width += cols.tyre;
-        if (showErsDrsInfo) {
-            // DRS bar needs extra space if pens are disabled
-            // In the main layout, it spills into the pens column
-            // this workaround is good enough
-            width += showPens ? cols.ers : cols.ers + 10;
+        var w = cols.pos + cols.name;
+        w += cols.team_logo;
+        for (var i = 0; i < columnOrder.length; ++i) {
+            w += cols[columnOrder[i]];
         }
-        if (showPens) width += cols.pens;
-        if (showBestLap) width += cols.bestLap;
-        if (showLastLap) width += cols.lastLap;
-        if (showWingDmg) width += cols.wingDmg;
-        if (showSpeedTrap) width += cols.speedTrap;
-        if (showFuel) width += cols.fuel;
-        if (showDriverStatus) width += cols.driverStatus;
-        return width + 10; // Add padding
+        return w + 24;
+    }
+
+    function colHeaderLabel(colId) {
+        switch(colId) {
+            case "delta":         return "DELTA"
+            case "tyre":          return "TYRE"
+            case "ers_drs":       return "ERS/DRS"
+            case "pens":          return "PEN"
+            case "tl_warns":      return "TL"
+            case "best_lap":      return "BEST"
+            case "last_lap":      return "LAST"
+            case "wing_dmg":      return "DMG"
+            case "speed_trap":    return "TRAP"
+            case "fuel":          return "FUEL"
+            case "driver_status": return "STATUS"
+            default:              return colId
+        }
     }
 
     readonly property int effectiveRows: Math.min(numRows, tableData.length)
@@ -136,24 +151,6 @@ Window {
                         visible: showError && mode === "race"
                     }
 
-                    // Column widths
-                    QtObject {
-                        id: cols
-                        readonly property int pos: 30
-                        readonly property int team: 25
-                        readonly property int name: 120
-                        readonly property int delta: 72
-                        readonly property int tyre: 58
-                        readonly property int ers: 58
-                        readonly property int pens: 56
-                        readonly property int bestLap: 75
-                        readonly property int lastLap: 72
-                        readonly property int wingDmg: 50
-                        readonly property int speedTrap: 75
-                        readonly property int fuel: 55
-                        readonly property int driverStatus: 95
-                    }
-
                     // Column headers (race mode)
                     Item {
                         id: raceColHeader
@@ -170,141 +167,80 @@ Window {
                             anchors.verticalCenter: parent.verticalCenter
                             height: parent.height
 
-                            Text {
+                            Item {
                                 width: cols.pos
                                 height: parent.height
-                                text: "P"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
+                                Text {
+                                    anchors.fill: parent
+                                    text: "P"
+                                    font.family: "Formula1"
+                                    font.pixelSize: 10
+                                    color: "#666666"
+                                    horizontalAlignment: Text.AlignHCenter
+                                    verticalAlignment: Text.AlignVCenter
+                                }
+                                Rectangle {
+                                    anchors.right: parent.right
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    width: 1
+                                    height: parent.height - 4
+                                    color: Qt.rgba(1, 1, 1, 0.15)
+                                }
                             }
-                            Text {
-                                width: showTeamLogos ? cols.team : 0
+                            // team_logo header: fixed, empty label
+                            Item {
+                                width: cols.team_logo
                                 height: parent.height
-                                text: ""
-                                visible: showTeamLogos
+                                Rectangle {
+                                    anchors.right: parent.right
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    width: 1
+                                    height: parent.height - 4
+                                    color: Qt.rgba(1, 1, 1, 0.15)
+                                }
                             }
-                            Text {
+                            Item {
                                 width: cols.name
                                 height: parent.height
-                                text: "DRIVER"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignLeft
-                                verticalAlignment: Text.AlignVCenter
+                                Text {
+                                    anchors.fill: parent
+                                    text: "DRIVER"
+                                    font.family: "Formula1"
+                                    font.pixelSize: 10
+                                    color: "#666666"
+                                    horizontalAlignment: Text.AlignLeft
+                                    verticalAlignment: Text.AlignVCenter
+                                }
+                                Rectangle {
+                                    anchors.right: parent.right
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    width: 1
+                                    height: parent.height - 4
+                                    color: Qt.rgba(1, 1, 1, 0.15)
+                                }
                             }
-                            Text {
-                                width: showDeltas ? cols.delta : 0
-                                height: parent.height
-                                text: "DELTA"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
-                                visible: showDeltas
-                            }
-                            Text {
-                                width: showTyreInfo ? cols.tyre : 0
-                                height: parent.height
-                                text: "TYRE"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
-                                visible: showTyreInfo
-                            }
-                            Text {
-                                width: showErsDrsInfo ? cols.ers : 0
-                                height: parent.height
-                                text: "ERS/DRS"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
-                                visible: showErsDrsInfo
-                            }
-                            Text {
-                                width: showPens ? cols.pens : 0
-                                height: parent.height
-                                text: "PEN"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignLeft
-                                verticalAlignment: Text.AlignVCenter
-                                visible: showPens
-                            }
-                            Text {
-                                width: showBestLap ? cols.bestLap : 0
-                                height: parent.height
-                                text: "BEST"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
-                                visible: showBestLap
-                            }
-                            Text {
-                                width: showLastLap ? cols.lastLap : 0
-                                height: parent.height
-                                text: "LAST"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
-                                visible: showLastLap
-                            }
-                            Text {
-                                width: showWingDmg ? cols.wingDmg : 0
-                                height: parent.height
-                                text: "DMG"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
-                                visible: showWingDmg
-                            }
-                            Text {
-                                width: showSpeedTrap ? cols.speedTrap : 0
-                                height: parent.height
-                                text: "TRAP"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
-                                visible: showSpeedTrap
-                            }
-                            Text {
-                                width: showFuel ? cols.fuel : 0
-                                height: parent.height
-                                text: "FUEL"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
-                                visible: showFuel
-                            }
-                            Text {
-                                width: showDriverStatus ? cols.driverStatus : 0
-                                height: parent.height
-                                text: "STATUS"
-                                font.family: "Formula1"
-                                font.pixelSize: 10
-                                color: "#666666"
-                                horizontalAlignment: Text.AlignHCenter
-                                verticalAlignment: Text.AlignVCenter
-                                visible: showDriverStatus
+                            Repeater {
+                                model: columnOrder
+                                delegate: Item {
+                                    width: cols[modelData]
+                                    height: parent.height
+                                    Text {
+                                        anchors.fill: parent
+                                        text: colHeaderLabel(modelData)
+                                        font.family: "Formula1"
+                                        font.pixelSize: 10
+                                        color: "#666666"
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                    Rectangle {
+                                        anchors.right: parent.right
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        width: 1
+                                        height: parent.height - 4
+                                        color: Qt.rgba(1, 1, 1, 0.15)
+                                    }
+                                }
                             }
                         }
                     }
@@ -325,13 +261,14 @@ Window {
                         model: tableData
 
                         delegate: Item {
+                            property var rowData: modelData
                             width: tableView.width
                             height: 28
 
                             // Row background
                             Rectangle {
                                 anchors.fill: parent
-                                color: modelData.isReference
+                                color: rowData.isReference
                                     ? Qt.rgba(1, 1, 1, 0.07)
                                     : Qt.rgba(0.08, 0.08, 0.10, 0.6)
                                 radius: 3
@@ -351,7 +288,7 @@ Window {
                                 anchors.verticalCenter: parent.verticalCenter
                                 width: 2
                                 height: parent.height - 6
-                                color: modelData.isReference ? "#ffffff" : "transparent"
+                                color: rowData.isReference ? "#ffffff" : "transparent"
                                 radius: 1
                             }
 
@@ -362,7 +299,7 @@ Window {
                                 height: parent.height
                                 spacing: 0
 
-                                // Position
+                                // Position (fixed)
                                 Item {
                                     width: cols.pos
                                     height: parent.height
@@ -370,13 +307,13 @@ Window {
                                     Rectangle {
                                         anchors.fill: parent
                                         anchors.margins: 1
-                                        color: modelData.isSb ? "#4a1d7a" : "transparent"
+                                        color: rowData.isSb ? "#4a1d7a" : "transparent"
                                         radius: 2
                                     }
 
                                     Text {
                                         anchors.fill: parent
-                                        text: modelData.position < 10 ? modelData.position + " " : modelData.position
+                                        text: rowData.position < 10 ? rowData.position + " " : rowData.position
                                         font.family: "Consolas"
                                         font.pixelSize: 12
                                         color: "#ddd"
@@ -385,11 +322,10 @@ Window {
                                     }
                                 }
 
-                                // Team icon
+                                // Team logo (fixed)
                                 Item {
-                                    width: showTeamLogos ? cols.team : 0
+                                    width: cols.team_logo
                                     height: parent.height
-                                    visible: showTeamLogos
 
                                     Image {
                                         anchors.right: parent.right
@@ -399,7 +335,7 @@ Window {
                                         height: 20
                                         sourceSize.width: width * Screen.devicePixelRatio * 2
                                         sourceSize.height: height * Screen.devicePixelRatio * 2
-                                        source: modelData.teamIcon || ""
+                                        source: rowData.teamIcon || ""
                                         fillMode: Image.PreserveAspectFit
                                         smooth: true
                                         mipmap: true
@@ -408,11 +344,11 @@ Window {
                                     }
                                 }
 
-                                // Driver name
+                                // Driver name (fixed)
                                 Text {
                                     width: cols.name
                                     height: parent.height
-                                    text: modelData.name
+                                    text: rowData.name
                                     font.family: "Formula1"
                                     font.pixelSize: 13
                                     color: "#ffffff"
@@ -421,215 +357,226 @@ Window {
                                     elide: Text.ElideRight
                                 }
 
-                                // Delta
-                                Text {
-                                    width: showDeltas ? cols.delta : 0
-                                    height: parent.height
-                                    text: modelData.delta
-                                    font.family: "Consolas"
-                                    font.pixelSize: 13
-                                    color: "#ffffff"
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
-                                    visible: showDeltas
-                                }
+                                // Dynamic columns
+                                Repeater {
+                                    model: columnOrder
+                                    delegate: Item {
+                                        property string colId: modelData
+                                        width: cols[colId]
+                                        height: parent.height
 
-                                // Tyre
-                                Item {
-                                    width: showTyreInfo ? cols.tyre : 0
-                                    height: parent.height
-                                    visible: showTyreInfo
-
-                                    Row {
-                                        anchors.centerIn: parent
-                                        spacing: 4
-
-                                        Image {
-                                            width: 20
-                                            height: 20
-                                            sourceSize.width: width * Screen.devicePixelRatio
-                                            sourceSize.height: height * Screen.devicePixelRatio
-                                            source: modelData.tyreIcon || ""
-                                            fillMode: Image.PreserveAspectFit
-                                            smooth: true
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            cache: true
-                                            antialiasing: true
-                                        }
-
+                                        // delta
                                         Text {
-                                            text: modelData.tyreWear
+                                            anchors.fill: parent
+                                            visible: colId === "delta"
+                                            text: rowData.delta
                                             font.family: "Consolas"
                                             font.pixelSize: 13
                                             color: "#ffffff"
-                                            anchors.verticalCenter: parent.verticalCenter
+                                            horizontalAlignment: Text.AlignHCenter
+                                            verticalAlignment: Text.AlignVCenter
                                         }
-                                    }
-                                }
 
-                                // ERS/DRS
-                                Item {
-                                    width: showErsDrsInfo ? cols.ers : 0
-                                    height: parent.height
-                                    visible: showErsDrsInfo
+                                        // tyre
+                                        Item {
+                                            anchors.fill: parent
+                                            visible: colId === "tyre"
 
-                                    // ERS mode strip (left)
-                                    Rectangle {
-                                        anchors.left: parent.left
-                                        anchors.leftMargin: 1
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        width: 6
-                                        height: parent.height - 8
-                                        radius: 2
-                                        color: {
-                                            switch(modelData.ersMode) {
-                                                case "Medium": return "#e6d800"
-                                                case "Hotlap": return "#00e676"
-                                                case "Overtake": return "#ff1744"
-                                                default: return "#444444"
+                                            Row {
+                                                anchors.centerIn: parent
+                                                spacing: 4
+
+                                                Image {
+                                                    width: 20
+                                                    height: 20
+                                                    sourceSize.width: width * Screen.devicePixelRatio
+                                                    sourceSize.height: height * Screen.devicePixelRatio
+                                                    source: rowData.tyreIcon || ""
+                                                    fillMode: Image.PreserveAspectFit
+                                                    smooth: true
+                                                    anchors.verticalCenter: parent.verticalCenter
+                                                    cache: true
+                                                    antialiasing: true
+                                                }
+
+                                                Text {
+                                                    text: rowData.tyreWear
+                                                    font.family: "Consolas"
+                                                    font.pixelSize: 13
+                                                    color: "#ffffff"
+                                                    anchors.verticalCenter: parent.verticalCenter
+                                                }
                                             }
                                         }
-                                    }
 
-                                    // ERS text (center)
-                                    Text {
-                                        anchors.centerIn: parent
-                                        text: modelData.ers
-                                        font.family: "Consolas"
-                                        font.pixelSize: 13
-                                        color: "#dddddd"
-                                        horizontalAlignment: Text.AlignHCenter
-                                        verticalAlignment: Text.AlignVCenter
-                                    }
+                                        // ers_drs
+                                        Item {
+                                            anchors.fill: parent
+                                            visible: colId === "ers_drs"
 
-                                    // DRS strip (right)
-                                    Rectangle {
-                                        anchors.right: parent.right
-                                        anchors.rightMargin: 1
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        width: 6
-                                        height: parent.height - 8
-                                        radius: 2
-                                        color: modelData.drs ? "#00e676" : "#333333"
-                                    }
-                                }
+                                            // ERS mode strip (left)
+                                            Rectangle {
+                                                anchors.left: parent.left
+                                                anchors.leftMargin: 1
+                                                anchors.verticalCenter: parent.verticalCenter
+                                                width: 6
+                                                height: parent.height - 8
+                                                radius: 2
+                                                color: {
+                                                    switch(rowData.ersMode) {
+                                                        case "Medium":   return "#e6d800"
+                                                        case "Hotlap":   return "#00e676"
+                                                        case "Overtake": return "#ff1744"
+                                                        default:         return "#444444"
+                                                    }
+                                                }
+                                            }
 
-                                // Penalties
-                                Rectangle {
-                                    width: showPens ? cols.pens : 0
-                                    height: parent.height
-                                    color: "transparent"
-                                    visible: showPens
+                                            // ERS text (center)
+                                            Text {
+                                                anchors.centerIn: parent
+                                                text: rowData.ers
+                                                font.family: "Consolas"
+                                                font.pixelSize: 13
+                                                color: "#dddddd"
+                                                horizontalAlignment: Text.AlignHCenter
+                                                verticalAlignment: Text.AlignVCenter
+                                            }
 
-                                    Text {
-                                        anchors.left: parent.left
-                                        anchors.leftMargin: 4
-                                        anchors.verticalCenter: parent.verticalCenter
-                                        text: modelData.penalties
-                                        font.family: "Formula1"
-                                        font.pixelSize: 11
-                                        color: "white"
-                                        horizontalAlignment: Text.AlignLeft
-                                        verticalAlignment: Text.AlignVCenter
-                                        wrapMode: Text.NoWrap
-                                        elide: Text.ElideRight
-                                    }
-                                }
+                                            // DRS strip (right)
+                                            Rectangle {
+                                                anchors.right: parent.right
+                                                anchors.rightMargin: 1
+                                                anchors.verticalCenter: parent.verticalCenter
+                                                width: 6
+                                                height: parent.height - 8
+                                                radius: 2
+                                                color: rowData.drs ? "#00e676" : "#333333"
+                                            }
+                                        }
 
-                                // Best Lap
-                                Text {
-                                    width: showBestLap ? cols.bestLap : 0
-                                    height: parent.height
-                                    text: modelData.bestLap
-                                    font.family: "Consolas"
-                                    font.pixelSize: 12
-                                    color: modelData.isSb ? "#c084fc" : "#dddddd"
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
-                                    visible: showBestLap
-                                }
+                                        // pens
+                                        Item {
+                                            anchors.fill: parent
+                                            visible: colId === "pens"
 
-                                // Last Lap
-                                Text {
-                                    width: showLastLap ? cols.lastLap : 0
-                                    height: parent.height
-                                    text: modelData.lastLap
-                                    font.family: "Consolas"
-                                    font.pixelSize: 12
-                                    color: {
-                                        if (!modelData.isPb) return "#dddddd";
-                                        return modelData.isSb ? "#c084fc" : "#44dd88";
-                                    }
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
-                                    visible: showLastLap
-                                }
+                                            Text {
+                                                anchors.left: parent.left
+                                                anchors.leftMargin: 4
+                                                anchors.verticalCenter: parent.verticalCenter
+                                                text: rowData.penalties
+                                                font.family: "Formula1"
+                                                font.pixelSize: 11
+                                                color: "white"
+                                                horizontalAlignment: Text.AlignLeft
+                                                verticalAlignment: Text.AlignVCenter
+                                                wrapMode: Text.NoWrap
+                                                elide: Text.ElideRight
+                                            }
+                                        }
 
-                                // Wing Damage
-                                Text {
-                                    width: showWingDmg ? cols.wingDmg : 0
-                                    height: parent.height
-                                    text: modelData.wingDmg
-                                    font.family: "Consolas"
-                                    font.pixelSize: 12
-                                    color: modelData.wingDmg === "N/A" ? "#666666" : "#ff9944"
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
-                                    visible: showWingDmg
-                                }
+                                        // tl_warns
+                                        Text {
+                                            anchors.fill: parent
+                                            visible: colId === "tl_warns"
+                                            text: rowData.tlWarns !== undefined ? rowData.tlWarns : "---"
+                                            font.family: "Consolas"
+                                            font.pixelSize: 13
+                                            color: "#dddddd"
+                                            horizontalAlignment: Text.AlignHCenter
+                                            verticalAlignment: Text.AlignVCenter
+                                        }
 
-                                // Speed Trap
-                                Text {
-                                    width: showSpeedTrap ? cols.speedTrap : 0
-                                    height: parent.height
-                                    text: modelData.speedTrap
-                                    font.family: "Consolas"
-                                    font.pixelSize: 12
-                                    color: "#dddddd"
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
-                                    visible: showSpeedTrap
-                                }
+                                        // best_lap
+                                        Text {
+                                            anchors.fill: parent
+                                            visible: colId === "best_lap"
+                                            text: rowData.bestLap
+                                            font.family: "Consolas"
+                                            font.pixelSize: 12
+                                            color: rowData.isSb ? "#c084fc" : "#dddddd"
+                                            horizontalAlignment: Text.AlignHCenter
+                                            verticalAlignment: Text.AlignVCenter
+                                        }
 
-                                // Fuel
-                                Text {
-                                    width: showFuel ? cols.fuel : 0
-                                    height: parent.height
-                                    text: modelData.fuel
-                                    font.family: "Consolas"
-                                    font.pixelSize: 12
-                                    color: {
-                                        var f = modelData.fuel;
-                                        if (f === "N/A" || f === "---") return "#666666";
-                                        return f.charAt(0) === "-" ? "#ff4444" : "#44dd88";
-                                    }
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
-                                    visible: showFuel
-                                }
+                                        // last_lap
+                                        Text {
+                                            anchors.fill: parent
+                                            visible: colId === "last_lap"
+                                            text: rowData.lastLap
+                                            font.family: "Consolas"
+                                            font.pixelSize: 12
+                                            color: {
+                                                if (!rowData.isPb) return "#dddddd";
+                                                return rowData.isSb ? "#c084fc" : "#44dd88";
+                                            }
+                                            horizontalAlignment: Text.AlignHCenter
+                                            verticalAlignment: Text.AlignVCenter
+                                        }
 
-                                // Driver Status
-                                Text {
-                                    width: showDriverStatus ? cols.driverStatus : 0
-                                    height: parent.height
-                                    text: modelData.driverStatus
-                                    font.family: "Formula1"
-                                    font.pixelSize: 10
-                                    color: {
-                                        switch(modelData.driverStatus) {
-                                            case "Flying Lap": return "#00e676"
-                                            case "On Track": return "#aaaaaa"
-                                            case "Out Lap": return "#e6d800"
-                                            case "In Lap": return "#e6d800"
-                                            case "In Garage": return "#555555"
-                                            case "Retired": return "#ff4444"
-                                            default: return "#666666"
+                                        // wing_dmg
+                                        Text {
+                                            anchors.fill: parent
+                                            visible: colId === "wing_dmg"
+                                            text: rowData.wingDmg
+                                            font.family: "Consolas"
+                                            font.pixelSize: 12
+                                            color: rowData.wingDmg === "N/A" ? "#666666" : "#ff9944"
+                                            horizontalAlignment: Text.AlignHCenter
+                                            verticalAlignment: Text.AlignVCenter
+                                        }
+
+                                        // speed_trap
+                                        Text {
+                                            anchors.fill: parent
+                                            visible: colId === "speed_trap"
+                                            text: rowData.speedTrap
+                                            font.family: "Consolas"
+                                            font.pixelSize: 12
+                                            color: "#dddddd"
+                                            horizontalAlignment: Text.AlignHCenter
+                                            verticalAlignment: Text.AlignVCenter
+                                        }
+
+                                        // fuel
+                                        Text {
+                                            anchors.fill: parent
+                                            visible: colId === "fuel"
+                                            text: rowData.fuel
+                                            font.family: "Consolas"
+                                            font.pixelSize: 12
+                                            color: {
+                                                var f = rowData.fuel;
+                                                if (f === "N/A" || f === "---") return "#666666";
+                                                return f.charAt(0) === "-" ? "#ff4444" : "#44dd88";
+                                            }
+                                            horizontalAlignment: Text.AlignHCenter
+                                            verticalAlignment: Text.AlignVCenter
+                                        }
+
+                                        // driver_status
+                                        Text {
+                                            anchors.fill: parent
+                                            visible: colId === "driver_status"
+                                            text: rowData.driverStatus
+                                            font.family: "Formula1"
+                                            font.pixelSize: 10
+                                            color: {
+                                                switch(rowData.driverStatus) {
+                                                    case "Flying Lap": return "#00e676"
+                                                    case "On Track":   return "#aaaaaa"
+                                                    case "Out Lap":    return "#e6d800"
+                                                    case "In Lap":     return "#e6d800"
+                                                    case "In Garage":  return "#555555"
+                                                    case "Retired":    return "#ff4444"
+                                                    default:           return "#666666"
+                                                }
+                                            }
+                                            horizontalAlignment: Text.AlignHCenter
+                                            verticalAlignment: Text.AlignVCenter
+                                            elide: Text.ElideRight
                                         }
                                     }
-                                    horizontalAlignment: Text.AlignHCenter
-                                    verticalAlignment: Text.AlignVCenter
-                                    elide: Text.ElideRight
-                                    visible: showDriverStatus
                                 }
                             }
                         }

--- a/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
+++ b/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
@@ -34,7 +34,7 @@ from apps.hud.ui.overlays.base import BaseOverlayQML
 from lib.assets_loader import (load_team_logos_uri_dict,
                                load_tyre_icons_uri_dict)
 from lib.config import (OverlayId, OverlayPosition, OverlaysFuelEstimationMode,
-                        OverlaysSpeedUnit, TimingTowerColId, TimingTowerColOptions)
+                        OverlaysSpeedUnit, TimingTowerColOptions)
 from lib.f1_types import F1Utils
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
@@ -80,10 +80,8 @@ class TimingTowerOverlay(BaseOverlayQML):
         self.show_col_header = tt_col_options.show_col_header
         self.speed_unit = speed_unit
 
-        # team_logo is a fixed-position column rendered outside columnOrder
         self.column_order: List[str] = [
             col_id for col_id, _ in tt_col_options.sorted_enabled_cols()
-            if col_id != TimingTowerColId.TEAM_LOGO.value
         ]
         self.fuel_est_mode = fuel_est_mode
 

--- a/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
+++ b/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
@@ -79,8 +79,11 @@ class TimingTowerOverlay(BaseOverlayQML):
 
         self.show_col_header = tt_col_options.show_col_header
         self.speed_unit = speed_unit
-        self.column_order: List[TimingTowerColId] = [
+
+        # team_logo is a fixed-position column rendered outside columnOrder
+        self.column_order: List[str] = [
             col_id for col_id, _ in tt_col_options.sorted_enabled_cols()
+            if col_id != TimingTowerColId.TEAM_LOGO.value
         ]
         self.fuel_est_mode = fuel_est_mode
 
@@ -276,6 +279,7 @@ class TimingTowerOverlay(BaseOverlayQML):
             "ersMode": ers_info.get("ers-mode", "None"),
             "drs": driver_info.get("drs", False),
             "penalties": self._format_penalties(warns_pens_info),
+            "tlWarns": warns_pens_info.get("corner-cutting-warnings", 0),
             "isReference": driver_idx == ref_index,
 
             "bestLap": self._format_lap_time(best_lap_ms),

--- a/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
+++ b/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
@@ -34,7 +34,7 @@ from apps.hud.ui.overlays.base import BaseOverlayQML
 from lib.assets_loader import (load_team_logos_uri_dict,
                                load_tyre_icons_uri_dict)
 from lib.config import (OverlayId, OverlayPosition, OverlaysFuelEstimationMode,
-                        OverlaysSpeedUnit, TimingTowerColOptions)
+                        OverlaysSpeedUnit, TimingTowerColId, TimingTowerColOptions)
 from lib.f1_types import F1Utils
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
@@ -79,21 +79,9 @@ class TimingTowerOverlay(BaseOverlayQML):
 
         self.show_col_header = tt_col_options.show_col_header
         self.speed_unit = speed_unit
-
-        self.show_team_logos = tt_col_options.show_team_logos
-        self.show_tyre_info = tt_col_options.show_tyre_info
-        self.show_deltas = tt_col_options.show_deltas
-        self.show_ers_drs_info = tt_col_options.show_ers_drs_info
-        self.show_pens = tt_col_options.show_pens
-        self.show_tl_warns = tt_col_options.show_tl_warns
-
-        self.show_best_lap = tt_col_options.show_best_lap
-        self.show_last_lap = tt_col_options.show_last_lap
-        self.show_wing_dmg = tt_col_options.show_wing_dmg
-        self.show_speed_trap = tt_col_options.show_speed_trap
-        self.show_fuel = tt_col_options.show_fuel
-        self.show_driver_status = tt_col_options.show_driver_status
-
+        self.column_order: List[TimingTowerColId] = [
+            col_id for col_id, _ in tt_col_options.sorted_enabled_cols()
+        ]
         self.fuel_est_mode = fuel_est_mode
 
         self.team_logo_uris: defaultdict[str, str] = defaultdict(str)
@@ -121,18 +109,7 @@ class TimingTowerOverlay(BaseOverlayQML):
     def post_setup(self):
         """Set QML properties after the window is ready."""
         self.set_qml_property("numRows", self.total_rows)
-        self.set_qml_property("showTeamLogos", self.show_team_logos)
-        self.set_qml_property("showTyreInfo", self.show_tyre_info)
-        self.set_qml_property("showDeltas", self.show_deltas)
-        self.set_qml_property("showErsDrsInfo", self.show_ers_drs_info)
-        self.set_qml_property("showPens", self.show_pens)
-
-        self.set_qml_property("showBestLap", self.show_best_lap)
-        self.set_qml_property("showLastLap", self.show_last_lap)
-        self.set_qml_property("showWingDmg", self.show_wing_dmg)
-        self.set_qml_property("showSpeedTrap", self.show_speed_trap)
-        self.set_qml_property("showFuel", self.show_fuel)
-        self.set_qml_property("showDriverStatus", self.show_driver_status)
+        self.set_qml_property("columnOrder", self.column_order)
         self.set_qml_property("showColHeader", self.show_col_header)
 
         self._set_race_mode()
@@ -397,10 +374,6 @@ class TimingTowerOverlay(BaseOverlayQML):
 
         if pens_sec > 0:
             return f"+{pens_sec}s"
-
-        if self.show_tl_warns:
-            tl_warns = warns_pens_info.get("corner-cutting-warnings", 0)
-            return f"TL: {tl_warns}"
 
         return ""
 

--- a/apps/launcher/gui/settings/reorderable_collection.py
+++ b/apps/launcher/gui/settings/reorderable_collection.py
@@ -36,6 +36,19 @@ class ReorderableCollection:
         self.is_reorderable = ui_config.get("reorderable_collection", False)
         self.enabled_field = ui_config.get("item_enabled_field", "enabled")
         self.position_field = ui_config.get("item_position_field", "position")
+        self.label_field = ui_config.get("item_label_field", None)
+
+    def get_label(self, item_name: str, item: Any) -> str:
+        """Return the display label for an item.
+
+        Uses the label_field attribute on the item when configured; falls back to
+        converting the dict key from snake_case to Title Case.
+        """
+        if self.label_field:
+            label = getattr(item, self.label_field, None)
+            if label:
+                return label
+        return item_name.replace("_", " ").title()
 
     def get_enabled(self, item: Any) -> bool:
         """Get enabled state from an item"""

--- a/apps/launcher/gui/settings/settings.py
+++ b/apps/launcher/gui/settings/settings.py
@@ -360,6 +360,7 @@ class SettingsWindow(QDialog):
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll.setStyleSheet("QScrollBar:vertical { width: 12px; }")
 
         content_widget = QWidget()
         layout = QVBoxLayout()
@@ -950,7 +951,7 @@ class SettingsWindow(QDialog):
         # Enabled checkbox
         item_path = f"{parent_path}.{item_name}"
         enabled_path = f"{item_path}.{collection_meta.enabled_field}"
-        enabled_cb = QCheckBox(item_name.replace("_", " ").title())
+        enabled_cb = QCheckBox(collection_meta.get_label(item_name, item_settings))
         enabled_cb.setFont(QFont("Roboto", 10))
         enabled_cb.setChecked(collection_meta.get_enabled(item_settings))
         enabled_cb.stateChanged.connect(
@@ -1025,7 +1026,7 @@ class SettingsWindow(QDialog):
         # Enabled checkbox
         item_path = f"{parent_path}.{item_name}"
         enabled_path = f"{item_path}.{collection_meta.enabled_field}"
-        enabled_cb = QCheckBox(item_name.replace("_", " ").title())
+        enabled_cb = QCheckBox(collection_meta.get_label(item_name, item_settings))
         enabled_cb.setFont(QFont("Exo 2", 10))
         enabled_cb.setChecked(collection_meta.get_enabled(item_settings))
         enabled_cb.stateChanged.connect(

--- a/lib/config/__init__.py
+++ b/lib/config/__init__.py
@@ -32,7 +32,8 @@ from .schema import (CaptureSettings, DisplaySettings, ForwardingSettings,
                      NetworkSettings, OverlayId, OverlayPosition,
                      PitTimeLossF1, PitTimeLossF2, PngSettings,
                      PredictionSettings, PrivacySettings,
-                     StreamOverlaySettings, SubSysCtrl, TimingTowerColOptions,
+                     StreamOverlaySettings, SubSysCtrl, TimingTowerColId,
+                     TimingTowerColOptions, TimingTowerColSettings,
                      WeatherMFDUIType)
 from .types import FilePathStr
 
@@ -55,7 +56,9 @@ __all__ = [
     'MfdPageId',
     'MfdSettings',
     'MfdPageSettings',
+    'TimingTowerColId',
     'TimingTowerColOptions',
+    'TimingTowerColSettings',
     'WeatherMFDUIType',
     'MfdTyreWearRateType',
     'OverlaysSpeedUnit',

--- a/lib/config/schema/__init__.py
+++ b/lib/config/schema/__init__.py
@@ -29,7 +29,9 @@ from .https import HttpsSettings
 from .hud import (OverlaysFuelEstimationMode, OverlaysSpeedUnit,
                   HudSettings, MfdPageId, MfdPageSettings, MfdSettings,
                   MfdTyreWearRateType, OverlayId, OverlayPosition,
-                  TimingTowerColOptions, WeatherMFDUIType)
+                  TimingTowerColId, TimingTowerColOptions,
+                  TimingTowerColSettings,
+                  WeatherMFDUIType)
 from .network import NetworkSettings
 from .pit_time_loss_f1 import PitTimeLossF1
 from .pit_time_loss_f2 import PitTimeLossF2
@@ -50,7 +52,9 @@ __all__ = [
     'MfdPageId',
     'MfdSettings',
     'MfdPageSettings',
+    'TimingTowerColId',
     'TimingTowerColOptions',
+    'TimingTowerColSettings',
     'OverlayPosition',
     'NetworkSettings',
     'PitTimeLossF1',

--- a/lib/config/schema/hud/__init__.py
+++ b/lib/config/schema/hud/__init__.py
@@ -26,7 +26,8 @@ from .hud import (OverlaysFuelEstimationMode, OverlaysSpeedUnit,
                   HudSettings, MfdTyreWearRateType, WeatherMFDUIType)
 from .layout import OverlayId, OverlayPosition
 from .mfd import MfdPageId, MfdPageSettings, MfdSettings
-from .timing_tower import TimingTowerColOptions
+from .timing_tower import (TimingTowerColId, TimingTowerColOptions,
+                           TimingTowerColSettings)
 
 # -------------------------------------- EXPORTS -----------------------------------------------------------------------
 
@@ -40,7 +41,9 @@ __all__ = [
     'MfdSettings',
     'MfdPageSettings',
     'OverlayPosition',
+    'TimingTowerColId',
     'TimingTowerColOptions',
+    'TimingTowerColSettings',
 
     'OverlayId',
 

--- a/lib/config/schema/hud/timing_tower.py
+++ b/lib/config/schema/hud/timing_tower.py
@@ -103,7 +103,7 @@ class TimingTowerColOptions(ConfigDiffMixin, BaseModel):
         json_schema_extra={"ui": {"type": "check_box"}}
     )
 
-    cols: Dict[str, TimingTowerColSettings] = Field(
+    cols: Dict[TimingTowerColId, TimingTowerColSettings] = Field(
         default_factory=lambda: copy.deepcopy(DEFAULT_COLS),
         description="Column visibility and order",
         json_schema_extra={
@@ -144,8 +144,7 @@ class TimingTowerColOptions(ConfigDiffMixin, BaseModel):
         used_positions = {col.position for col in merged.values()}
 
         for col_id, default_col in DEFAULT_COLS.items():
-            key = col_id.value if isinstance(col_id, TimingTowerColId) else col_id
-            if key not in merged:
+            if col_id not in merged:
                 new_col = default_col.model_copy(deep=True)
                 new_col.enabled = False
                 pos = new_col.position
@@ -153,7 +152,7 @@ class TimingTowerColOptions(ConfigDiffMixin, BaseModel):
                     pos += 1
                 new_col.position = pos
                 used_positions.add(pos)
-                merged[key] = new_col
+                merged[col_id] = new_col
 
         self.cols = merged
         return self
@@ -167,12 +166,11 @@ class TimingTowerColOptions(ConfigDiffMixin, BaseModel):
         description onto every column so callers can read col.description at runtime.
         """
         for col_id, default_col in DEFAULT_COLS.items():
-            key = col_id.value if isinstance(col_id, TimingTowerColId) else col_id
-            if key in self.cols:
-                self.cols[key].description = default_col.description
+            if col_id in self.cols:
+                self.cols[col_id].description = default_col.description
         return self
 
-    def sorted_enabled_cols(self) -> List[Tuple[str, TimingTowerColSettings]]:
+    def sorted_enabled_cols(self) -> List[Tuple[TimingTowerColId, TimingTowerColSettings]]:
         """Return enabled columns sorted by position, ascending."""
         return sorted(
             [(col_id, col) for col_id, col in self.cols.items() if col.enabled],

--- a/lib/config/schema/hud/timing_tower.py
+++ b/lib/config/schema/hud/timing_tower.py
@@ -103,7 +103,7 @@ class TimingTowerColOptions(ConfigDiffMixin, BaseModel):
         json_schema_extra={"ui": {"type": "check_box"}}
     )
 
-    cols: Dict[TimingTowerColId, TimingTowerColSettings] = Field(
+    cols: Dict[str, TimingTowerColSettings] = Field(
         default_factory=lambda: copy.deepcopy(DEFAULT_COLS),
         description="Column visibility and order",
         json_schema_extra={
@@ -144,7 +144,7 @@ class TimingTowerColOptions(ConfigDiffMixin, BaseModel):
         used_positions = {col.position for col in merged.values()}
 
         for col_id, default_col in DEFAULT_COLS.items():
-            if col_id not in merged:
+            if col_id.value not in merged:
                 new_col = default_col.model_copy(deep=True)
                 new_col.enabled = False
                 pos = new_col.position
@@ -152,7 +152,7 @@ class TimingTowerColOptions(ConfigDiffMixin, BaseModel):
                     pos += 1
                 new_col.position = pos
                 used_positions.add(pos)
-                merged[col_id] = new_col
+                merged[col_id.value] = new_col
 
         self.cols = merged
         return self
@@ -166,11 +166,11 @@ class TimingTowerColOptions(ConfigDiffMixin, BaseModel):
         description onto every column so callers can read col.description at runtime.
         """
         for col_id, default_col in DEFAULT_COLS.items():
-            if col_id in self.cols:
-                self.cols[col_id].description = default_col.description
+            if col_id.value in self.cols:
+                self.cols[col_id.value].description = default_col.description
         return self
 
-    def sorted_enabled_cols(self) -> List[Tuple[TimingTowerColId, TimingTowerColSettings]]:
+    def sorted_enabled_cols(self) -> List[Tuple[str, TimingTowerColSettings]]:
         """Return enabled columns sorted by position, ascending."""
         return sorted(
             [(col_id, col) for col_id, col in self.cols.items() if col.enabled],

--- a/lib/config/schema/hud/timing_tower.py
+++ b/lib/config/schema/hud/timing_tower.py
@@ -22,11 +22,78 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
-from pydantic import BaseModel, Field
+import copy
+from enum import Enum
+from typing import Any, ClassVar, Dict, List, Tuple
+
+from pydantic import BaseModel, Field, model_validator
 
 from ..diff import ConfigDiffMixin
 
+# ------------------------------------- CONSTANTS ----------------------------------------------------------------------
+
+class TimingTowerColId(str, Enum):
+    TEAM_LOGO     = "team_logo"
+    DELTA         = "delta"
+    TYRE          = "tyre"
+    ERS_DRS       = "ers_drs"
+    PENS          = "pens"
+    TL_WARNS      = "tl_warns"
+    BEST_LAP      = "best_lap"
+    LAST_LAP      = "last_lap"
+    WING_DMG      = "wing_dmg"
+    SPEED_TRAP    = "speed_trap"
+    FUEL          = "fuel"
+    DRIVER_STATUS = "driver_status"
+
 # -------------------------------------- CLASS  DEFINITIONS ------------------------------------------------------------
+
+class TimingTowerColSettings(ConfigDiffMixin, BaseModel):
+    ui_meta: ClassVar[Dict[str, Any]] = {"visible": True}
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable this column",
+        json_schema_extra={"ui": {"type": "check_box", "visible": True}},
+    )
+
+    position: int = Field(
+        gt=0,
+        description="Ordering index",
+        json_schema_extra={"ui": {"type": "text_box", "visible": True}},
+    )
+
+    # Not stored in JSON — filled at runtime from DEFAULT_COLS by TimingTowerColOptions.fill_col_descriptions.
+    description: str = Field(default="", exclude=True)
+
+
+DEFAULT_COLS: Dict[TimingTowerColId, "TimingTowerColSettings"] = {
+    TimingTowerColId.TEAM_LOGO: TimingTowerColSettings(
+        enabled=True,  position=1,  description="Team logo"),
+    TimingTowerColId.DELTA: TimingTowerColSettings(
+        enabled=True,  position=2,  description="Delta"),
+    TimingTowerColId.TYRE: TimingTowerColSettings(
+        enabled=True,  position=3,  description="Tyre compound and wear"),
+    TimingTowerColId.ERS_DRS: TimingTowerColSettings(
+        enabled=True,  position=4,  description="ERS / DRS"),
+    TimingTowerColId.PENS: TimingTowerColSettings(
+        enabled=True,  position=5,  description="Penalties"),
+    TimingTowerColId.TL_WARNS: TimingTowerColSettings(
+        enabled=True,  position=6,  description="Track Limit warnings"),
+    TimingTowerColId.BEST_LAP: TimingTowerColSettings(
+        enabled=False, position=7,  description="Best Lap"),
+    TimingTowerColId.LAST_LAP: TimingTowerColSettings(
+        enabled=False, position=8,  description="Last Lap"),
+    TimingTowerColId.WING_DMG: TimingTowerColSettings(
+        enabled=False, position=9,  description="Front Wing Damage"),
+    TimingTowerColId.SPEED_TRAP: TimingTowerColSettings(
+        enabled=False, position=10, description="Speed Trap"),
+    TimingTowerColId.FUEL: TimingTowerColSettings(
+        enabled=False, position=11, description="Fuel level (surplus laps)"),
+    TimingTowerColId.DRIVER_STATUS: TimingTowerColSettings(
+        enabled=False, position=12,
+        description="Driver status (e.g., IN_GARAGE, FLYING_LAP"),
+}
 
 class TimingTowerColOptions(ConfigDiffMixin, BaseModel):
 
@@ -36,81 +103,78 @@ class TimingTowerColOptions(ConfigDiffMixin, BaseModel):
         json_schema_extra={"ui": {"type": "check_box"}}
     )
 
-    show_team_logos: bool = Field(
-        default=True,
-        description="Show team logos",
-        json_schema_extra={"ui": {"type": "check_box"}}
-    )
-
-    show_tyre_info: bool = Field(
-        default=True,
-        description="Show tyre compound and wear information",
-        json_schema_extra={"ui": {"type": "check_box"}}
-    )
-
-    show_deltas: bool = Field(
-        default=True,
-        description="Show time deltas",
-        json_schema_extra={"ui": {"type": "check_box"}}
-    )
-
-    show_ers_drs_info: bool = Field(
-        default=True,
-        description="Show ERS / DRS status",
-        json_schema_extra={"ui": {"type": "check_box"}}
-    )
-
-    show_pens: bool = Field(
-        default=True,
-        description="Show penalties",
-        json_schema_extra={"ui": {"type": "check_box"}}
-    )
-
-    show_tl_warns: bool = Field(
-        default=True,
-        description="Show Track Limit warnings",
+    cols: Dict[str, TimingTowerColSettings] = Field(
+        default_factory=lambda: copy.deepcopy(DEFAULT_COLS),
+        description="Column visibility and order",
         json_schema_extra={
             "ui": {
-                "type": "check_box",
-                "ext_info": [
-                    'Display track limit warns if the driver has no penalties instead of a blank cell'
-                ]
+                "type": "group_box",
+                "visible": True,
+                "reorderable_collection": True,
+                "item_enabled_field": "enabled",
+                "item_position_field": "position",
+                "item_label_field": "description",
             }
-        }
+        },
     )
 
-    show_best_lap: bool = Field(
-        default=False,
-        description="Show best lap",
-        json_schema_extra={"ui": {"type": "check_box"}}
-    )
+    @model_validator(mode="after")
+    def check_unique_positions(self):
+        pos_map: Dict[int, str] = {}
+        for col_id, col in self.cols.items():
+            if not col.enabled:
+                continue
+            if col.position in pos_map:
+                raise ValueError(
+                    f"Timing tower column '{col_id}' has duplicate position {col.position} "
+                    f"(also used by '{pos_map[col.position]}')"
+                )
+            pos_map[col.position] = col_id
+        return self
 
-    show_last_lap: bool = Field(
-        default=False,
-        description="Show last lap",
-        json_schema_extra={"ui": {"type": "check_box"}}
-    )
+    @model_validator(mode="after")
+    def add_missing_cols(self):
+        """Ensure all DEFAULT_COLS entries are present.
 
-    show_wing_dmg: bool = Field(
-        default=False,
-        description="Show front wing damage",
-        json_schema_extra={"ui": {"type": "check_box"}}
-    )
+        Any column absent from the stored config is added as disabled with a
+        non-conflicting position.  This is the forward-compatibility hook that
+        handles both version upgrades and future new-column additions.
+        """
+        merged = dict(self.cols)
+        used_positions = {col.position for col in merged.values()}
 
-    show_speed_trap: bool = Field(
-        default=False,
-        description="Show speed trap",
-        json_schema_extra={"ui": {"type": "check_box"}}
-    )
+        for col_id, default_col in DEFAULT_COLS.items():
+            key = col_id.value if isinstance(col_id, TimingTowerColId) else col_id
+            if key not in merged:
+                new_col = default_col.model_copy(deep=True)
+                new_col.enabled = False
+                pos = new_col.position
+                while pos in used_positions:
+                    pos += 1
+                new_col.position = pos
+                used_positions.add(pos)
+                merged[key] = new_col
 
-    show_fuel: bool = Field(
-        default=False,
-        description="Show fuel level (surplus laps)", # TODO: add choice for builtin vs custom fuel calculation
-        json_schema_extra={"ui": {"type": "check_box"}}
-    )
+        self.cols = merged
+        return self
 
-    show_driver_status: bool = Field(
-        default=False,
-        description="Show driver status (IN_GARAGE, FLYING_LAP, IN_LAP, OUT_LAP, ON_TRACK)",
-        json_schema_extra={"ui": {"type": "check_box"}}
-    )
+    @model_validator(mode="after")
+    def fill_col_descriptions(self):
+        """Populate the excluded description field on every known column from DEFAULT_COLS.
+
+        Because description is excluded from JSON serialisation, it is always "" after a
+        round-trip through the config file.  This validator re-stamps the canonical
+        description onto every column so callers can read col.description at runtime.
+        """
+        for col_id, default_col in DEFAULT_COLS.items():
+            key = col_id.value if isinstance(col_id, TimingTowerColId) else col_id
+            if key in self.cols:
+                self.cols[key].description = default_col.description
+        return self
+
+    def sorted_enabled_cols(self) -> List[Tuple[str, TimingTowerColSettings]]:
+        """Return enabled columns sorted by position, ascending."""
+        return sorted(
+            [(col_id, col) for col_id, col in self.cols.items() if col.enabled],
+            key=lambda p: p[1].position
+        )

--- a/lib/config/schema/hud/timing_tower.py
+++ b/lib/config/schema/hud/timing_tower.py
@@ -89,7 +89,7 @@ DEFAULT_COLS: Dict[TimingTowerColId, "TimingTowerColSettings"] = {
         enabled=False, position=10, description="Fuel level (surplus laps)"),
     TimingTowerColId.DRIVER_STATUS: TimingTowerColSettings(
         enabled=False, position=11,
-        description="Driver status (e.g., IN_GARAGE, FLYING_LAP"),
+        description="Driver status (e.g., IN_GARAGE, FLYING_LAP, etc.)"),
 }
 
 class TimingTowerColOptions(ConfigDiffMixin, BaseModel):

--- a/lib/config/schema/hud/timing_tower.py
+++ b/lib/config/schema/hud/timing_tower.py
@@ -33,7 +33,6 @@ from ..diff import ConfigDiffMixin
 # ------------------------------------- CONSTANTS ----------------------------------------------------------------------
 
 class TimingTowerColId(str, Enum):
-    TEAM_LOGO     = "team_logo"
     DELTA         = "delta"
     TYRE          = "tyre"
     ERS_DRS       = "ers_drs"
@@ -68,30 +67,28 @@ class TimingTowerColSettings(ConfigDiffMixin, BaseModel):
 
 
 DEFAULT_COLS: Dict[TimingTowerColId, "TimingTowerColSettings"] = {
-    TimingTowerColId.TEAM_LOGO: TimingTowerColSettings(
-        enabled=True,  position=1,  description="Team logo"),
     TimingTowerColId.DELTA: TimingTowerColSettings(
-        enabled=True,  position=2,  description="Delta"),
+        enabled=True,  position=1,  description="Delta"),
     TimingTowerColId.TYRE: TimingTowerColSettings(
-        enabled=True,  position=3,  description="Tyre compound and wear"),
+        enabled=True,  position=2,  description="Tyre compound and wear"),
     TimingTowerColId.ERS_DRS: TimingTowerColSettings(
-        enabled=True,  position=4,  description="ERS / DRS"),
+        enabled=True,  position=3,  description="ERS / DRS"),
     TimingTowerColId.PENS: TimingTowerColSettings(
-        enabled=True,  position=5,  description="Penalties"),
+        enabled=True,  position=4,  description="Penalties"),
     TimingTowerColId.TL_WARNS: TimingTowerColSettings(
-        enabled=True,  position=6,  description="Track Limit warnings"),
+        enabled=True,  position=5,  description="Track Limit warnings"),
     TimingTowerColId.BEST_LAP: TimingTowerColSettings(
-        enabled=False, position=7,  description="Best Lap"),
+        enabled=False, position=6,  description="Best Lap"),
     TimingTowerColId.LAST_LAP: TimingTowerColSettings(
-        enabled=False, position=8,  description="Last Lap"),
+        enabled=False, position=7,  description="Last Lap"),
     TimingTowerColId.WING_DMG: TimingTowerColSettings(
-        enabled=False, position=9,  description="Front Wing Damage"),
+        enabled=False, position=8,  description="Front Wing Damage"),
     TimingTowerColId.SPEED_TRAP: TimingTowerColSettings(
-        enabled=False, position=10, description="Speed Trap"),
+        enabled=False, position=9,  description="Speed Trap"),
     TimingTowerColId.FUEL: TimingTowerColSettings(
-        enabled=False, position=11, description="Fuel level (surplus laps)"),
+        enabled=False, position=10, description="Fuel level (surplus laps)"),
     TimingTowerColId.DRIVER_STATUS: TimingTowerColSettings(
-        enabled=False, position=12,
+        enabled=False, position=11,
         description="Driver status (e.g., IN_GARAGE, FLYING_LAP"),
 }
 

--- a/tests/tests_config/__init__.py
+++ b/tests/tests_config/__init__.py
@@ -32,7 +32,7 @@ from .tests_display_settings import TestDisplaySettings
 from .tests_file_path_str_config import TestFilePathStr
 from .tests_forwarding_settings import TestForwardingSettings
 from .tests_https_settings import TestHttpsSettings
-from .tests_hud_settings import TestHudSettings
+from .tests_hud_settings import TestHudSettings, TestTimingTowerColConfig
 from .tests_network_settings import TestNetworkSettings
 from .tests_pit_time_loss import TestPitTimeLossF1, TestPitTimeLossF2
 from .tests_png_settings import TestPngSettings
@@ -64,6 +64,7 @@ __all__ = [
     "TestPngSettingsPrediction",
     "TestSubSysCtrl",
     "TestHudSettings",
+    "TestTimingTowerColConfig",
 
     "TestFilePathStr",
     "TestConfigDiffMixin",

--- a/tests/tests_config/tests_hud_settings.py
+++ b/tests/tests_config/tests_hud_settings.py
@@ -33,8 +33,10 @@ from pydantic import ValidationError
 from lib.config import (OverlaysFuelEstimationMode, OverlaysSpeedUnit,
                         HudSettings, MfdPageId, MfdPageSettings, MfdSettings,
                         MfdTyreWearRateType, OverlayId, OverlayPosition,
-                        TimingTowerColOptions, WeatherMFDUIType)
+                        TimingTowerColId, TimingTowerColOptions,
+                        TimingTowerColSettings, WeatherMFDUIType)
 from lib.config.schema.hud.mfd import DEFAULT_PAGES
+from lib.config.schema.hud.timing_tower import DEFAULT_COLS
 
 from .tests_config_base import TestF1ConfigBase
 
@@ -55,18 +57,19 @@ class TestHudSettings(TestF1ConfigBase):
         self.assertEqual(settings.timing_tower_max_rows, 5)
         self.assertEqual(settings.timing_tower_toggle_udp_action_code, None)
         self.assertTrue(settings.timing_tower_col_options.show_col_header)
-        self.assertTrue(settings.timing_tower_col_options.show_deltas)
-        self.assertTrue(settings.timing_tower_col_options.show_tyre_info)
-        self.assertTrue(settings.timing_tower_col_options.show_team_logos)
-        self.assertTrue(settings.timing_tower_col_options.show_ers_drs_info)
-        self.assertTrue(settings.timing_tower_col_options.show_pens)
-        self.assertTrue(settings.timing_tower_col_options.show_tl_warns)
-        self.assertFalse(settings.timing_tower_col_options.show_best_lap)
-        self.assertFalse(settings.timing_tower_col_options.show_last_lap)
-        self.assertFalse(settings.timing_tower_col_options.show_wing_dmg)
-        self.assertFalse(settings.timing_tower_col_options.show_speed_trap)
-        self.assertFalse(settings.timing_tower_col_options.show_fuel)
-        self.assertFalse(settings.timing_tower_col_options.show_driver_status)
+        cols = settings.timing_tower_col_options.cols
+        self.assertTrue(cols[TimingTowerColId.TEAM_LOGO].enabled)
+        self.assertTrue(cols[TimingTowerColId.DELTA].enabled)
+        self.assertTrue(cols[TimingTowerColId.TYRE].enabled)
+        self.assertTrue(cols[TimingTowerColId.ERS_DRS].enabled)
+        self.assertTrue(cols[TimingTowerColId.PENS].enabled)
+        self.assertTrue(cols[TimingTowerColId.TL_WARNS].enabled)
+        self.assertFalse(cols[TimingTowerColId.BEST_LAP].enabled)
+        self.assertFalse(cols[TimingTowerColId.LAST_LAP].enabled)
+        self.assertFalse(cols[TimingTowerColId.WING_DMG].enabled)
+        self.assertFalse(cols[TimingTowerColId.SPEED_TRAP].enabled)
+        self.assertFalse(cols[TimingTowerColId.FUEL].enabled)
+        self.assertFalse(cols[TimingTowerColId.DRIVER_STATUS].enabled)
         self.assertEqual(settings.show_mfd, True)
         self.assertEqual(settings.mfd_toggle_udp_action_code, None)
         self.assertEqual(settings.mfd_interaction_udp_action_code, None)
@@ -673,39 +676,28 @@ class TestHudSettings(TestF1ConfigBase):
         self.assertFalse(old_settings.has_changed(new_settings))
         self.assertEqual(old_settings.diff(new_settings), {})
 
-        # Diff from parent obj - real diff
+        # Diff from parent obj - real diff (disable a column that is enabled by default)
+        modified_cols = {k: v.model_copy(deep=True) for k, v in DEFAULT_COLS.items()}
+        modified_cols[TimingTowerColId.ERS_DRS] = TimingTowerColSettings(
+            enabled=False, position=DEFAULT_COLS[TimingTowerColId.ERS_DRS].position
+        )
         new_settings = HudSettings(
-            timing_tower_col_options=TimingTowerColOptions(
-                show_ers_drs_info=False,
-            )
+            timing_tower_col_options=TimingTowerColOptions(cols=modified_cols)
         )
         self.assertTrue(old_settings.has_changed(new_settings))
-        self.assertEqual(old_settings.diff(new_settings), {
-            "timing_tower_col_options": {
-                "show_ers_drs_info": {
-                    "old_value": True,
-                    "new_value": False
-                }
-            }
-        })
+        diff = old_settings.diff(new_settings)
+        self.assertIn("timing_tower_col_options", diff)
+        self.assertIn("cols", diff["timing_tower_col_options"])
 
         # Diff from obj directly - no diff
-        old_settings = TimingTowerColOptions()
-        new_settings = TimingTowerColOptions()
-        self.assertFalse(old_settings.has_changed(new_settings))
-        self.assertEqual(old_settings.diff(new_settings), {})
+        old_col_opts = TimingTowerColOptions()
+        new_col_opts = TimingTowerColOptions()
+        self.assertFalse(old_col_opts.has_changed(new_col_opts))
+        self.assertEqual(old_col_opts.diff(new_col_opts), {})
 
-        # Real diff
-        new_settings = TimingTowerColOptions(
-            show_ers_drs_info=False,
-        )
-        self.assertTrue(old_settings.has_changed(new_settings))
-        self.assertEqual(old_settings.diff(new_settings), {
-            "show_ers_drs_info": {
-                "old_value": True,
-                "new_value": False
-            }
-        })
+        # Real diff on obj directly
+        new_col_opts = TimingTowerColOptions(cols=modified_cols)
+        self.assertTrue(old_col_opts.has_changed(new_col_opts))
 
     def test_idle_opacity(self):
 
@@ -904,3 +896,158 @@ class TestHudSettings(TestF1ConfigBase):
         with self.assertRaises(ValidationError):
             HudSettings(menu_silence_threshold_sec=None)  # type: ignore
 
+
+# ----------------------------------------------------------------------------------------------------------------------
+
+class TestTimingTowerColConfig(TestF1ConfigBase):
+    """Tests for TimingTowerColId, TimingTowerColSettings, and TimingTowerColOptions."""
+
+    # --- Enum ---
+
+    def test_col_id_values_are_strings(self):
+        for col_id in TimingTowerColId:
+            self.assertIsInstance(col_id.value, str)
+            self.assertIsInstance(col_id, str)  # str, Enum members ARE strings
+
+    def test_col_id_used_as_dict_key(self):
+        opts = TimingTowerColOptions()
+        dumped = opts.model_dump()
+        # After model_dump all keys must be plain strings (JSON-serializable)
+        for key in dumped["cols"].keys():
+            self.assertIsInstance(key, str)
+
+    # --- Defaults ---
+
+    def test_default_cols_all_present(self):
+        opts = TimingTowerColOptions()
+        for col_id in TimingTowerColId:
+            self.assertIn(col_id.value, opts.cols)
+
+    def test_default_positions_unique(self):
+        opts = TimingTowerColOptions()
+        positions = [col.position for col in opts.cols.values()]
+        self.assertEqual(len(positions), len(set(positions)))
+
+    def test_default_enabled_set(self):
+        opts = TimingTowerColOptions()
+        enabled_by_default = {
+            TimingTowerColId.TEAM_LOGO, TimingTowerColId.DELTA,
+            TimingTowerColId.TYRE, TimingTowerColId.ERS_DRS,
+            TimingTowerColId.PENS, TimingTowerColId.TL_WARNS,
+        }
+        disabled_by_default = set(TimingTowerColId) - enabled_by_default
+        for col_id in enabled_by_default:
+            self.assertTrue(opts.cols[col_id.value].enabled, f"{col_id} should be enabled by default")
+        for col_id in disabled_by_default:
+            self.assertFalse(opts.cols[col_id.value].enabled, f"{col_id} should be disabled by default")
+
+    # --- sorted_enabled_cols ---
+
+    def test_sorted_enabled_cols_order(self):
+        opts = TimingTowerColOptions()
+        enabled = opts.sorted_enabled_cols()
+        positions = [col.position for _, col in enabled]
+        self.assertEqual(positions, sorted(positions))
+        # All returned cols must be enabled
+        for _, col in enabled:
+            self.assertTrue(col.enabled)
+
+    def test_sorted_enabled_cols_excludes_disabled(self):
+        opts = TimingTowerColOptions()
+        enabled_keys = {key for key, _ in opts.sorted_enabled_cols()}
+        for col_id in TimingTowerColId:
+            col = opts.cols[col_id.value]
+            if not col.enabled:
+                self.assertNotIn(col_id.value, enabled_keys)
+
+    def test_sorted_enabled_cols_empty_when_all_disabled(self):
+        all_disabled = {
+            col_id.value: TimingTowerColSettings(enabled=False, position=i + 1)
+            for i, col_id in enumerate(TimingTowerColId)
+        }
+        opts = TimingTowerColOptions(cols=all_disabled)
+        self.assertEqual(opts.sorted_enabled_cols(), [])
+
+    # --- Validators ---
+
+    def test_duplicate_position_among_enabled_rejected(self):
+        with self.assertRaises(ValidationError):
+            TimingTowerColOptions(cols={
+                TimingTowerColId.DELTA.value:   TimingTowerColSettings(enabled=True, position=1),
+                TimingTowerColId.TYRE.value:    TimingTowerColSettings(enabled=True, position=1),
+            })
+
+    def test_duplicate_position_among_disabled_allowed(self):
+        # Two disabled cols sharing a position must not raise
+        opts = TimingTowerColOptions(cols={
+            TimingTowerColId.DELTA.value:   TimingTowerColSettings(enabled=False, position=1),
+            TimingTowerColId.TYRE.value:    TimingTowerColSettings(enabled=False, position=1),
+        })
+        self.assertIsNotNone(opts)
+
+    def test_missing_col_auto_added_as_disabled(self):
+        # Provide only one column; all others must be auto-inserted as disabled
+        partial = {TimingTowerColId.DELTA.value: TimingTowerColSettings(enabled=True, position=1)}
+        opts = TimingTowerColOptions(cols=partial)
+        for col_id in TimingTowerColId:
+            self.assertIn(col_id.value, opts.cols)
+        # The auto-added ones must be disabled
+        for col_id in TimingTowerColId:
+            if col_id.value != TimingTowerColId.DELTA.value:
+                self.assertFalse(opts.cols[col_id.value].enabled)
+
+    def test_empty_cols_auto_filled_with_defaults(self):
+        opts = TimingTowerColOptions.model_validate({"cols": {}})
+        self.assertEqual(len(opts.cols), len(TimingTowerColId))
+        # All auto-filled must be disabled (missing cols default to disabled)
+        for col in opts.cols.values():
+            self.assertFalse(col.enabled)
+
+    def test_auto_added_positions_are_unique(self):
+        # Even when auto-filled from empty, positions must not collide
+        opts = TimingTowerColOptions.model_validate({"cols": {}})
+        positions = [col.position for col in opts.cols.values()]
+        self.assertEqual(len(positions), len(set(positions)))
+
+    # --- Upgrade compatibility ---
+
+    def test_old_flat_booleans_ignored_gracefully(self):
+        # Old config format: flat show_* booleans under timing_tower_col_options.
+        # With extra="ignore" (Pydantic default), these are silently dropped and
+        # cols falls back to defaults (all missing cols auto-inserted as disabled).
+        old_data = {
+            "show_team_logos": True,
+            "show_deltas": True,
+            "show_tyre_info": True,
+            "show_ers_drs_info": True,
+            "show_pens": True,
+            "show_tl_warns": True,
+            "show_best_lap": False,
+            "show_last_lap": False,
+            "show_wing_dmg": False,
+            "show_speed_trap": False,
+            "show_fuel": False,
+            "show_driver_status": False,
+        }
+        opts = TimingTowerColOptions.model_validate(old_data)
+        # All 12 cols must be present (auto-filled)
+        self.assertEqual(len(opts.cols), len(TimingTowerColId))
+
+    def test_partial_cols_in_stored_config_auto_filled(self):
+        # Simulate a future upgrade where two new columns were added to the enum
+        # but the stored config only has the old columns.
+        stored = {
+            TimingTowerColId.DELTA.value:  {"enabled": True,  "position": 1},
+            TimingTowerColId.TYRE.value:   {"enabled": True,  "position": 2},
+            TimingTowerColId.PENS.value:   {"enabled": False, "position": 3},
+        }
+        opts = TimingTowerColOptions.model_validate({"cols": stored})
+        self.assertEqual(len(opts.cols), len(TimingTowerColId))
+        # Stored values are preserved
+        self.assertTrue(opts.cols[TimingTowerColId.DELTA.value].enabled)
+        self.assertTrue(opts.cols[TimingTowerColId.TYRE.value].enabled)
+        self.assertFalse(opts.cols[TimingTowerColId.PENS.value].enabled)
+        # Missing ones are added as disabled
+        for col_id in TimingTowerColId:
+            if col_id.value not in stored:
+                self.assertFalse(opts.cols[col_id.value].enabled)

--- a/tests/tests_config/tests_hud_settings.py
+++ b/tests/tests_config/tests_hud_settings.py
@@ -58,7 +58,6 @@ class TestHudSettings(TestF1ConfigBase):
         self.assertEqual(settings.timing_tower_toggle_udp_action_code, None)
         self.assertTrue(settings.timing_tower_col_options.show_col_header)
         cols = settings.timing_tower_col_options.cols
-        self.assertTrue(cols[TimingTowerColId.TEAM_LOGO].enabled)
         self.assertTrue(cols[TimingTowerColId.DELTA].enabled)
         self.assertTrue(cols[TimingTowerColId.TYRE].enabled)
         self.assertTrue(cols[TimingTowerColId.ERS_DRS].enabled)
@@ -931,9 +930,9 @@ class TestTimingTowerColConfig(TestF1ConfigBase):
     def test_default_enabled_set(self):
         opts = TimingTowerColOptions()
         enabled_by_default = {
-            TimingTowerColId.TEAM_LOGO, TimingTowerColId.DELTA,
-            TimingTowerColId.TYRE, TimingTowerColId.ERS_DRS,
-            TimingTowerColId.PENS, TimingTowerColId.TL_WARNS,
+            TimingTowerColId.DELTA, TimingTowerColId.TYRE,
+            TimingTowerColId.ERS_DRS, TimingTowerColId.PENS,
+            TimingTowerColId.TL_WARNS,
         }
         disabled_by_default = set(TimingTowerColId) - enabled_by_default
         for col_id in enabled_by_default:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -57,7 +57,8 @@ from tests_config import (TestCaptureSettings, TestConfigDiffMixin,
                           TestPitTimeLossF2, TestPngSettings,
                           TestPngSettingsPrediction, TestPredictionSettings,
                           TestPrivacySettings, TestSampleSettingsFixture,
-                          TestStreamOverlaySettings, TestSubSysCtrl)
+                          TestStreamOverlaySettings, TestSubSysCtrl,
+                          TestTimingTowerColConfig)
 from tests_custom_markers import (TestCustomMarkerEntry,
                                   TestCustomMarkersHistory)
 from tests_data_per_driver import (TestTyreSetHistoryEntry,


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Make timing tower columns re-orderable

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [ ] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
<paste result here>
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [ ] My code follows project style conventions
* [ ] All new and existing tests pass
* [ ] I have added relevant documentation/comments
* [ ] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Introduce configurable, reorderable timing tower columns and update HUD, config schema, and launcher settings UI to support them.

New Features:
- Allow timing tower columns to be enabled/disabled and reordered via new TimingTowerColId/TimingTowerColSettings/TimingTowerColOptions config structures.
- Drive the HUD timing tower overlay layout from an ordered list of enabled column IDs instead of hard-coded booleans, including a dedicated track-limit warnings column.
- Enhance the launcher settings UI to render generic reorderable collections with custom item labels derived from schema metadata.

Enhancements:
- Refactor timing tower QML to render headers and row cells dynamically from a column order model rather than fixed column blocks.
- Ensure configuration backward/forward compatibility for timing tower column settings, including automatic filling of missing columns and validation of ordering.
- Slightly adjust the settings window scroll area styling to use a narrower vertical scrollbar.

Tests:
- Extend HUD settings tests and add dedicated tests for timing tower column config types, including defaults, sorting, validation, and upgrade compatibility.