### PR TITLE
Refactor F1 telemetry packet parsers into shared parse helpers

### DIFF
--- a/lib/f1_types/packet_0_car_motion_data.py
+++ b/lib/f1_types/packet_0_car_motion_data.py
@@ -126,13 +126,30 @@ class CarMotionData(F1SubPacketBase):
         self.m_pitch: float
         self.m_roll: float
 
-        # Now, unpack the data and populate the members
-        self.m_worldPositionX, self.m_worldPositionY, self.m_worldPositionZ, \
-            self.m_worldVelocityX, self.m_worldVelocityY, self.m_worldVelocityZ, \
-            self.m_worldForwardDirX, self.m_worldForwardDirY, self.m_worldForwardDirZ, \
-            self.m_worldRightDirX, self.m_worldRightDirY, self.m_worldRightDirZ, \
-            self.m_gForceLateral, self.m_gForceLongitudinal, self.m_gForceVertical, \
-            self.m_yaw, self.m_pitch, self.m_roll = self.COMPILED_PACKET_STRUCT.unpack(data)
+        self._parse(data)
+
+    def _parse(self, data: bytes) -> None:
+        """Raw byte unpacking."""
+        (
+            self.m_worldPositionX,
+            self.m_worldPositionY,
+            self.m_worldPositionZ,
+            self.m_worldVelocityX,
+            self.m_worldVelocityY,
+            self.m_worldVelocityZ,
+            self.m_worldForwardDirX,
+            self.m_worldForwardDirY,
+            self.m_worldForwardDirZ,
+            self.m_worldRightDirX,
+            self.m_worldRightDirY,
+            self.m_worldRightDirZ,
+            self.m_gForceLateral,
+            self.m_gForceLongitudinal,
+            self.m_gForceVertical,
+            self.m_yaw,
+            self.m_pitch,
+            self.m_roll,
+        ) = self.COMPILED_PACKET_STRUCT.unpack(data)
 
     def __str__(self) -> str:
         """Return a formatted string representing the CarMotionData object

--- a/lib/f1_types/packet_10_car_damage_data.py
+++ b/lib/f1_types/packet_10_car_damage_data.py
@@ -152,77 +152,92 @@ class CarDamageData(F1SubPacketBase):
         self.m_brakesDamage = [0] * 4
         self.m_tyreBlisters = [0] * 4
         self.m_packetFormat = packet_format
-        if packet_format >= 2025:
-            (
-                self.m_tyresWear[0],
-                self.m_tyresWear[1],
-                self.m_tyresWear[2],
-                self.m_tyresWear[3],
-                self.m_tyresDamage[0],
-                self.m_tyresDamage[1],
-                self.m_tyresDamage[2],
-                self.m_tyresDamage[3],
-                self.m_brakesDamage[0],
-                self.m_brakesDamage[1],
-                self.m_brakesDamage[2],
-                self.m_brakesDamage[3],
-                self.m_tyreBlisters[0],
-                self.m_tyreBlisters[1],
-                self.m_tyreBlisters[2],
-                self.m_tyreBlisters[3],
-                self.m_frontLeftWingDamage,
-                self.m_frontRightWingDamage,
-                self.m_rearWingDamage,
-                self.m_floorDamage,
-                self.m_diffuserDamage,
-                self.m_sidepodDamage,
-                self.m_drsFault,
-                self.m_ersFault,
-                self.m_gearBoxDamage,
-                self.m_engineDamage,
-                self.m_engineMGUHWear,
-                self.m_engineESWear,
-                self.m_engineCEWear,
-                self.m_engineICEWear,
-                self.m_engineMGUKWear,
-                self.m_engineTCWear,
-                self.m_engineBlown,
-                self.m_engineSeized,
-            ) = struct.unpack(self.PACKET_FORMAT_25, data)
-        else:
-            (
-                self.m_tyresWear[0],
-                self.m_tyresWear[1],
-                self.m_tyresWear[2],
-                self.m_tyresWear[3],
-                self.m_tyresDamage[0],
-                self.m_tyresDamage[1],
-                self.m_tyresDamage[2],
-                self.m_tyresDamage[3],
-                self.m_brakesDamage[0],
-                self.m_brakesDamage[1],
-                self.m_brakesDamage[2],
-                self.m_brakesDamage[3],
-                self.m_frontLeftWingDamage,
-                self.m_frontRightWingDamage,
-                self.m_rearWingDamage,
-                self.m_floorDamage,
-                self.m_diffuserDamage,
-                self.m_sidepodDamage,
-                self.m_drsFault,
-                self.m_ersFault,
-                self.m_gearBoxDamage,
-                self.m_engineDamage,
-                self.m_engineMGUHWear,
-                self.m_engineESWear,
-                self.m_engineCEWear,
-                self.m_engineICEWear,
-                self.m_engineMGUKWear,
-                self.m_engineTCWear,
-                self.m_engineBlown,
-                self.m_engineSeized,
-            ) = self.COMPILED_PACKET_STRUCT.unpack(data)
+        self._parse(data, packet_format)
+        self._cast_enums()
 
+    def _parse(self, data: bytes, packet_format: int) -> None:
+        """Dispatch to the correct format-specific unpack."""
+        if packet_format >= 2025:
+            self._parse_f25(data)
+        else:
+            self._parse_pre25(data)
+
+    def _parse_f25(self, data: bytes) -> None:
+        """Unpack F1 2025+ binary layout (includes m_tyreBlisters)."""
+        (
+            self.m_tyresWear[0],
+            self.m_tyresWear[1],
+            self.m_tyresWear[2],
+            self.m_tyresWear[3],
+            self.m_tyresDamage[0],
+            self.m_tyresDamage[1],
+            self.m_tyresDamage[2],
+            self.m_tyresDamage[3],
+            self.m_brakesDamage[0],
+            self.m_brakesDamage[1],
+            self.m_brakesDamage[2],
+            self.m_brakesDamage[3],
+            self.m_tyreBlisters[0],
+            self.m_tyreBlisters[1],
+            self.m_tyreBlisters[2],
+            self.m_tyreBlisters[3],
+            self.m_frontLeftWingDamage,
+            self.m_frontRightWingDamage,
+            self.m_rearWingDamage,
+            self.m_floorDamage,
+            self.m_diffuserDamage,
+            self.m_sidepodDamage,
+            self.m_drsFault,
+            self.m_ersFault,
+            self.m_gearBoxDamage,
+            self.m_engineDamage,
+            self.m_engineMGUHWear,
+            self.m_engineESWear,
+            self.m_engineCEWear,
+            self.m_engineICEWear,
+            self.m_engineMGUKWear,
+            self.m_engineTCWear,
+            self.m_engineBlown,
+            self.m_engineSeized,
+        ) = struct.unpack(self.PACKET_FORMAT_25, data)
+
+    def _parse_pre25(self, data: bytes) -> None:
+        """Unpack F1 2023/2024 binary layout."""
+        (
+            self.m_tyresWear[0],
+            self.m_tyresWear[1],
+            self.m_tyresWear[2],
+            self.m_tyresWear[3],
+            self.m_tyresDamage[0],
+            self.m_tyresDamage[1],
+            self.m_tyresDamage[2],
+            self.m_tyresDamage[3],
+            self.m_brakesDamage[0],
+            self.m_brakesDamage[1],
+            self.m_brakesDamage[2],
+            self.m_brakesDamage[3],
+            self.m_frontLeftWingDamage,
+            self.m_frontRightWingDamage,
+            self.m_rearWingDamage,
+            self.m_floorDamage,
+            self.m_diffuserDamage,
+            self.m_sidepodDamage,
+            self.m_drsFault,
+            self.m_ersFault,
+            self.m_gearBoxDamage,
+            self.m_engineDamage,
+            self.m_engineMGUHWear,
+            self.m_engineESWear,
+            self.m_engineCEWear,
+            self.m_engineICEWear,
+            self.m_engineMGUKWear,
+            self.m_engineTCWear,
+            self.m_engineBlown,
+            self.m_engineSeized,
+        ) = self.COMPILED_PACKET_STRUCT.unpack(data)
+
+    def _cast_enums(self) -> None:
+        """Convert raw ints to bools."""
         self.m_drsFault = bool(self.m_drsFault)
         self.m_ersFault = bool(self.m_ersFault)
         self.m_engineBlown = bool(self.m_engineBlown)

--- a/lib/f1_types/packet_11_session_history_data.py
+++ b/lib/f1_types/packet_11_session_history_data.py
@@ -300,7 +300,10 @@ class TyreStintHistoryData(F1SubPacketBase):
             self.m_tyreActualCompound,
             self.m_tyreVisualCompound,
         ) = self.COMPILED_PACKET_STRUCT.unpack(data)
+        self._cast_enums()
 
+    def _cast_enums(self) -> None:
+        """Cast raw ints to compound enums."""
         self.m_tyreActualCompound = ActualTyreCompound.safeCast(self.m_tyreActualCompound)
         self.m_tyreVisualCompound = VisualTyreCompound.safeCast(self.m_tyreVisualCompound)
 

--- a/lib/f1_types/packet_14_time_trial_data.py
+++ b/lib/f1_types/packet_14_time_trial_data.py
@@ -117,8 +117,11 @@ class TimeTrialDataSet(F1SubPacketBase):
             self.m_customSetup,
             self.m_isValid,
         ) = self.COMPILED_PACKET_STRUCT.unpack(data)
+        self._cast_enums(packet_format)
 
-        # No ned to check game year, since this packet type is not available in F1 23
+    def _cast_enums(self, packet_format: int) -> None:
+        """All safeCast and bool conversions in one place."""
+        # No need to check game year, since this packet type is not available in F1 23
         if packet_format < 2025:
             self.m_teamId = TeamID24.safeCast(self.m_teamId)
         else:

--- a/lib/f1_types/packet_1_session_data.py
+++ b/lib/f1_types/packet_1_session_data.py
@@ -1115,9 +1115,9 @@ class PacketSessionData(F1PacketBase):
                 self.m_sector3LapDistanceStart,
             ) = unpacked_data
 
-            self.m_weekendStructure = self.m_weekendStructure[:self.m_numSessionsInWeekend]
-            for session_id in self.m_weekendStructure:
-                session_id = SessionType24(session_id)
+            self.m_weekendStructure = [
+                SessionType24(s) for s in self.m_weekendStructure[:self.m_numSessionsInWeekend]
+            ]
         else:
             self.m_equalCarPerformance = 0
             self.m_recoveryMode = 0
@@ -1342,10 +1342,10 @@ class PacketSessionData(F1PacketBase):
         if not self.__eq_f1_23(other):
             return False
 
-        if self.m_header.m_packetFormat == 2024:
+        if self.m_header.m_packetFormat >= 2024:
             return self.__eq_f1_24(other)
 
-        return NotImplemented
+        return True
 
     def __eq_f1_23(self, other: "PacketSessionData") -> bool:
         """

--- a/lib/f1_types/packet_1_session_data.py
+++ b/lib/f1_types/packet_1_session_data.py
@@ -870,7 +870,6 @@ class PacketSessionData(F1PacketBase):
         INCREASED = 3
 
     def __init__(self, header: PacketHeader, data: bytes) -> None:
-        # sourcery skip: low-code-quality
         """Construct a PacketSessionData object
 
         Args:
@@ -960,14 +959,19 @@ class PacketSessionData(F1PacketBase):
         self.m_sector2LapDistanceStart: float    # // Distance in m around track where sector 2 starts
         self.m_sector3LapDistanceStart: float    # // Distance in m around track where sector 3
 
-        if header.m_packetFormat == 2023:
-            max_weather_forecast_samples = self.F1_23_MAX_NUM_WEATHER_FORECAST_SAMPLES
-        else:
-            max_weather_forecast_samples = self.F1_24_MAX_NUM_WEATHER_FORECAST_SAMPLES
+        offset = self._parse_base(data, header.m_packetFormat)
+        self._parse_f24(data, offset, header.m_packetFormat)
+        self._cast_enums(header.m_packetFormat)
+
+    def _parse_base(self, data: bytes, fmt: int) -> int:
+        """Parse fields present in all packet formats. Returns byte offset after consumed data."""
+        max_weather_forecast_samples = (
+            self.F1_23_MAX_NUM_WEATHER_FORECAST_SAMPLES if fmt == 2023
+            else self.F1_24_MAX_NUM_WEATHER_FORECAST_SAMPLES
+        )
+
         # First, section 0
-        section_0_raw_data = data[:self.PACKET_LEN_SECTION_0]
         byte_index_so_far = self.PACKET_LEN_SECTION_0
-        unpacked_data = self.COMPILED_PACKET_STRUCT_SECTION_0.unpack(section_0_raw_data)
         (
             self.m_weather,
             self.m_trackTemperature,
@@ -985,17 +989,7 @@ class PacketSessionData(F1PacketBase):
             self.m_spectatorCarIndex,
             self.m_sliProNativeSupport,
             self.m_numMarshalZones,
-        ) = unpacked_data
-        self.m_isSpectating = bool(self.m_isSpectating)
-        self.m_weather = WeatherForecastSample.WeatherCondition.safeCast(self.m_weather)
-        self.m_trackId = TrackID.safeCast(self.m_trackId)
-
-        if header.m_packetFormat == 2023:
-            self.m_sessionType = SessionType23.safeCast(self.m_sessionType)
-        else:
-            self.m_sessionType = SessionType24.safeCast(self.m_sessionType)
-
-        self.m_formula = PacketSessionData.FormulaType.safeCast(self.m_formula)
+        ) = self.COMPILED_PACKET_STRUCT_SECTION_0.unpack(data[:self.PACKET_LEN_SECTION_0])
 
         # Next section 1, marshalZones
         self.m_marshalZones, byte_index_so_far = MarshalZone.parse_array(
@@ -1007,16 +1001,14 @@ class PacketSessionData(F1PacketBase):
         )
 
         # Section 2, till numWeatherForecastSamples
-        section_2_raw_data = data[byte_index_so_far:byte_index_so_far + self.PACKET_LEN_SECTION_2]
-        byte_index_so_far += self.PACKET_LEN_SECTION_2
-        unpacked_data = self.COMPILED_PACKET_STRUCT_SECTION_2.unpack(section_2_raw_data)
         (
             self.m_safetyCarStatus, #           // 0 = no safety car, 1 = full 2 = virtual, 3 = formation lap
-            self.m_networkGame, #               // 0 = offline, 1 = online
-            self.m_numWeatherForecastSamples # // Number of weather samples to follow
-        ) = unpacked_data
-        self.m_safetyCarStatus = SafetyCarType.safeCast(self.m_safetyCarStatus)
-        section_2_raw_data = None
+            self.m_networkGame,     #           // 0 = offline, 1 = online
+            self.m_numWeatherForecastSamples,   # // Number of weather samples to follow
+        ) = self.COMPILED_PACKET_STRUCT_SECTION_2.unpack(
+            data[byte_index_so_far:byte_index_so_far + self.PACKET_LEN_SECTION_2]
+        )
+        byte_index_so_far += self.PACKET_LEN_SECTION_2
 
         # Section 3 - weather forecast samples
         self.m_weatherForecastSamples, byte_index_so_far = WeatherForecastSample.parse_array(
@@ -1025,13 +1017,10 @@ class PacketSessionData(F1PacketBase):
             item_len=WeatherForecastSample.PACKET_LEN,
             count=self.m_numWeatherForecastSamples,
             max_count=max_weather_forecast_samples,
-            packet_format=header.m_packetFormat
+            packet_format=fmt,
         )
 
         # Section 4 - rest of the packet
-        section_4_raw_data = data[byte_index_so_far:byte_index_so_far + self.PACKET_LEN_SECTION_4]
-        byte_index_so_far += self.PACKET_LEN_SECTION_4
-        unpacked_data = self.COMPILED_PACKET_STRUCT_SECTION_4.unpack(section_4_raw_data)
         (
             self.m_forecastAccuracy,                   # uint8
             self.m_aiDifficulty,                       # uint8
@@ -1061,93 +1050,99 @@ class PacketSessionData(F1PacketBase):
             self.m_numSafetyCarPeriods,              # uint8
             self.m_numVirtualSafetyCarPeriods,       # uint8
             self.m_numRedFlagPeriods,                # uint8
-        ) = unpacked_data
-        section_4_raw_data = None
+        ) = self.COMPILED_PACKET_STRUCT_SECTION_4.unpack(
+            data[byte_index_so_far:byte_index_so_far + self.PACKET_LEN_SECTION_4]
+        )
+        byte_index_so_far += self.PACKET_LEN_SECTION_4
+
+        return byte_index_so_far
+
+    def _parse_f24(self, data: bytes, offset: int, fmt: int) -> int:
+        """Parse F1 24+ fields. Assigns zero defaults for older formats. Returns updated byte offset."""
+        if fmt == 2024:
+            (
+                self.m_equalCarPerformance,         # uint8 - car equal performance. 0 = off, 1 = on
+                self.m_recoveryMode,                # uint8 - 0 = None, 1 = Flashbacks, 2 = Auto-recovery
+                self.m_flashbackLimit,              # uint8 - 0 = Low, 1 = Medium, 2 = High, 3 = Unlimited
+                self.m_surfaceType,                 # uint8 - 0 = Simplified, 1 = Realistic
+                self.m_lowFuelMode,                 # uint8 - 0 = Easy, 1 = Hard
+                self.m_raceStarts,                  # uint8 - 0 = Manual, 1 = Assisted
+                self.m_tyreTemperatureMode,         # uint8 - 0 = Surface only, 1 = Surface & Carcass
+                self.m_pitLaneTyreSim,              # uint8 - 0 = On, 1 = Off
+                self.m_carDamage,                   # uint8 - 0 = Off, 1 = Reduced, 2 = Standard, 3 = Simulation
+                self.m_carDamageRate,               # uint8 - 0 = Reduced, 1 = Standard, 2 = Simulation
+                self.m_collisions,                  # uint8 - 0 = Off, 1 = Player-to-Player Off, 2 = On
+                self.m_collisionsOffForFirstLapOnly, # uint8 - 0 = Disabled, 1 = Enabled
+                self.m_mpUnsafePitRelease,          # uint8 - 0 = On, 1 = Off (Multiplayer)
+                self.m_mpOffForGriefing,            # uint8 - 0 = Disabled, 1 = Enabled (Multiplayer)
+                self.m_cornerCuttingStringency,     # uint8 - 0 = Regular, 1 = Strict
+                self.m_parcFermeRules,              # uint8 - 0 = Off, 1 = On
+                self.m_pitStopExperience,           # uint8 - 0 = Automatic, 1 = Broadcast, 2 = Immersive
+                self.m_safetyCar,                   # uint8 - 0 = Off, 1 = Reduced, 2 = Standard, 3 = Increased
+                self.m_safetyCarExperience,         # uint8 - 0 = Broadcast, 1 = Immersive
+                self.m_formationLap,                # uint8 - 0 = Off, 1 = On
+                self.m_formationLapExperience,      # uint8 - 0 = Broadcast, 1 = Immersive
+                self.m_redFlags,                    # uint8 - 0 = Off, 1 = Reduced, 2 = Standard, 3 = Increased
+                self.m_affectsLicenceLevelSolo,     # uint8 - 0 = Off, 1 = On
+                self.m_affectsLicenceLevelMP,       # uint8 - 0 = Off, 1 = On
+                self.m_numSessionsInWeekend,        # uint8 - Number of session in following array
+                ws0, ws1, ws2, ws3, ws4, ws5, ws6, ws7, ws8, ws9, ws10, ws11,  # uint8[12] - weekend structure
+                self.m_sector2LapDistanceStart,     # float - Distance in m around track where sector 2 starts
+                self.m_sector3LapDistanceStart,     # float - Distance in m around track where sector 3 starts
+            ) = self.COMPILED_PACKET_STRUCT_SECTION_5.unpack(
+                data[offset:offset + self.PACKET_LEN_SECTION_5]
+            )
+            self.m_weekendStructure = [
+                SessionType24(s) for s in
+                (ws0, ws1, ws2, ws3, ws4, ws5, ws6, ws7, ws8, ws9, ws10, ws11)[:self.m_numSessionsInWeekend]
+            ]
+            return offset + self.PACKET_LEN_SECTION_5
+
+        self.m_equalCarPerformance = 0
+        self.m_recoveryMode = 0
+        self.m_flashbackLimit = 0
+        self.m_surfaceType = 0
+        self.m_lowFuelMode = 0
+        self.m_raceStarts = 0
+        self.m_tyreTemperatureMode = 0
+        self.m_pitLaneTyreSim = 0
+        self.m_carDamage = 0
+        self.m_carDamageRate = 0
+        self.m_collisions = 0
+        self.m_collisionsOffForFirstLapOnly = 0
+        self.m_mpUnsafePitRelease = 0
+        self.m_mpOffForGriefing = 0
+        self.m_cornerCuttingStringency = 0
+        self.m_parcFermeRules = 0
+        self.m_pitStopExperience = 0
+        self.m_safetyCar = 0
+        self.m_safetyCarExperience = 0
+        self.m_formationLap = 0
+        self.m_formationLapExperience = 0
+        self.m_redFlags = 0
+        self.m_affectsLicenceLevelSolo = 0
+        self.m_affectsLicenceLevelMP = 0
+        self.m_numSessionsInWeekend = 0
+        self.m_weekendStructure = [0] * 12
+        self.m_sector2LapDistanceStart = 0.0
+        self.m_sector3LapDistanceStart = 0.0
+        return offset
+
+    def _cast_enums(self, fmt: int) -> None:
+        """Apply enum casts to all parsed fields."""
+        self.m_isSpectating = bool(self.m_isSpectating)
+        self.m_weather = WeatherForecastSample.WeatherCondition.safeCast(self.m_weather)
+        self.m_trackId = TrackID.safeCast(self.m_trackId)
+        if fmt == 2023:
+            self.m_sessionType = SessionType23.safeCast(self.m_sessionType)
+        else:
+            self.m_sessionType = SessionType24.safeCast(self.m_sessionType)
+        self.m_formula = PacketSessionData.FormulaType.safeCast(self.m_formula)
+        self.m_safetyCarStatus = SafetyCarType.safeCast(self.m_safetyCarStatus)
         self.m_gearboxAssist = GearboxAssistMode.safeCast(self.m_gearboxAssist)
         self.m_sessionLength = SessionLength.safeCast(self.m_sessionLength)
         self.m_gameMode = GameMode.safeCast(self.m_gameMode)
         self.m_ruleSet = RuleSet.safeCast(self.m_ruleSet)
-
-        self.m_weekendStructure = [0] * 12
-        # Section 5 - F1 24 specific stuff
-        if header.m_packetFormat == 2024:
-            section_5_raw_data = data[byte_index_so_far:byte_index_so_far + self.PACKET_LEN_SECTION_5]
-            unpacked_data = self.COMPILED_PACKET_STRUCT_SECTION_5.unpack(section_5_raw_data)
-            (
-                self.m_equalCarPerformance,
-                self.m_recoveryMode,
-                self.m_flashbackLimit,
-                self.m_surfaceType,
-                self.m_lowFuelMode,
-                self.m_raceStarts,
-                self.m_tyreTemperatureMode,
-                self.m_pitLaneTyreSim,
-                self.m_carDamage,
-                self.m_carDamageRate,
-                self.m_collisions,
-                self.m_collisionsOffForFirstLapOnly,
-                self.m_mpUnsafePitRelease,
-                self.m_mpOffForGriefing,
-                self.m_cornerCuttingStringency,
-                self.m_parcFermeRules,
-                self.m_pitStopExperience,
-                self.m_safetyCar,
-                self.m_safetyCarExperience,
-                self.m_formationLap,
-                self.m_formationLapExperience,
-                self.m_redFlags,
-                self.m_affectsLicenceLevelSolo,
-                self.m_affectsLicenceLevelMP,
-                self.m_numSessionsInWeekend,
-                self.m_weekendStructure[0],
-                self.m_weekendStructure[1],
-                self.m_weekendStructure[2],
-                self.m_weekendStructure[3],
-                self.m_weekendStructure[4],
-                self.m_weekendStructure[5],
-                self.m_weekendStructure[6],
-                self.m_weekendStructure[7],
-                self.m_weekendStructure[8],
-                self.m_weekendStructure[9],
-                self.m_weekendStructure[10],
-                self.m_weekendStructure[11],
-                self.m_sector2LapDistanceStart,
-                self.m_sector3LapDistanceStart,
-            ) = unpacked_data
-
-            self.m_weekendStructure = [
-                SessionType24(s) for s in self.m_weekendStructure[:self.m_numSessionsInWeekend]
-            ]
-        else:
-            self.m_equalCarPerformance = 0
-            self.m_recoveryMode = 0
-            self.m_flashbackLimit = 0
-            self.m_surfaceType = 0
-            self.m_lowFuelMode = 0
-            self.m_raceStarts = 0
-            self.m_tyreTemperatureMode = 0
-            self.m_pitLaneTyreSim = 0
-            self.m_carDamage = 0
-            self.m_carDamageRate = 0
-            self.m_collisions = 0
-            self.m_collisionsOffForFirstLapOnly = 0
-            self.m_mpUnsafePitRelease = 0
-            self.m_mpOffForGriefing = 0
-            self.m_cornerCuttingStringency = 0
-            self.m_parcFermeRules = 0
-            self.m_pitStopExperience = 0
-            self.m_safetyCar = 0
-            self.m_safetyCarExperience = 0
-            self.m_formationLap = 0
-            self.m_formationLapExperience = 0
-            self.m_redFlags = 0
-            self.m_affectsLicenceLevelSolo = 0
-            self.m_affectsLicenceLevelMP = 0
-            self.m_numSessionsInWeekend = 0
-            self.m_sector2LapDistanceStart = 0.0
-            self.m_sector3LapDistanceStart = 0.0
-
-        # Convert into enum types if supported
         self.m_recoveryMode = PacketSessionData.RecoveryMode.safeCast(self.m_recoveryMode)
         self.m_flashbackLimit = PacketSessionData.FlashbackLimit.safeCast(self.m_flashbackLimit)
         self.m_surfaceType = PacketSessionData.SurfaceType.safeCast(self.m_surfaceType)
@@ -1158,7 +1153,7 @@ class PacketSessionData(F1PacketBase):
         self.m_carDamageRate = PacketSessionData.CarDamageRate.safeCast(self.m_carDamageRate)
         self.m_collisions = PacketSessionData.CollisionsMode.safeCast(self.m_collisions)
         self.m_cornerCuttingStringency = PacketSessionData.CornerCuttingStringency.safeCast(
-                self.m_cornerCuttingStringency)
+            self.m_cornerCuttingStringency)
         self.m_pitStopExperience = PacketSessionData.PitStopExperience.safeCast(self.m_pitStopExperience)
         self.m_safetyCar = PacketSessionData.SafetyCarSetting.safeCast(self.m_safetyCar)
         self.m_safetyCarExperience = PacketSessionData.SafetyCarExperience.safeCast(self.m_safetyCarExperience)
@@ -1238,8 +1233,14 @@ class PacketSessionData(F1PacketBase):
         Returns:
             Dict[str, Any]: A dictionary representing the JSON-compatible data.
         """
+        json_data = self._base_json() | self._f24_json()
+        if include_header:
+            json_data["header"] = self.m_header.toJSON()
+        return json_data
 
-        json_data = {
+    def _base_json(self) -> Dict[str, Any]:
+        """Return JSON dict for fields present in all packet formats."""
+        return {
             "weather": str(self.m_weather),
             "track-temperature": self.m_trackTemperature,
             "air-temperature": self.m_airTemperature,
@@ -1289,7 +1290,11 @@ class PacketSessionData(F1PacketBase):
             "num-safety-car-periods": self.m_numSafetyCarPeriods,
             "num-virtual-safety-car-periods": self.m_numVirtualSafetyCarPeriods,
             "num-red-flag-periods": self.m_numRedFlagPeriods,
+        }
 
+    def _f24_json(self) -> Dict[str, Any]:
+        """Return JSON dict for F1 24+ fields."""
+        return {
             "equal-car-performance" : str(self.m_equalCarPerformance),
             "recovery-mode" : str(self.m_recoveryMode),
             "flashback-limit" : str(self.m_flashbackLimit),
@@ -1319,9 +1324,6 @@ class PacketSessionData(F1PacketBase):
             "sector-2-lap-distance-start" : str(self.m_sector2LapDistanceStart),
             "sector-3-lap-distance-start" : str(self.m_sector3LapDistanceStart),
         }
-        if include_header:
-            json_data["header"] = self.m_header.toJSON()
-        return json_data
 
     def __eq__(self, other: "PacketSessionData") -> bool:
         """
@@ -1339,17 +1341,17 @@ class PacketSessionData(F1PacketBase):
         if self.m_header != other.m_header:
             return False
 
-        if not self.__eq_f1_23(other):
+        if not self._eq_base(other):
             return False
 
         if self.m_header.m_packetFormat >= 2024:
-            return self.__eq_f1_24(other)
+            return self._eq_f24(other)
 
         return True
 
-    def __eq_f1_23(self, other: "PacketSessionData") -> bool:
+    def _eq_base(self, other: "PacketSessionData") -> bool:
         """
-        Check the F1 23 specific stuff
+        Check the fields present in all packet formats.
 
         Args:
             other (object): The other object to compare against.
@@ -1357,9 +1359,6 @@ class PacketSessionData(F1PacketBase):
         Returns:
             bool: True if both PacketSessionData objects are equal, False otherwise.
         """
-        if not isinstance(other, PacketSessionData):
-            return NotImplemented
-
         return (
             self.m_weather == other.m_weather and
             self.m_trackTemperature == other.m_trackTemperature and
@@ -1412,9 +1411,9 @@ class PacketSessionData(F1PacketBase):
             self.m_numRedFlagPeriods == other.m_numRedFlagPeriods
         )
 
-    def __eq_f1_24(self, other: "PacketSessionData") -> bool:
+    def _eq_f24(self, other: "PacketSessionData") -> bool:
         """
-        Check the F1 24 specific stuff
+        Check the F1 24+ specific fields.
 
         Args:
             other (object): The other object to compare against.

--- a/lib/f1_types/packet_2_lap_data.py
+++ b/lib/f1_types/packet_2_lap_data.py
@@ -257,83 +257,93 @@ class LapData(F1SubPacketBase):
         - struct.error: If the binary data does not match the expected format.
         """
 
-        # Assign the members from unpacked_data
         self.m_packetFormat = packet_format
-        if packet_format == 2023:
-            raw_data = data[:self.PACKET_LEN_23]
-            (
-                self.m_lastLapTimeInMS,
-                self.m_currentLapTimeInMS,
-                self.m_sector1TimeInMS,
-                self.m_sector1TimeMinutes,
-                self.m_sector2TimeInMS,
-                self.m_sector2TimeMinutes,
-                self.m_deltaToCarInFrontInMS,
-                self.m_deltaToRaceLeaderInMS,
-                self.m_lapDistance,
-                self.m_totalDistance,
-                self.m_safetyCarDelta,
-                self.m_carPosition,
-                self.m_currentLapNum,
-                self.m_pitStatus,
-                self.m_numPitStops,
-                self.m_sector,
-                self.m_currentLapInvalid,
-                self.m_penalties,
-                self.m_totalWarnings,
-                self.m_cornerCuttingWarnings,
-                self.m_numUnservedDriveThroughPens,
-                self.m_numUnservedStopGoPens,
-                self.m_gridPosition,
-                self.m_driverStatus,
-                self.m_resultStatus,
-                self.m_pitLaneTimerActive,
-                self.m_pitLaneTimeInLaneInMS,
-                self.m_pitStopTimerInMS,
-                self.m_pitStopShouldServePen,
-            ) = self.COMPILED_PACKET_STRUCT_23.unpack(raw_data)
-            self.m_deltaToCarInFrontMinutes: int = 0
-            self.m_deltaToRaceLeaderMinutes: int = 0
-            self.m_speedTrapFastestSpeed: float = 0
-            self.m_speedTrapFastestLap: int = 0
-        else: # 24
-            raw_data = data[0:self.PACKET_LEN_24]
-            (
-                self.m_lastLapTimeInMS,
-                self.m_currentLapTimeInMS,
-                self.m_sector1TimeInMS,
-                self.m_sector1TimeMinutes,
-                self.m_sector2TimeInMS,
-                self.m_sector2TimeMinutes,
-                self.m_deltaToCarInFrontInMS,
-                self.m_deltaToCarInFrontMinutes,
-                self.m_deltaToRaceLeaderInMS,
-                self.m_deltaToRaceLeaderMinutes,
-                self.m_lapDistance,
-                self.m_totalDistance,
-                self.m_safetyCarDelta,
-                self.m_carPosition,
-                self.m_currentLapNum,
-                self.m_pitStatus,
-                self.m_numPitStops,
-                self.m_sector,
-                self.m_currentLapInvalid,
-                self.m_penalties,
-                self.m_totalWarnings,
-                self.m_cornerCuttingWarnings,
-                self.m_numUnservedDriveThroughPens,
-                self.m_numUnservedStopGoPens,
-                self.m_gridPosition,
-                self.m_driverStatus,
-                self.m_resultStatus,
-                self.m_pitLaneTimerActive,
-                self.m_pitLaneTimeInLaneInMS,
-                self.m_pitStopTimerInMS,
-                self.m_pitStopShouldServePen,
-                self.m_speedTrapFastestSpeed,
-                self.m_speedTrapFastestLap
-            ) = self.COMPILED_PACKET_STRUCT_24.unpack(raw_data)
+        self._parse(data, packet_format)
+        self._cast_enums()
 
+    def _parse(self, data: bytes, packet_format: int) -> None:
+        """Raw byte unpacking only. Dispatches to format-specific helpers."""
+        if packet_format == 2023:
+            self._parse_f23(data)
+        else:  # 24+
+            self._parse_f24(data)
+
+    def _parse_f23(self, data: bytes) -> None:
+        (
+            self.m_lastLapTimeInMS,
+            self.m_currentLapTimeInMS,
+            self.m_sector1TimeInMS,
+            self.m_sector1TimeMinutes,
+            self.m_sector2TimeInMS,
+            self.m_sector2TimeMinutes,
+            self.m_deltaToCarInFrontInMS,
+            self.m_deltaToRaceLeaderInMS,
+            self.m_lapDistance,
+            self.m_totalDistance,
+            self.m_safetyCarDelta,
+            self.m_carPosition,
+            self.m_currentLapNum,
+            self.m_pitStatus,
+            self.m_numPitStops,
+            self.m_sector,
+            self.m_currentLapInvalid,
+            self.m_penalties,
+            self.m_totalWarnings,
+            self.m_cornerCuttingWarnings,
+            self.m_numUnservedDriveThroughPens,
+            self.m_numUnservedStopGoPens,
+            self.m_gridPosition,
+            self.m_driverStatus,
+            self.m_resultStatus,
+            self.m_pitLaneTimerActive,
+            self.m_pitLaneTimeInLaneInMS,
+            self.m_pitStopTimerInMS,
+            self.m_pitStopShouldServePen,
+        ) = self.COMPILED_PACKET_STRUCT_23.unpack(data[:self.PACKET_LEN_23])
+        self.m_deltaToCarInFrontMinutes: int = 0
+        self.m_deltaToRaceLeaderMinutes: int = 0
+        self.m_speedTrapFastestSpeed: float = 0
+        self.m_speedTrapFastestLap: int = 0
+
+    def _parse_f24(self, data: bytes) -> None:
+        (
+            self.m_lastLapTimeInMS,
+            self.m_currentLapTimeInMS,
+            self.m_sector1TimeInMS,
+            self.m_sector1TimeMinutes,
+            self.m_sector2TimeInMS,
+            self.m_sector2TimeMinutes,
+            self.m_deltaToCarInFrontInMS,
+            self.m_deltaToCarInFrontMinutes,
+            self.m_deltaToRaceLeaderInMS,
+            self.m_deltaToRaceLeaderMinutes,
+            self.m_lapDistance,
+            self.m_totalDistance,
+            self.m_safetyCarDelta,
+            self.m_carPosition,
+            self.m_currentLapNum,
+            self.m_pitStatus,
+            self.m_numPitStops,
+            self.m_sector,
+            self.m_currentLapInvalid,
+            self.m_penalties,
+            self.m_totalWarnings,
+            self.m_cornerCuttingWarnings,
+            self.m_numUnservedDriveThroughPens,
+            self.m_numUnservedStopGoPens,
+            self.m_gridPosition,
+            self.m_driverStatus,
+            self.m_resultStatus,
+            self.m_pitLaneTimerActive,
+            self.m_pitLaneTimeInLaneInMS,
+            self.m_pitStopTimerInMS,
+            self.m_pitStopShouldServePen,
+            self.m_speedTrapFastestSpeed,
+            self.m_speedTrapFastestLap
+        ) = self.COMPILED_PACKET_STRUCT_24.unpack(data[0:self.PACKET_LEN_24])
+
+    def _cast_enums(self) -> None:
+        """All safeCast and bool conversions in one place."""
         self.m_driverStatus = LapData.DriverStatus.safeCast(self.m_driverStatus)
         self.m_resultStatus = ResultStatus.safeCast(self.m_resultStatus)
         self.m_pitStatus = LapData.PitStatus.safeCast(self.m_pitStatus)

--- a/lib/f1_types/packet_3_event_data.py
+++ b/lib/f1_types/packet_3_event_data.py
@@ -603,7 +603,10 @@ class PacketEventData(F1PacketBase):
                 self.lapNum,
                 self.placesGained
             ) = self.COMPILED_PACKET_STRUCT.unpack(data[:self.PACKET_LEN])
+            self._cast_enums()
 
+        def _cast_enums(self) -> None:
+            """Cast raw ints to penalty/infringement enums."""
             self.penaltyType = PacketEventData.Penalty.PenaltyType.safeCast(self.penaltyType)
             self.infringementType = PacketEventData.Penalty.InfringementType.safeCast(self.infringementType)
 
@@ -704,6 +707,10 @@ class PacketEventData(F1PacketBase):
                 self.fastestVehicleIdxInSession,
                 self.fastestSpeedInSession
             ) = self.COMPILED_PACKET_STRUCT.unpack(data[:self.PACKET_LEN])
+            self._cast_enums()
+
+        def _cast_enums(self) -> None:
+            """Cast raw ints to bools."""
             self.isOverallFastestInSession = bool(self.isOverallFastestInSession)
             self.isDriverFastestInSession = bool(self.isDriverFastestInSession)
 
@@ -1351,6 +1358,10 @@ class PacketEventData(F1PacketBase):
                 struct.error: If the binary data does not match the expected format.
             """
             self.m_safety_car_type, self.m_event_type = self.COMPILED_PACKET_STRUCT.unpack(data[:self.PACKET_LEN])
+            self._cast_enums()
+
+        def _cast_enums(self) -> None:
+            """Cast raw ints to safety car type/event enums."""
             self.m_safety_car_type = SafetyCarType.safeCast(self.m_safety_car_type)
             self.m_event_type = SafetyCarEventType.safeCast(self.m_event_type)
 

--- a/lib/f1_types/packet_4_participants_data.py
+++ b/lib/f1_types/packet_4_participants_data.py
@@ -208,63 +208,78 @@ class ParticipantData(F1SubPacketBase):
         self.m_packetFormat = packet_format
         self.m_numColours: int = 0
         self.m_liveryColours: List[LiveryColour]
+        self._parse(data, packet_format)
+        self._cast_enums(packet_format)
+
+    def _parse(self, data: bytes, packet_format: int) -> None:
+        """Raw byte unpacking only. Dispatches to format-specific helpers."""
         if packet_format == 2023:
-            (
-                self.m_aiControlled,
-                self.m_driverId,
-                self.networkId,
-                self.m_teamId,
-                self.m_myTeam,
-                self.m_raceNumber,
-                self.m_nationality,
-                self.m_name,
-                self.m_yourTelemetry,
-                self.m_showOnlineNames,
-                self.m_platform
-            ) = self.COMPILED_PACKET_STRUCT_23.unpack(data)
-            self.m_techLevel = 0
+            self._parse_f23(data)
         elif packet_format == 2024:
-            (
-                self.m_aiControlled,
-                self.m_driverId,
-                self.networkId,
-                self.m_teamId,
-                self.m_myTeam,
-                self.m_raceNumber,
-                self.m_nationality,
-                self.m_name,
-                self.m_yourTelemetry,
-                self.m_showOnlineNames,
-                self.m_techLevel,
-                self.m_platform
-            ) = self.COMPILED_PACKET_STRUCT_24.unpack(data)
+            self._parse_f24(data)
         else:
-
-            (
-                self.m_aiControlled,
-                self.m_driverId,
-                self.networkId,
-                self.m_teamId,
-                self.m_myTeam,
-                self.m_raceNumber,
-                self.m_nationality,
-                self.m_name,
-                self.m_yourTelemetry,
-                self.m_showOnlineNames,
-                self.m_techLevel,
-                self.m_platform,
-                self.m_numColours
-            ) = self.COMPILED_PACKET_STRUCT_25_BASE.unpack(data[:self.PACKET_LEN_25_BASE])
-
-            self.m_liveryColours, _ = LiveryColour.parse_array(
-                data=data,
-                offset=self.PACKET_LEN_25_BASE,
-                item_len=LiveryColour.PACKET_LEN,
-                count=self.m_numColours,
-                max_count=self.MAX_LIVERY_COLOURS
-            )
-
+            self._parse_f25(data)
         self.m_name = self.m_name.decode('utf-8', errors='replace').rstrip('\x00')
+
+    def _parse_f23(self, data: bytes) -> None:
+        (
+            self.m_aiControlled,
+            self.m_driverId,
+            self.networkId,
+            self.m_teamId,
+            self.m_myTeam,
+            self.m_raceNumber,
+            self.m_nationality,
+            self.m_name,
+            self.m_yourTelemetry,
+            self.m_showOnlineNames,
+            self.m_platform
+        ) = self.COMPILED_PACKET_STRUCT_23.unpack(data)
+        self.m_techLevel = 0
+
+    def _parse_f24(self, data: bytes) -> None:
+        (
+            self.m_aiControlled,
+            self.m_driverId,
+            self.networkId,
+            self.m_teamId,
+            self.m_myTeam,
+            self.m_raceNumber,
+            self.m_nationality,
+            self.m_name,
+            self.m_yourTelemetry,
+            self.m_showOnlineNames,
+            self.m_techLevel,
+            self.m_platform
+        ) = self.COMPILED_PACKET_STRUCT_24.unpack(data)
+
+    def _parse_f25(self, data: bytes) -> None:
+        (
+            self.m_aiControlled,
+            self.m_driverId,
+            self.networkId,
+            self.m_teamId,
+            self.m_myTeam,
+            self.m_raceNumber,
+            self.m_nationality,
+            self.m_name,
+            self.m_yourTelemetry,
+            self.m_showOnlineNames,
+            self.m_techLevel,
+            self.m_platform,
+            self.m_numColours
+        ) = self.COMPILED_PACKET_STRUCT_25_BASE.unpack(data[:self.PACKET_LEN_25_BASE])
+
+        self.m_liveryColours, _ = LiveryColour.parse_array(
+            data=data,
+            offset=self.PACKET_LEN_25_BASE,
+            item_len=LiveryColour.PACKET_LEN,
+            count=self.m_numColours,
+            max_count=self.MAX_LIVERY_COLOURS
+        )
+
+    def _cast_enums(self, packet_format: int) -> None:
+        """All safeCast and bool conversions in one place."""
         self.m_platform = Platform.safeCast(self.m_platform)
         if packet_format == 2023:
             self.m_teamId = TeamID23.safeCast(self.m_teamId)

--- a/lib/f1_types/packet_5_car_setups_data.py
+++ b/lib/f1_types/packet_5_car_setups_data.py
@@ -150,58 +150,68 @@ class CarSetupData(F1SubPacketBase):
         """
 
         self.m_packetFormat = packet_format
+        self._parse(data, packet_format)
+
+    def _parse(self, data: bytes, packet_format: int) -> None:
+        """Raw byte unpacking. Dispatches to format-specific helpers."""
         if packet_format == 2023:
-            (
-                self.m_frontWing,
-                self.m_rearWing,
-                self.m_onThrottle,
-                self.m_offThrottle,
-                self.m_frontCamber,
-                self.m_rearCamber,
-                self.m_frontToe,
-                self.m_rearToe,
-                self.m_frontSuspension,
-                self.m_rearSuspension,
-                self.m_frontAntiRollBar,
-                self.m_rearAntiRollBar,
-                self.m_frontSuspensionHeight,
-                self.m_rearSuspensionHeight,
-                self.m_brakePressure,
-                self.m_brakeBias,
-                self.m_rearLeftTyrePressure,
-                self.m_rearRightTyrePressure,
-                self.m_frontLeftTyrePressure,
-                self.m_frontRightTyrePressure,
-                self.m_ballast,
-                self.m_fuelLoad,
-            ) = self.COMPILED_PACKET_STRUCT_23.unpack(data)
-            self.m_engineBraking = 0
+            self._parse_f23(data)
         else:
-            (
-                self.m_frontWing,
-                self.m_rearWing,
-                self.m_onThrottle,
-                self.m_offThrottle,
-                self.m_frontCamber,
-                self.m_rearCamber,
-                self.m_frontToe,
-                self.m_rearToe,
-                self.m_frontSuspension,
-                self.m_rearSuspension,
-                self.m_frontAntiRollBar,
-                self.m_rearAntiRollBar,
-                self.m_frontSuspensionHeight,
-                self.m_rearSuspensionHeight,
-                self.m_brakePressure,
-                self.m_brakeBias,
-                self.m_engineBraking,
-                self.m_rearLeftTyrePressure,
-                self.m_rearRightTyrePressure,
-                self.m_frontLeftTyrePressure,
-                self.m_frontRightTyrePressure,
-                self.m_ballast,
-                self.m_fuelLoad,
-            ) = self.COMPILED_PACKET_STRUCT_24.unpack(data)
+            self._parse_f24(data)
+
+    def _parse_f23(self, data: bytes) -> None:
+        (
+            self.m_frontWing,
+            self.m_rearWing,
+            self.m_onThrottle,
+            self.m_offThrottle,
+            self.m_frontCamber,
+            self.m_rearCamber,
+            self.m_frontToe,
+            self.m_rearToe,
+            self.m_frontSuspension,
+            self.m_rearSuspension,
+            self.m_frontAntiRollBar,
+            self.m_rearAntiRollBar,
+            self.m_frontSuspensionHeight,
+            self.m_rearSuspensionHeight,
+            self.m_brakePressure,
+            self.m_brakeBias,
+            self.m_rearLeftTyrePressure,
+            self.m_rearRightTyrePressure,
+            self.m_frontLeftTyrePressure,
+            self.m_frontRightTyrePressure,
+            self.m_ballast,
+            self.m_fuelLoad,
+        ) = self.COMPILED_PACKET_STRUCT_23.unpack(data)
+        self.m_engineBraking = 0
+
+    def _parse_f24(self, data: bytes) -> None:
+        (
+            self.m_frontWing,
+            self.m_rearWing,
+            self.m_onThrottle,
+            self.m_offThrottle,
+            self.m_frontCamber,
+            self.m_rearCamber,
+            self.m_frontToe,
+            self.m_rearToe,
+            self.m_frontSuspension,
+            self.m_rearSuspension,
+            self.m_frontAntiRollBar,
+            self.m_rearAntiRollBar,
+            self.m_frontSuspensionHeight,
+            self.m_rearSuspensionHeight,
+            self.m_brakePressure,
+            self.m_brakeBias,
+            self.m_engineBraking,
+            self.m_rearLeftTyrePressure,
+            self.m_rearRightTyrePressure,
+            self.m_frontLeftTyrePressure,
+            self.m_frontRightTyrePressure,
+            self.m_ballast,
+            self.m_fuelLoad,
+        ) = self.COMPILED_PACKET_STRUCT_24.unpack(data)
 
     def isValid(self) -> bool:
         """

--- a/lib/f1_types/packet_6_car_telemetry_data.py
+++ b/lib/f1_types/packet_6_car_telemetry_data.py
@@ -104,6 +104,11 @@ class CarTelemetryData(F1SubPacketBase):
         Raises:
             struct.error: If the binary data does not match the expected format.
         """
+        self._parse(data)
+        self._cast_enums()
+
+    def _parse(self, data: bytes) -> None:
+        """Raw byte unpacking."""
         self.m_brakesTemperature = [0] * 4
         self.m_tyresSurfaceTemperature = [0] * 4
         self.m_tyresInnerTemperature = [0] * 4
@@ -144,6 +149,8 @@ class CarTelemetryData(F1SubPacketBase):
             self.m_surfaceType[3],
         ) = self.COMPILED_PACKET_STRUCT.unpack(data)
 
+    def _cast_enums(self) -> None:
+        """All bool conversions in one place."""
         self.m_drs = bool(self.m_drs)
 
     def __str__(self) -> str:

--- a/lib/f1_types/packet_7_car_status_data.py
+++ b/lib/f1_types/packet_7_car_status_data.py
@@ -265,6 +265,11 @@ class CarStatusData(F1SubPacketBase):
             data (bytes): Raw data representing car status.
         """
 
+        self._parse(data)
+        self._cast_enums()
+
+    def _parse(self, data: bytes) -> None:
+        """Unpack raw bytes into fields."""
         (
             self.m_tractionControl,
             self.m_antiLockBrakes,
@@ -290,14 +295,14 @@ class CarStatusData(F1SubPacketBase):
             self.m_ersHarvestedThisLapMGUK,
             self.m_ersHarvestedThisLapMGUH,
             self.m_ersDeployedThisLap,
-            self.m_networkPaused
+            self.m_networkPaused,
         ) = self.COMPILED_PACKET_STRUCT.unpack(data)
 
-        # Convert boolean fields using bitwise AND
+    def _cast_enums(self) -> None:
+        """Convert raw ints to bools and enums."""
         self.m_antiLockBrakes = bool(self.m_antiLockBrakes)
         self.m_pitLimiterStatus = bool(self.m_pitLimiterStatus)
         self.m_networkPaused = bool(self.m_networkPaused)
-
         self.m_actualTyreCompound = ActualTyreCompound.safeCast(self.m_actualTyreCompound)
         self.m_visualTyreCompound = VisualTyreCompound.safeCast(self.m_visualTyreCompound)
         self.m_vehicleFiaFlags = CarStatusData.VehicleFIAFlags.safeCast(self.m_vehicleFiaFlags)

--- a/lib/f1_types/packet_8_final_classification_data.py
+++ b/lib/f1_types/packet_8_final_classification_data.py
@@ -131,99 +131,110 @@ class FinalClassificationData(F1SubPacketBase):
         self.m_tyreStintsEndLaps: List[int] = [0] * 8
         self.m_resultReason: ResultReason = ResultReason.INVALID
         self.m_packetFormat = packet_format
-        if packet_format <= 2024:
-            (
-                self.m_position,
-                self.m_numLaps,
-                self.m_gridPosition,
-                self.m_points,
-                self.m_numPitStops,
-                self.m_resultStatus,
-                self.m_bestLapTimeInMS,
-                self.m_totalRaceTime,
-                self.m_penaltiesTime,
-                self.m_numPenalties,
-                self.m_numTyreStints,
-                # self.m_tyreStintsActual,  # array of 8
-                self.m_tyreStintsActual[0],
-                self.m_tyreStintsActual[1],
-                self.m_tyreStintsActual[2],
-                self.m_tyreStintsActual[3],
-                self.m_tyreStintsActual[4],
-                self.m_tyreStintsActual[5],
-                self.m_tyreStintsActual[6],
-                self.m_tyreStintsActual[7],
-                # self.m_tyreStintsVisual,  # array of 8
-                self.m_tyreStintsVisual[0],
-                self.m_tyreStintsVisual[1],
-                self.m_tyreStintsVisual[2],
-                self.m_tyreStintsVisual[3],
-                self.m_tyreStintsVisual[4],
-                self.m_tyreStintsVisual[5],
-                self.m_tyreStintsVisual[6],
-                self.m_tyreStintsVisual[7],
-                # self.m_tyreStintsEndLaps,  # array of 8
-                self.m_tyreStintsEndLaps[0],
-                self.m_tyreStintsEndLaps[1],
-                self.m_tyreStintsEndLaps[2],
-                self.m_tyreStintsEndLaps[3],
-                self.m_tyreStintsEndLaps[4],
-                self.m_tyreStintsEndLaps[5],
-                self.m_tyreStintsEndLaps[6],
-                self.m_tyreStintsEndLaps[7]
-            ) = self.COMPILED_PACKET_STRUCT.unpack(data)
-        else: # F1 25+
-            (
-                self.m_position,
-                self.m_numLaps,
-                self.m_gridPosition,
-                self.m_points,
-                self.m_numPitStops,
-                self.m_resultStatus,
-                self.m_resultReason,
-                self.m_bestLapTimeInMS,
-                self.m_totalRaceTime,
-                self.m_penaltiesTime,
-                self.m_numPenalties,
-                self.m_numTyreStints,
-                # self.m_tyreStintsActual,  # array of 8
-                self.m_tyreStintsActual[0],
-                self.m_tyreStintsActual[1],
-                self.m_tyreStintsActual[2],
-                self.m_tyreStintsActual[3],
-                self.m_tyreStintsActual[4],
-                self.m_tyreStintsActual[5],
-                self.m_tyreStintsActual[6],
-                self.m_tyreStintsActual[7],
-                # self.m_tyreStintsVisual,  # array of 8
-                self.m_tyreStintsVisual[0],
-                self.m_tyreStintsVisual[1],
-                self.m_tyreStintsVisual[2],
-                self.m_tyreStintsVisual[3],
-                self.m_tyreStintsVisual[4],
-                self.m_tyreStintsVisual[5],
-                self.m_tyreStintsVisual[6],
-                self.m_tyreStintsVisual[7],
-                # self.m_tyreStintsEndLaps,  # array of 8
-                self.m_tyreStintsEndLaps[0],
-                self.m_tyreStintsEndLaps[1],
-                self.m_tyreStintsEndLaps[2],
-                self.m_tyreStintsEndLaps[3],
-                self.m_tyreStintsEndLaps[4],
-                self.m_tyreStintsEndLaps[5],
-                self.m_tyreStintsEndLaps[6],
-                self.m_tyreStintsEndLaps[7]
-            ) = self.COMPILED_PACKET_STRUCT_25.unpack(data)
+        self._parse(data, packet_format)
+        self._cast_enums()
 
+    def _parse(self, data: bytes, packet_format: int) -> None:
+        """Dispatch to the correct format-specific unpack."""
+        if packet_format <= 2024:
+            self._parse_pre25(data)
+        else:
+            self._parse_f25(data)
+
+    def _parse_pre25(self, data: bytes) -> None:
+        """Unpack F1 2023/2024 binary layout."""
+        (
+            self.m_position,
+            self.m_numLaps,
+            self.m_gridPosition,
+            self.m_points,
+            self.m_numPitStops,
+            self.m_resultStatus,
+            self.m_bestLapTimeInMS,
+            self.m_totalRaceTime,
+            self.m_penaltiesTime,
+            self.m_numPenalties,
+            self.m_numTyreStints,
+            # self.m_tyreStintsActual,  # array of 8
+            self.m_tyreStintsActual[0],
+            self.m_tyreStintsActual[1],
+            self.m_tyreStintsActual[2],
+            self.m_tyreStintsActual[3],
+            self.m_tyreStintsActual[4],
+            self.m_tyreStintsActual[5],
+            self.m_tyreStintsActual[6],
+            self.m_tyreStintsActual[7],
+            # self.m_tyreStintsVisual,  # array of 8
+            self.m_tyreStintsVisual[0],
+            self.m_tyreStintsVisual[1],
+            self.m_tyreStintsVisual[2],
+            self.m_tyreStintsVisual[3],
+            self.m_tyreStintsVisual[4],
+            self.m_tyreStintsVisual[5],
+            self.m_tyreStintsVisual[6],
+            self.m_tyreStintsVisual[7],
+            # self.m_tyreStintsEndLaps,  # array of 8
+            self.m_tyreStintsEndLaps[0],
+            self.m_tyreStintsEndLaps[1],
+            self.m_tyreStintsEndLaps[2],
+            self.m_tyreStintsEndLaps[3],
+            self.m_tyreStintsEndLaps[4],
+            self.m_tyreStintsEndLaps[5],
+            self.m_tyreStintsEndLaps[6],
+            self.m_tyreStintsEndLaps[7],
+        ) = self.COMPILED_PACKET_STRUCT.unpack(data)
+
+    def _parse_f25(self, data: bytes) -> None:
+        """Unpack F1 2025+ binary layout (includes m_resultReason)."""
+        (
+            self.m_position,
+            self.m_numLaps,
+            self.m_gridPosition,
+            self.m_points,
+            self.m_numPitStops,
+            self.m_resultStatus,
+            self.m_resultReason,
+            self.m_bestLapTimeInMS,
+            self.m_totalRaceTime,
+            self.m_penaltiesTime,
+            self.m_numPenalties,
+            self.m_numTyreStints,
+            # self.m_tyreStintsActual,  # array of 8
+            self.m_tyreStintsActual[0],
+            self.m_tyreStintsActual[1],
+            self.m_tyreStintsActual[2],
+            self.m_tyreStintsActual[3],
+            self.m_tyreStintsActual[4],
+            self.m_tyreStintsActual[5],
+            self.m_tyreStintsActual[6],
+            self.m_tyreStintsActual[7],
+            # self.m_tyreStintsVisual,  # array of 8
+            self.m_tyreStintsVisual[0],
+            self.m_tyreStintsVisual[1],
+            self.m_tyreStintsVisual[2],
+            self.m_tyreStintsVisual[3],
+            self.m_tyreStintsVisual[4],
+            self.m_tyreStintsVisual[5],
+            self.m_tyreStintsVisual[6],
+            self.m_tyreStintsVisual[7],
+            # self.m_tyreStintsEndLaps,  # array of 8
+            self.m_tyreStintsEndLaps[0],
+            self.m_tyreStintsEndLaps[1],
+            self.m_tyreStintsEndLaps[2],
+            self.m_tyreStintsEndLaps[3],
+            self.m_tyreStintsEndLaps[4],
+            self.m_tyreStintsEndLaps[5],
+            self.m_tyreStintsEndLaps[6],
+            self.m_tyreStintsEndLaps[7],
+        ) = self.COMPILED_PACKET_STRUCT_25.unpack(data)
+
+    def _cast_enums(self) -> None:
+        """Cast raw ints to enums and trim tyre stint arrays."""
         self.m_resultStatus = ResultStatus.safeCast(self.m_resultStatus)
         self.m_resultReason = ResultReason.safeCast(self.m_resultReason)
-
-        # Trim the tyre stints info
-        self.m_tyreStintsActual     = self.m_tyreStintsActual[:self.m_numTyreStints]
-        self.m_tyreStintsVisual     = self.m_tyreStintsVisual[:self.m_numTyreStints]
-        self.m_tyreStintsEndLaps    = self.m_tyreStintsEndLaps[:self.m_numTyreStints]
-
-        # Make tyre stint values as enum
+        self.m_tyreStintsActual = self.m_tyreStintsActual[:self.m_numTyreStints]
+        self.m_tyreStintsVisual = self.m_tyreStintsVisual[:self.m_numTyreStints]
+        self.m_tyreStintsEndLaps = self.m_tyreStintsEndLaps[:self.m_numTyreStints]
         self.m_tyreStintsActual = [ActualTyreCompound.safeCast(compound) for compound in self.m_tyreStintsActual]
         self.m_tyreStintsVisual = [VisualTyreCompound.safeCast(compound) for compound in self.m_tyreStintsVisual]
 

--- a/lib/f1_types/packet_9_lobby_info_data.py
+++ b/lib/f1_types/packet_9_lobby_info_data.py
@@ -182,7 +182,7 @@ class LobbyInfoData(F1SubPacketBase):
             self.m_teamId = TeamID23.safeCast(self.m_teamId)
         elif packet_format == 2024:
             self.m_teamId = TeamID24.safeCast(self.m_teamId)
-        elif packet_format == 2025:
+        elif packet_format >= 2025:
             self.m_teamId = TeamID25.safeCast(self.m_teamId)
         if packet_format != 2023:
             self.m_yourTelemetry = TelemetrySetting.safeCast(self.m_yourTelemetry)
@@ -279,7 +279,7 @@ class LobbyInfoData(F1SubPacketBase):
                 self.m_techLevel,
                 self.m_readyStatus.value,
             )
-        if self.packet_format == 2025:
+        if self.packet_format >= 2025:
             return self.COMPILED_PACKET_STRUCT_25.pack(
                 self.m_aiControlled,
                 self.m_teamId.value,
@@ -351,7 +351,7 @@ class LobbyInfoData(F1SubPacketBase):
                 tech_level,
                 ready_status.value,
             ), header.m_packetFormat)
-        if header.m_packetFormat == 2025:
+        if header.m_packetFormat >= 2025:
             return cls(cls.COMPILED_PACKET_STRUCT_25.pack(
                 ai_controlled,
                 team_id.value,

--- a/lib/f1_types/packet_9_lobby_info_data.py
+++ b/lib/f1_types/packet_9_lobby_info_data.py
@@ -121,48 +121,71 @@ class LobbyInfoData(F1SubPacketBase):
         """
 
         self.packet_format = packet_format
+        self._parse(data, packet_format)
+        self._cast_enums(packet_format)
+
+    def _parse(self, data: bytes, packet_format: int) -> None:
+        """Raw byte unpacking only. Dispatches to format-specific helpers."""
         if packet_format == 2023:
-            (
-                self.m_aiControlled,
-                self.m_teamId,
-                self.m_nationality,
-                self.m_platform,
-                self.m_name,
-                self.m_carNumber,
-                self.m_readyStatus,
-            ) = self.COMPILED_PACKET_STRUCT_23.unpack(data)
-            self.m_yourTelemetry = TelemetrySetting.PUBLIC
-            self.m_showOnlineNames = True
-            self.m_techLevel = 0
+            self._parse_f23(data)
+        elif packet_format == 2024:
+            self._parse_f24(data)
         else:
-            if packet_format == 2024:
-                _struct = self.COMPILED_PACKET_STRUCT_24
-            else:
-                _struct = self.COMPILED_PACKET_STRUCT_25
-
-            (
-                self.m_aiControlled,
-                self.m_teamId,
-                self.m_nationality,
-                self.m_platform,
-                self.m_name,
-                self.m_carNumber,
-                self.m_yourTelemetry,
-                self.m_showOnlineNames,
-                self.m_techLevel,
-                self.m_readyStatus,
-            ) = _struct.unpack(data)
-            self.m_yourTelemetry = TelemetrySetting.safeCast(self.m_yourTelemetry)
-
+            self._parse_f25(data)
         self.m_name = self.m_name.decode('utf-8', errors='replace').rstrip('\x00')
 
-        if self.packet_format == 2023:
-            self.m_teamId = TeamID23.safeCast(self.m_teamId)
-        elif self.packet_format == 2024:
-            self.m_teamId = TeamID24.safeCast(self.m_teamId)
-        elif self.packet_format == 2025:
-            self.m_teamId = TeamID25.safeCast(self.m_teamId)
+    def _parse_f23(self, data: bytes) -> None:
+        (
+            self.m_aiControlled,
+            self.m_teamId,
+            self.m_nationality,
+            self.m_platform,
+            self.m_name,
+            self.m_carNumber,
+            self.m_readyStatus,
+        ) = self.COMPILED_PACKET_STRUCT_23.unpack(data)
+        self.m_yourTelemetry = TelemetrySetting.PUBLIC
+        self.m_showOnlineNames = True
+        self.m_techLevel = 0
 
+    def _parse_f24(self, data: bytes) -> None:
+        (
+            self.m_aiControlled,
+            self.m_teamId,
+            self.m_nationality,
+            self.m_platform,
+            self.m_name,
+            self.m_carNumber,
+            self.m_yourTelemetry,
+            self.m_showOnlineNames,
+            self.m_techLevel,
+            self.m_readyStatus,
+        ) = self.COMPILED_PACKET_STRUCT_24.unpack(data)
+
+    def _parse_f25(self, data: bytes) -> None:
+        (
+            self.m_aiControlled,
+            self.m_teamId,
+            self.m_nationality,
+            self.m_platform,
+            self.m_name,
+            self.m_carNumber,
+            self.m_yourTelemetry,
+            self.m_showOnlineNames,
+            self.m_techLevel,
+            self.m_readyStatus,
+        ) = self.COMPILED_PACKET_STRUCT_25.unpack(data)
+
+    def _cast_enums(self, packet_format: int) -> None:
+        """All safeCast and bool conversions in one place."""
+        if packet_format == 2023:
+            self.m_teamId = TeamID23.safeCast(self.m_teamId)
+        elif packet_format == 2024:
+            self.m_teamId = TeamID24.safeCast(self.m_teamId)
+        elif packet_format == 2025:
+            self.m_teamId = TeamID25.safeCast(self.m_teamId)
+        if packet_format != 2023:
+            self.m_yourTelemetry = TelemetrySetting.safeCast(self.m_yourTelemetry)
         self.m_nationality = Nationality.safeCast(self.m_nationality)
         self.m_platform = Platform.safeCast(self.m_platform)
         self.m_readyStatus = LobbyInfoData.ReadyStatus.safeCast(self.m_readyStatus)

--- a/tests/f1_types/tests_packet_1_session_data.py
+++ b/tests/f1_types/tests_packet_1_session_data.py
@@ -271,6 +271,7 @@ class TestPacketSessionData(F1TypesTest):
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
         self.assertFalse(hasattr(parsed_packet, '__dict__'))
+        self.assertEqual(parsed_packet, PacketSessionData(random_header, packet))
 
     def test_f1_24(self):
         """
@@ -437,3 +438,4 @@ class TestPacketSessionData(F1TypesTest):
         parsed_json = parsed_packet.toJSON()
         self.jsonComparisionUtil(expected_json, parsed_json)
         self.assertFalse(hasattr(parsed_packet, '__dict__'))
+        self.assertEqual(parsed_packet, PacketSessionData(random_header, packet))


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Come up with a simple standardised flow for pkt obj construction

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [ ] New feature 🚀
- [x] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [x] All integration tests pass
* Attach test command/output:

```
================================================================================
2026-05-22 20:24:33,328 [TEST] [runner.py:281] - TEST STATISTICS
2026-05-22 20:24:33,328 [TEST] [runner.py:282] - ================================================================================
2026-05-22 20:24:33,329 [TEST] [runner.py:283] - Files processed:        32
2026-05-22 20:24:33,329 [TEST] [runner.py:284] - Telemetry sent:         32
2026-05-22 20:24:33,329 [TEST] [runner.py:285] - Telemetry failed:       0
2026-05-22 20:24:33,329 [TEST] [runner.py:286] - Endpoint checks passed: 832
2026-05-22 20:24:33,329 [TEST] [runner.py:287] - Endpoint checks failed: 0
2026-05-22 20:24:33,330 [TEST] [runner.py:294] - Telemetry success rate: 100.0%
2026-05-22 20:24:33,330 [TEST] [runner.py:298] - Endpoint success rate:  100.0%
2026-05-22 20:24:33,330 [TEST] [runner.py:300] - ================================================================================
2026-05-22 20:24:33,331 [TEST] [runner.py:404] - 
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [x] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [ ] My code follows project style conventions
* [ ] All new and existing tests pass
* [ ] I have added relevant documentation/comments
* [ ] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Refactor F1 telemetry packet parsers to standardise parsing, enum casting, and equality/JSON handling across formats.

Enhancements:
- Split parsing logic into format-specific helper methods and centralised enum/boolean casting for multiple F1 packet types (session, lap, final classification, car damage, participants, car setups, lobby info, car motion, event, car status, telemetry, time trial, and session history).
- Improve PacketSessionData JSON generation and equality checks by separating base vs F1 24+ fields and comparisons.
- Clarify handling of pre- and post-2025 binary layouts for packets that gained new fields while keeping default values for older formats.

Tests:
- Extend PacketSessionData tests to also assert equality between independently parsed instances for F1 23 and F1 25 sample packets.