### PR TITLE
Traffic monitor MFD page

### DIFF
--- a/apps/backend/state_mgmt_layer/intf/readers/helpers/drivers_list_rsp.py
+++ b/apps/backend/state_mgmt_layer/intf/readers/helpers/drivers_list_rsp.py
@@ -444,25 +444,25 @@ class DriversListRsp(BaseAPI):
 
     def _getLapInfoJSON(self, driver_data: DataPerDriver) -> Dict[str, Any]:
         """Extract lap information section for JSON response."""
-        lap_progress = self._calculateLapProgress(driver_data)
+        lap_dist = self._getLapDistance(driver_data)
 
         return {
             "current-lap": driver_data.m_lap_info.m_current_lap,
             "last-lap": self._getLapDetailsSubsection(driver_data, for_best_lap=False),
             "best-lap": self._getLapDetailsSubsection(driver_data, for_best_lap=True),
             "curr-lap": self._getCurrLapSubsection(driver_data),
-            "lap-progress": lap_progress,
+            "lap-distance": lap_dist,
             "speed-trap-record-kmph": self._getSpeedTrapRecord(driver_data),
             "top-speed-kmph": driver_data.m_lap_info.m_top_speed_kmph_this_lap,
         }
 
-    def _calculateLapProgress(self, driver_data: DataPerDriver) -> Optional[float]:
-        """Calculate lap progress percentage."""
+    def _getLapDistance(self, driver_data: DataPerDriver) -> Optional[float]:
+        """Get lap distance."""
         lap_data = driver_data.m_packet_copies.m_packet_lap_data
         if not lap_data or not self.m_track_length:
             return None
 
-        return (lap_data.m_lapDistance / self.m_track_length) * 100.0
+        return lap_data.m_lapDistance
 
     def _getSpeedTrapRecord(self, driver_data: DataPerDriver) -> Optional[float]:
         """Get speed trap record if available."""

--- a/apps/backend/state_mgmt_layer/intf/readers/periodic_update_data.py
+++ b/apps/backend/state_mgmt_layer/intf/readers/periodic_update_data.py
@@ -72,6 +72,7 @@ class PeriodicUpdateData(BaseAPI):
             "packet-format" : self._getValueOrDefaultValue(self.m_session_info.m_packet_format, None),
             "circuit": str(self.m_session_info.m_track) if self.m_session_info.m_track is not None else "---",
             "circuit-len": self._getValueOrDefaultValue(self.m_track_length, default_value=None),
+            "circuit-enum-value": self.m_session_info.m_track.value if self.m_session_info.m_track is not None else None,
             "formula": str(self.m_session_info.m_formula) if self.m_session_info.m_formula is not None else None,
             "pit-time-loss": self.m_session_info.m_pit_time_loss,
             "track-temperature": self._getValueOrDefaultValue(self.m_session_info.m_track_temp, default_value=0),

--- a/apps/hud/common.py
+++ b/apps/hud/common.py
@@ -22,6 +22,7 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
+from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 
@@ -31,12 +32,12 @@ JSONType = Union[dict, list, str, int, float, bool, None]
 
 # -------------------------------------- CONSTANTS ---------------------------------------------------------------------
 
-ERS_MODE_COLORS: Dict[str, str] = {
+ERS_MODE_COLOR_DEFAULT = "#444444"
+ERS_MODE_COLORS: defaultdict = defaultdict(lambda: ERS_MODE_COLOR_DEFAULT, {
     "Medium":   "#e6d800",
     "Hotlap":   "#00e676",
     "Overtake": "#ff1744",
-}
-ERS_MODE_COLOR_DEFAULT = "#444444"
+})
 
 # -------------------------------------- FUNCTIONS ---------------------------------------------------------------------
 

--- a/apps/hud/common.py
+++ b/apps/hud/common.py
@@ -29,6 +29,15 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 JSONType = Union[dict, list, str, int, float, bool, None]
 
+# -------------------------------------- CONSTANTS ---------------------------------------------------------------------
+
+ERS_MODE_COLORS: Dict[str, str] = {
+    "Medium":   "#e6d800",
+    "Hotlap":   "#00e676",
+    "Overtake": "#ff1744",
+}
+ERS_MODE_COLOR_DEFAULT = "#444444"
+
 # -------------------------------------- FUNCTIONS ---------------------------------------------------------------------
 
 # ------------------------------------------------

--- a/apps/hud/ui/overlays/mfd/mfd.py
+++ b/apps/hud/ui/overlays/mfd/mfd.py
@@ -34,8 +34,8 @@ from apps.hud.ui.overlays.mfd.pages import (CollapsedPage, FuelInfoPage,
                                             LapTimesPage, MfdPageBase,
                                             PaceCompPage,
                                             PitRejoinPredictionPage,
-                                            TyreInfoPage, TyreSetsPage,
-                                            WeatherForecastPage)
+                                            TrafficMonitorPage, TyreInfoPage,
+                                            TyreSetsPage, WeatherForecastPage)
 from lib.config import (MfdPageId, OverlayId, OverlayPosition, PngSettings,
                         WeatherMFDUIType)
 
@@ -55,6 +55,7 @@ class MfdOverlay(BaseOverlayQML):
         WeatherForecastPage,
         TyreSetsPage,
         PaceCompPage,
+        TrafficMonitorPage,
     ]
     PAGE_CLS_BY_KEY = {page.KEY: page for page in PAGES}
 

--- a/apps/hud/ui/overlays/mfd/pages/base_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/base_page.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
 
 EventCommandHandler = Callable[[Dict[str, Any]], None] # Takes dict arg, returns None
 
+_UNSET = object()  # sentinel for absent page-property cache entries
+
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
 class MfdPageBase:
@@ -54,6 +56,7 @@ class MfdPageBase:
         self.logger = logger
         self._handlers: Dict[str, Callable[[Dict[str, Any]], None]] = {}
         self._stats = EventCounter()
+        self._page_props: dict = {}
 
     def on_event(self, event_type: str, requires_page_item: bool = True):
         """Decorator to register an event handler for this page.
@@ -101,6 +104,19 @@ class MfdPageBase:
         self._stats.track_event("__EVENTS__", "__TOTAL__")
         self._stats.track_event("__EVENTS__", event_type)
 
+    def _set_page_property(self, name: str, value) -> None:
+        """Set a property on the active page QML item with diff-based caching.
+
+        Silently does nothing when the page is not active or the value is
+        unchanged since the last push.
+        """
+        if self._page_item is None:
+            return
+        if self._page_props.get(name, _UNSET) == value:
+            return
+        self._page_props[name] = value
+        self._page_item.setProperty(name, value)
+
     @property
     def page_item(self):
         return self.overlay.current_page_item
@@ -108,6 +124,7 @@ class MfdPageBase:
     def _on_page_activated(self, item: QQuickItem):
         """Internal activation — stores item, tracks stats, then calls the public hook."""
         self._page_item = item
+        self._page_props.clear()  # fresh item — invalidate all cached property values
         self._stats.track_event("__LIFECYCLE__", "activated")
         self.logger.debug("%s | Page activated", self.KEY)
         self.on_page_activated(item)

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/__init__.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/__init__.py
@@ -22,28 +22,10 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
-from .base_page import MfdPageBase
-from .collapsed import CollapsedPage
-from .fuel import FuelInfoPage
-from .lap_times import LapTimesPage
-from .pit_rejoin import PitRejoinPredictionPage
-from .tyre_sets import TyreSetsPage
-from .tyre_wear import TyreInfoPage
-from .weather import WeatherForecastPage
-from .pace_comp.pace_comp import PaceCompPage
-from .traffic_monitor import TrafficMonitorPage
+from .traffic_monitor_page import TrafficMonitorPage
 
 # -------------------------------------- EXPORTS -----------------------------------------------------------------------
 
 __all__ = [
-    "MfdPageBase",
-    "CollapsedPage",
-    "FuelInfoPage",
-    "LapTimesPage",
-    "PitRejoinPredictionPage",
-    "TyreSetsPage",
-    "TyreInfoPage",
-    "WeatherForecastPage",
-    "PaceCompPage",
     "TrafficMonitorPage",
 ]

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
@@ -63,18 +63,17 @@ class TrafficMonitorPage(MfdPageBase):
     def _init_event_handlers(self):
         @self.on_event("race_table_update")
         def _handle_race_table_update(data: Dict[str, Any]) -> None:
-            page_item = self._page_item
             table_entries: Optional[List] = data.get("table-entries")
             circuit_len: Optional[float] = data.get("circuit-len")
             circuit_num: Optional[int] = data.get("circuit-enum-value")
 
             if not table_entries or not circuit_len:
-                page_item.showEmptyTable()
+                self._show_empty()
                 return
 
             ref_arr_index = get_ref_row_index(data)
             if ref_arr_index is None:
-                page_item.showEmptyTable()
+                self._show_empty()
                 return
 
             ref_row = table_entries[ref_arr_index]
@@ -83,12 +82,12 @@ class TrafficMonitorPage(MfdPageBase):
 
             ref_status = ref_row.get("lap-info", {}).get("curr-lap", {}).get("driver-status")
             if ref_status == _DRIVER_STATUS_IN_GARAGE:
-                page_item.showInGarage()
+                self._show_in_garage()
                 return
 
             ref_lap_dist: Optional[float] = ref_row.get("lap-info", {}).get("lap-distance")
             if ref_lap_dist is None:
-                page_item.showEmptyTable()
+                self._show_empty()
                 return
 
             active_entries = [
@@ -98,7 +97,7 @@ class TrafficMonitorPage(MfdPageBase):
 
             sorted_entries = sort_by_rel_distance(active_entries, ref_lap_dist, circuit_len)
             if not sorted_entries:
-                page_item.showEmptyTable()
+                self._show_empty()
                 return
 
             ref_pos = next(
@@ -106,11 +105,20 @@ class TrafficMonitorPage(MfdPageBase):
                 None,
             )
             if ref_pos is None:
-                page_item.showEmptyTable()
+                self._show_empty()
                 return
 
             window = get_traffic_window(sorted_entries, ref_pos, self.NUM_ADJACENT)
-            page_item.updateData(self._build_rows(window, ref_index, circuit_num))
+            self._set_page_property("tableData", self._build_rows(window, ref_index, circuit_num))
+            self._set_page_property("viewState", "table")
+
+    def _show_empty(self) -> None:
+        self._set_page_property("tableData", [])
+        self._set_page_property("viewState", "empty")
+
+    def _show_in_garage(self) -> None:
+        self._set_page_property("tableData", [])
+        self._set_page_property("viewState", "inGarage")
 
     # ------------------------------------------------------------------------------------------------------------------
 

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, final
 
 from PySide6.QtQuick import QQuickItem
 
-from apps.hud.common import get_ref_row_index
+from apps.hud.common import ERS_MODE_COLOR_DEFAULT, ERS_MODE_COLORS, get_ref_row_index
 from apps.hud.ui.overlays.mfd.pages.base_page import MfdPageBase
 from lib.config import MfdPageId
 from lib.track_segment_info import TrackSegmentsDatabase
@@ -39,13 +39,6 @@ if TYPE_CHECKING:
     from apps.hud.ui.overlays.mfd.mfd import MfdOverlay
 
 # -------------------------------------- CONSTANTS ---------------------------------------------------------------------
-
-_ERS_MODE_COLORS: Dict[str, str] = {
-    "Medium":   "#e6d800",
-    "Hotlap":   "#00e676",
-    "Overtake": "#ff1744",
-}
-_ERS_MODE_COLOR_DEFAULT = "#444444"
 
 _DRIVER_STATUS_IN_GARAGE = "IN_GARAGE"
 
@@ -147,7 +140,7 @@ class TrafficMonitorPage(MfdPageBase):
         return {
             "team":         driver_info.get("team", ""),
             "name":         driver_info.get("name", ""),
-            "ersColor":     _ERS_MODE_COLORS.get(ers_mode, _ERS_MODE_COLOR_DEFAULT),
+            "ersColor":     ERS_MODE_COLORS.get(ers_mode, ERS_MODE_COLOR_DEFAULT),
             "ersPercent":   f"{ers_info.get('ers-percent-float', 0.0) or 0.0:.0f}%",
             "drs":          driver_info.get("drs-activated", False) or False,
             "relDist":      "---" if is_ref else f"{rel_dist_m:+.0f}m",

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
@@ -24,7 +24,7 @@
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, final
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, final
 
 from PySide6.QtQuick import QQuickItem
 
@@ -164,13 +164,16 @@ class TrafficMonitorPage(MfdPageBase):
                 rel_dist_str = f"{rel_dist_m:+.0f}m"
                 rel_dist_color = "#FF4444" if rel_dist_m < 0 else "#44FF44"
 
-            ers_mode: Optional[str] = ers_info.get("ers-mode") or "None"
+            ers_mode: str = ers_info.get("ers-mode") or "None"
+            ers_perc_float: float = ers_info.get("ers-percent-float", 0.0) or 0.0
+            drs_active: bool = driver_info.get("drs-activated", False) or False
 
             rows_data.append({
                 "team": driver_info.get("team", ""),
                 "name": driver_info.get("name", ""),
-                "ersMode": ers_mode,
                 "ersColor": _ERS_MODE_COLORS.get(ers_mode, _ERS_MODE_COLOR_DEFAULT),
+                "ersPercent": f"{ers_perc_float:.0f}%",
+                "drs": drs_active,
                 "relDist": rel_dist_str,
                 "relDistColor": rel_dist_color,
                 "isRef": is_ref,

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
@@ -1,0 +1,178 @@
+# MIT License
+#
+# Copyright (c) [2025] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------- IMPORTS -----------------------------------------------------------------------
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, final
+
+from PySide6.QtQuick import QQuickItem
+
+from apps.hud.common import get_adjacent_positions, get_ref_row_index
+from apps.hud.ui.overlays.mfd.pages.base_page import MfdPageBase
+from lib.config import MfdPageId
+
+if TYPE_CHECKING:
+    from apps.hud.ui.overlays.mfd.mfd import MfdOverlay
+
+# -------------------------------------- CONSTANTS ---------------------------------------------------------------------
+
+_ERS_MODE_COLORS: Dict[str, str] = {
+    "Medium":   "#e6d800",
+    "Hotlap":   "#00e676",
+    "Overtake": "#ff1744",
+}
+_ERS_MODE_COLOR_DEFAULT = "#444444"
+
+_DRIVER_STATUS_IN_GARAGE = "IN_GARAGE"
+
+# -------------------------------------- CLASSES -----------------------------------------------------------------------
+
+class TrafficMonitorPage(MfdPageBase):
+    """Traffic Monitor MFD Page — nearest 2 cars ahead/behind sorted by lap distance."""
+    KEY = MfdPageId.TRAFFIC_MONITOR
+    QML_FILE: Path = Path(__file__).parent / "traffic_monitor_page.qml"
+
+    NUM_ADJACENT = 2
+
+    def __init__(self, overlay: "MfdOverlay", logger: logging.Logger):
+        super().__init__(overlay, logger)
+        self._init_event_handlers()
+
+    @final
+    def on_page_activated(self, _: QQuickItem):
+        pass
+
+    def _init_event_handlers(self):
+        @self.on_event("race_table_update")
+        def _handle_race_table_update(data: Dict[str, Any]) -> None:
+            page_item = self._page_item
+            table_entries = data.get("table-entries")
+            circuit_len = data.get("circuit-len")
+
+            if not table_entries or not circuit_len:
+                page_item.showEmptyTable()
+                return
+
+            ref_arr_index = get_ref_row_index(data)
+            if ref_arr_index is None:
+                page_item.showEmptyTable()
+                return
+
+            ref_row = table_entries[ref_arr_index]
+            ref_index = ref_row["driver-info"]["index"]
+            assert ref_index is not None
+
+            # Show IN GARAGE state when the ref driver is in the garage
+            ref_status = ref_row.get("lap-info", {}).get("curr-lap", {}).get("driver-status")
+            if ref_status == _DRIVER_STATUS_IN_GARAGE:
+                page_item.showInGarage()
+                return
+
+            # Filter out IN_GARAGE cars from the field
+            active_entries = [
+                e for e in table_entries
+                if e.get("lap-info", {}).get("curr-lap", {}).get("driver-status") != _DRIVER_STATUS_IN_GARAGE
+            ]
+
+            sorted_entries = self._sort_by_track_distance(active_entries, circuit_len)
+            if not sorted_entries:
+                page_item.showEmptyTable()
+                return
+
+            ref_pos_in_sorted = next(
+                (i for i, (_, row) in enumerate(sorted_entries)
+                 if row["driver-info"]["index"] == ref_index),
+                None,
+            )
+            if ref_pos_in_sorted is None:
+                page_item.showEmptyTable()
+                return
+
+            window = self._get_window(sorted_entries, ref_pos_in_sorted)
+            ref_total_dist = sorted_entries[ref_pos_in_sorted][0]
+            rows_data = self._build_rows(window, ref_index, ref_total_dist)
+            page_item.updateData(rows_data)
+
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def _sort_by_track_distance(
+        self,
+        table_entries: List[Dict[str, Any]],
+        circuit_len: float,
+    ) -> List[Tuple[float, Dict[str, Any]]]:
+        """Return (normalised_lap_dist, row) pairs sorted descending — furthest ahead first."""
+        result = []
+        for row in table_entries:
+            lap_dist = row.get("lap-info", {}).get("lap-distance")
+            if lap_dist is None:
+                continue
+            result.append((lap_dist % circuit_len, row))
+        result.sort(key=lambda x: x[0], reverse=True)
+        return result
+
+    def _get_window(
+        self,
+        sorted_entries: List[Tuple[float, Dict[str, Any]]],
+        ref_pos: int,
+    ) -> List[Tuple[float, Dict[str, Any]]]:
+        """Return up to NUM_ADJACENT ahead + ref + NUM_ADJACENT behind, clamped to available cars."""
+        total = len(sorted_entries)
+        lower_bound, upper_bound = get_adjacent_positions(ref_pos + 1, total, self.NUM_ADJACENT)
+        if lower_bound is None:
+            return [sorted_entries[ref_pos]]
+        return sorted_entries[lower_bound - 1 : upper_bound]
+
+    def _build_rows(
+        self,
+        window: List[Tuple[float, Dict[str, Any]]],
+        ref_index: int,
+        ref_total_dist: float,
+    ) -> List[Dict[str, Any]]:
+        rows_data = []
+        for total_dist, row in window:
+            driver_info: Dict[str, Any] = row.get("driver-info", {})
+            ers_info: Dict[str, Any] = row.get("ers-info", {})
+
+            is_ref = (driver_info.get("index", -1) == ref_index)
+
+            rel_dist_m = ref_total_dist - total_dist  # negative = other is ahead
+            if is_ref:
+                rel_dist_str = "---"
+                rel_dist_color = "white"
+            else:
+                rel_dist_str = f"{rel_dist_m:+.0f}m"
+                rel_dist_color = "#FF4444" if rel_dist_m < 0 else "#44FF44"
+
+            ers_mode: Optional[str] = ers_info.get("ers-mode") or "None"
+
+            rows_data.append({
+                "team": driver_info.get("team", ""),
+                "name": driver_info.get("name", ""),
+                "ersMode": ers_mode,
+                "ersColor": _ERS_MODE_COLORS.get(ers_mode, _ERS_MODE_COLOR_DEFAULT),
+                "relDist": rel_dist_str,
+                "relDistColor": rel_dist_color,
+                "isRef": is_ref,
+            })
+        return rows_data

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
@@ -186,7 +186,8 @@ class TrafficMonitorPage(MfdPageBase):
                     case "corner":
                         location_str = f"T{segment_info.corner_number}"
                     case "complex_corner":
-                        location_str = segment_info.render()["turns"]
+                        first, last = segment_info.corner_numbers[0], segment_info.corner_numbers[-1]
+                        location_str = f"T{first}-{last}"
 
             rows_data.append({
                 "team": driver_info.get("team", ""),

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
@@ -100,7 +100,12 @@ class TrafficMonitorPage(MfdPageBase):
                 if e.get("lap-info", {}).get("curr-lap", {}).get("driver-status") != _DRIVER_STATUS_IN_GARAGE
             ]
 
-            sorted_entries = self._sort_by_track_distance(active_entries, circuit_len)
+            ref_lap_dist = ref_row.get("lap-info", {}).get("lap-distance")
+            if ref_lap_dist is None:
+                page_item.showEmptyTable()
+                return
+
+            sorted_entries = self._sort_by_rel_distance(active_entries, ref_lap_dist, circuit_len)
             if not sorted_entries:
                 page_item.showEmptyTable()
                 return
@@ -115,25 +120,32 @@ class TrafficMonitorPage(MfdPageBase):
                 return
 
             window = self._get_window(sorted_entries, ref_pos_in_sorted)
-            ref_total_dist = sorted_entries[ref_pos_in_sorted][0]
-            rows_data = self._build_rows(window, ref_index, ref_total_dist, circuit_num)
+            rows_data = self._build_rows(window, ref_index, circuit_num)
             page_item.updateData(rows_data)
 
     # ------------------------------------------------------------------------------------------------------------------
 
-    def _sort_by_track_distance(
+    def _sort_by_rel_distance(
         self,
         table_entries: List[Dict[str, Any]],
+        ref_lap_dist: float,
         circuit_len: float,
     ) -> List[Tuple[float, Dict[str, Any]]]:
-        """Return (normalised_lap_dist, row) pairs sorted descending — furthest ahead first."""
+        """Return (rel_dist, row) sorted ascending: most ahead (negative) → ref (0) → most behind (positive)."""
+        ref_norm = ref_lap_dist % circuit_len
+        half_len = circuit_len / 2
         result = []
         for row in table_entries:
             lap_dist = row.get("lap-info", {}).get("lap-distance")
             if lap_dist is None:
                 continue
-            result.append((lap_dist % circuit_len, row))
-        result.sort(key=lambda x: x[0], reverse=True)
+            rel = ref_norm - (lap_dist % circuit_len)
+            if rel > half_len:
+                rel -= circuit_len
+            elif rel < -half_len:
+                rel += circuit_len
+            result.append((rel, row))
+        result.sort(key=lambda x: x[0])
         return result
 
     def _get_window(
@@ -152,11 +164,10 @@ class TrafficMonitorPage(MfdPageBase):
         self,
         window: List[Tuple[float, Dict[str, Any]]],
         ref_index: int,
-        ref_total_dist: float,
         circuit_num: int,
     ) -> List[Dict[str, Any]]:
         rows_data = []
-        for total_dist, row in window:
+        for rel_dist_m, row in window:
             driver_info: Dict[str, Any] = row.get("driver-info", {})
             ers_info: Dict[str, Any] = row.get("ers-info", {})
             lap_info: Dict[str, Any] = row.get("lap-info", {})
@@ -164,7 +175,6 @@ class TrafficMonitorPage(MfdPageBase):
 
             is_ref = (driver_info.get("index", -1) == ref_index)
 
-            rel_dist_m = ref_total_dist - total_dist  # negative = other is ahead
             if is_ref:
                 rel_dist_str = "---"
                 rel_dist_color = "white"

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, final
 
 from PySide6.QtQuick import QQuickItem
 
-from apps.hud.common import ERS_MODE_COLOR_DEFAULT, ERS_MODE_COLORS, get_ref_row_index
+from apps.hud.common import ERS_MODE_COLORS, get_ref_row_index
 from apps.hud.ui.overlays.mfd.pages.base_page import MfdPageBase
 from lib.config import MfdPageId
 from lib.track_segment_info import TrackSegmentsDatabase
@@ -148,7 +148,7 @@ class TrafficMonitorPage(MfdPageBase):
         return {
             "team":         driver_info.get("team", ""),
             "name":         driver_info.get("name", ""),
-            "ersColor":     ERS_MODE_COLORS.get(ers_mode, ERS_MODE_COLOR_DEFAULT),
+            "ersColor":     ERS_MODE_COLORS[ers_mode],
             "ersPercent":   f"{ers_info.get('ers-percent-float', 0.0) or 0.0:.0f}%",
             "drs":          driver_info.get("drs-activated", False) or False,
             "relDist":      "---" if is_ref else f"{rel_dist_m:+.0f}m",

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
@@ -30,6 +30,7 @@ from PySide6.QtQuick import QQuickItem
 
 from apps.hud.common import get_adjacent_positions, get_ref_row_index
 from apps.hud.ui.overlays.mfd.pages.base_page import MfdPageBase
+from lib.track_segment_info import TrackSegmentsDatabase
 from lib.config import MfdPageId
 
 if TYPE_CHECKING:
@@ -56,6 +57,9 @@ class TrafficMonitorPage(MfdPageBase):
     NUM_ADJACENT = 2
 
     def __init__(self, overlay: "MfdOverlay", logger: logging.Logger):
+
+        self.tracks_db = TrackSegmentsDatabase(Path(__file__).parents[7] / "assets/track-segments")
+
         super().__init__(overlay, logger)
         self._init_event_handlers()
 
@@ -69,6 +73,7 @@ class TrafficMonitorPage(MfdPageBase):
             page_item = self._page_item
             table_entries = data.get("table-entries")
             circuit_len = data.get("circuit-len")
+            circuit_num = data.get("circuit-enum-value")
 
             if not table_entries or not circuit_len:
                 page_item.showEmptyTable()
@@ -111,7 +116,7 @@ class TrafficMonitorPage(MfdPageBase):
 
             window = self._get_window(sorted_entries, ref_pos_in_sorted)
             ref_total_dist = sorted_entries[ref_pos_in_sorted][0]
-            rows_data = self._build_rows(window, ref_index, ref_total_dist)
+            rows_data = self._build_rows(window, ref_index, ref_total_dist, circuit_num)
             page_item.updateData(rows_data)
 
     # ------------------------------------------------------------------------------------------------------------------
@@ -148,11 +153,14 @@ class TrafficMonitorPage(MfdPageBase):
         window: List[Tuple[float, Dict[str, Any]]],
         ref_index: int,
         ref_total_dist: float,
+        circuit_num: int,
     ) -> List[Dict[str, Any]]:
         rows_data = []
         for total_dist, row in window:
             driver_info: Dict[str, Any] = row.get("driver-info", {})
             ers_info: Dict[str, Any] = row.get("ers-info", {})
+            lap_info: Dict[str, Any] = row.get("lap-info", {})
+            curr_lap_info: Dict[str, Any] = lap_info.get("curr-lap", {})
 
             is_ref = (driver_info.get("index", -1) == ref_index)
 
@@ -168,6 +176,18 @@ class TrafficMonitorPage(MfdPageBase):
             ers_perc_float: float = ers_info.get("ers-percent-float", 0.0) or 0.0
             drs_active: bool = driver_info.get("drs-activated", False) or False
 
+            lap_dist = lap_info.get("lap-distance")
+            assert lap_dist is not None
+            segment_info = self.tracks_db.get_segment_info(circuit_num, lap_dist)
+            location_str = curr_lap_info.get("sector", "---")
+
+            if segment_info:
+                match segment_info.TYPE:
+                    case "corner":
+                        location_str = f"T{segment_info.corner_number}"
+                    case "complex_corner":
+                        location_str = segment_info.render()["turns"]
+
             rows_data.append({
                 "team": driver_info.get("team", ""),
                 "name": driver_info.get("name", ""),
@@ -177,5 +197,6 @@ class TrafficMonitorPage(MfdPageBase):
                 "relDist": rel_dist_str,
                 "relDistColor": rel_dist_color,
                 "isRef": is_ref,
+                "location": location_str,
             })
         return rows_data

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) [2025] [Ashwin Natarajan]
+# Copyright (c) [2026] [Ashwin Natarajan]
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,14 +24,16 @@
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, final
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, final
 
 from PySide6.QtQuick import QQuickItem
 
-from apps.hud.common import get_adjacent_positions, get_ref_row_index
+from apps.hud.common import get_ref_row_index
 from apps.hud.ui.overlays.mfd.pages.base_page import MfdPageBase
-from lib.track_segment_info import TrackSegmentsDatabase
 from lib.config import MfdPageId
+from lib.track_segment_info import TrackSegmentsDatabase
+
+from .utils import get_traffic_window, resolve_location, sort_by_rel_distance
 
 if TYPE_CHECKING:
     from apps.hud.ui.overlays.mfd.mfd import MfdOverlay
@@ -57,9 +59,7 @@ class TrafficMonitorPage(MfdPageBase):
     NUM_ADJACENT = 2
 
     def __init__(self, overlay: "MfdOverlay", logger: logging.Logger):
-
         self.tracks_db = TrackSegmentsDatabase(Path(__file__).parents[7] / "assets/track-segments")
-
         super().__init__(overlay, logger)
         self._init_event_handlers()
 
@@ -71,9 +71,9 @@ class TrafficMonitorPage(MfdPageBase):
         @self.on_event("race_table_update")
         def _handle_race_table_update(data: Dict[str, Any]) -> None:
             page_item = self._page_item
-            table_entries = data.get("table-entries")
-            circuit_len = data.get("circuit-len")
-            circuit_num = data.get("circuit-enum-value")
+            table_entries: Optional[List] = data.get("table-entries")
+            circuit_len: Optional[float] = data.get("circuit-len")
+            circuit_num: Optional[int] = data.get("circuit-enum-value")
 
             if not table_entries or not circuit_len:
                 page_item.showEmptyTable()
@@ -85,129 +85,77 @@ class TrafficMonitorPage(MfdPageBase):
                 return
 
             ref_row = table_entries[ref_arr_index]
-            ref_index = ref_row["driver-info"]["index"]
+            ref_index: Optional[int] = ref_row["driver-info"]["index"]
             assert ref_index is not None
 
-            # Show IN GARAGE state when the ref driver is in the garage
             ref_status = ref_row.get("lap-info", {}).get("curr-lap", {}).get("driver-status")
             if ref_status == _DRIVER_STATUS_IN_GARAGE:
                 page_item.showInGarage()
                 return
 
-            # Filter out IN_GARAGE cars from the field
+            ref_lap_dist: Optional[float] = ref_row.get("lap-info", {}).get("lap-distance")
+            if ref_lap_dist is None:
+                page_item.showEmptyTable()
+                return
+
             active_entries = [
                 e for e in table_entries
                 if e.get("lap-info", {}).get("curr-lap", {}).get("driver-status") != _DRIVER_STATUS_IN_GARAGE
             ]
 
-            ref_lap_dist = ref_row.get("lap-info", {}).get("lap-distance")
-            if ref_lap_dist is None:
-                page_item.showEmptyTable()
-                return
-
-            sorted_entries = self._sort_by_rel_distance(active_entries, ref_lap_dist, circuit_len)
+            sorted_entries = sort_by_rel_distance(active_entries, ref_lap_dist, circuit_len)
             if not sorted_entries:
                 page_item.showEmptyTable()
                 return
 
-            ref_pos_in_sorted = next(
-                (i for i, (_, row) in enumerate(sorted_entries)
-                 if row["driver-info"]["index"] == ref_index),
+            ref_pos = next(
+                (i for i, (_, row) in enumerate(sorted_entries) if row["driver-info"]["index"] == ref_index),
                 None,
             )
-            if ref_pos_in_sorted is None:
+            if ref_pos is None:
                 page_item.showEmptyTable()
                 return
 
-            window = self._get_window(sorted_entries, ref_pos_in_sorted)
-            rows_data = self._build_rows(window, ref_index, circuit_num)
-            page_item.updateData(rows_data)
+            window = get_traffic_window(sorted_entries, ref_pos, self.NUM_ADJACENT)
+            page_item.updateData(self._build_rows(window, ref_index, circuit_num))
 
     # ------------------------------------------------------------------------------------------------------------------
-
-    def _sort_by_rel_distance(
-        self,
-        table_entries: List[Dict[str, Any]],
-        ref_lap_dist: float,
-        circuit_len: float,
-    ) -> List[Tuple[float, Dict[str, Any]]]:
-        """Return (rel_dist, row) sorted ascending: most ahead (negative) → ref (0) → most behind (positive)."""
-        ref_norm = ref_lap_dist % circuit_len
-        half_len = circuit_len / 2
-        result = []
-        for row in table_entries:
-            lap_dist = row.get("lap-info", {}).get("lap-distance")
-            if lap_dist is None:
-                continue
-            rel = ref_norm - (lap_dist % circuit_len)
-            if rel > half_len:
-                rel -= circuit_len
-            elif rel < -half_len:
-                rel += circuit_len
-            result.append((rel, row))
-        result.sort(key=lambda x: x[0])
-        return result
-
-    def _get_window(
-        self,
-        sorted_entries: List[Tuple[float, Dict[str, Any]]],
-        ref_pos: int,
-    ) -> List[Tuple[float, Dict[str, Any]]]:
-        """Return up to NUM_ADJACENT ahead + ref + NUM_ADJACENT behind, clamped to available cars."""
-        total = len(sorted_entries)
-        lower_bound, upper_bound = get_adjacent_positions(ref_pos + 1, total, self.NUM_ADJACENT)
-        if lower_bound is None:
-            return [sorted_entries[ref_pos]]
-        return sorted_entries[lower_bound - 1 : upper_bound]
 
     def _build_rows(
         self,
         window: List[Tuple[float, Dict[str, Any]]],
         ref_index: int,
-        circuit_num: int,
+        circuit_num: Optional[int],
     ) -> List[Dict[str, Any]]:
-        rows_data = []
-        for rel_dist_m, row in window:
-            driver_info: Dict[str, Any] = row.get("driver-info", {})
-            ers_info: Dict[str, Any] = row.get("ers-info", {})
-            lap_info: Dict[str, Any] = row.get("lap-info", {})
-            curr_lap_info: Dict[str, Any] = lap_info.get("curr-lap", {})
+        return [self._build_row(rel_dist_m, row, ref_index, circuit_num) for rel_dist_m, row in window]
 
-            is_ref = (driver_info.get("index", -1) == ref_index)
+    def _build_row(
+        self,
+        rel_dist_m: float,
+        row: Dict[str, Any],
+        ref_index: int,
+        circuit_num: Optional[int],
+    ) -> Dict[str, Any]:
+        driver_info: Dict[str, Any] = row.get("driver-info", {})
+        ers_info: Dict[str, Any] = row.get("ers-info", {})
+        lap_info: Dict[str, Any] = row.get("lap-info", {})
+        curr_lap_info: Dict[str, Any] = lap_info.get("curr-lap", {})
 
-            if is_ref:
-                rel_dist_str = "---"
-                rel_dist_color = "white"
-            else:
-                rel_dist_str = f"{rel_dist_m:+.0f}m"
-                rel_dist_color = "#FF4444" if rel_dist_m < 0 else "#44FF44"
+        is_ref = (driver_info.get("index", -1) == ref_index)
+        ers_mode: str = ers_info.get("ers-mode") or "None"
 
-            ers_mode: str = ers_info.get("ers-mode") or "None"
-            ers_perc_float: float = ers_info.get("ers-percent-float", 0.0) or 0.0
-            drs_active: bool = driver_info.get("drs-activated", False) or False
-
-            lap_dist = lap_info.get("lap-distance")
-            assert lap_dist is not None
-            segment_info = self.tracks_db.get_segment_info(circuit_num, lap_dist)
-            location_str = curr_lap_info.get("sector", "---")
-
-            if segment_info:
-                match segment_info.TYPE:
-                    case "corner":
-                        location_str = f"T{segment_info.corner_number}"
-                    case "complex_corner":
-                        first, last = segment_info.corner_numbers[0], segment_info.corner_numbers[-1]
-                        location_str = f"T{first}-{last}"
-
-            rows_data.append({
-                "team": driver_info.get("team", ""),
-                "name": driver_info.get("name", ""),
-                "ersColor": _ERS_MODE_COLORS.get(ers_mode, _ERS_MODE_COLOR_DEFAULT),
-                "ersPercent": f"{ers_perc_float:.0f}%",
-                "drs": drs_active,
-                "relDist": rel_dist_str,
-                "relDistColor": rel_dist_color,
-                "isRef": is_ref,
-                "location": location_str,
-            })
-        return rows_data
+        return {
+            "team":         driver_info.get("team", ""),
+            "name":         driver_info.get("name", ""),
+            "ersColor":     _ERS_MODE_COLORS.get(ers_mode, _ERS_MODE_COLOR_DEFAULT),
+            "ersPercent":   f"{ers_info.get('ers-percent-float', 0.0) or 0.0:.0f}%",
+            "drs":          driver_info.get("drs-activated", False) or False,
+            "relDist":      "---" if is_ref else f"{rel_dist_m:+.0f}m",
+            "relDistColor": "white" if is_ref else ("#FF4444" if rel_dist_m < 0 else "#44FF44"),
+            "isRef":        is_ref,
+            "location":     resolve_location(
+                                self.tracks_db, circuit_num,
+                                lap_info.get("lap-distance"),
+                                curr_lap_info.get("sector"),
+                            ),
+        }

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
@@ -164,12 +164,24 @@ Rectangle {
 
                         // Relative distance
                         Text {
-                            Layout.fillWidth: true
+                            Layout.preferredWidth: 55
                             Layout.fillHeight: true
                             text: modelData.relDist
                             font.family: "B612 Mono"
                             font.pixelSize: 12
                             color: modelData.relDistColor
+                            horizontalAlignment: Text.AlignRight
+                            verticalAlignment: Text.AlignVCenter
+                        }
+
+                        // Location
+                        Text {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            text: modelData.location
+                            font.family: "B612 Mono"
+                            font.pixelSize: 12
+                            color: "#aaaaaa"
                             horizontalAlignment: Text.AlignRight
                             verticalAlignment: Text.AlignVCenter
                         }

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
@@ -1,0 +1,182 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+Rectangle {
+    id: root
+    property string title: "TRAFFIC MONITOR"
+    color: "transparent"
+
+    // States: "table" | "inGarage" | "empty"
+    property string viewState: "empty"
+    property var tableData: []
+
+    property string iconSourcePrefixTeam: "../../../../../../../assets/team-logos/"
+    readonly property var teamIcons: ({
+        "Alpine":               iconSourcePrefixTeam + "alpine.svg",
+        "Alpine '24":           iconSourcePrefixTeam + "alpine.svg",
+        "Aston Martin":         iconSourcePrefixTeam + "aston_martin.svg",
+        "Aston Martin '24":     iconSourcePrefixTeam + "aston_martin.svg",
+        "Ferrari":              iconSourcePrefixTeam + "ferrari.svg",
+        "Ferrari '24":          iconSourcePrefixTeam + "ferrari.svg",
+        "Haas":                 iconSourcePrefixTeam + "haas.svg",
+        "Haas '24":             iconSourcePrefixTeam + "haas.svg",
+        "McLaren":              iconSourcePrefixTeam + "mclaren.svg",
+        "Mclaren":              iconSourcePrefixTeam + "mclaren.svg",
+        "Mclaren '24":          iconSourcePrefixTeam + "mclaren.svg",
+        "Mercedes":             iconSourcePrefixTeam + "mercedes.svg",
+        "Mercedes '24":         iconSourcePrefixTeam + "mercedes.svg",
+        "RB":                   iconSourcePrefixTeam + "rb.svg",
+        "Rb '24":               iconSourcePrefixTeam + "rb.svg",
+        "VCARB":                iconSourcePrefixTeam + "rb.svg",
+        "Alpha Tauri":          iconSourcePrefixTeam + "rb.svg",
+        "Red Bull":             iconSourcePrefixTeam + "red_bull.svg",
+        "Red Bull Racing":      iconSourcePrefixTeam + "red_bull.svg",
+        "Red Bull Racing '24":  iconSourcePrefixTeam + "red_bull.svg",
+        "Sauber":               iconSourcePrefixTeam + "sauber.svg",
+        "Sauber '24":           iconSourcePrefixTeam + "sauber.svg",
+        "Alfa Romeo":           iconSourcePrefixTeam + "sauber.svg",
+        "Williams":             iconSourcePrefixTeam + "williams.svg",
+        "Williams '24":         iconSourcePrefixTeam + "williams.svg"
+    })
+    readonly property string defaultTeamIcon: iconSourcePrefixTeam + "default.svg"
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        // Header
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 40
+            color: "#B3000000"
+            border.color: "#444444"
+            border.width: 1
+
+            Text {
+                anchors.centerIn: parent
+                text: root.title
+                font.family: "Formula1"
+                font.pixelSize: 11
+                font.bold: true
+                color: "white"
+            }
+        }
+
+        // Body — switches between table, in-garage message, and empty
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            // Table view
+            ListView {
+                id: tableView
+                anchors.fill: parent
+                model: root.tableData
+                interactive: false
+                clip: true
+                visible: root.viewState === "table"
+
+                delegate: Rectangle {
+                    width: tableView.width
+                    height: 35
+                    color: "#80000000"
+
+                    border.color: modelData.isRef ? "white" : "transparent"
+                    border.width: modelData.isRef ? 2 : 0
+
+                    Rectangle {
+                        anchors.top: parent.top
+                        width: parent.width
+                        height: 1
+                        color: "#444444"
+                    }
+
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: 5
+                        anchors.rightMargin: 5
+                        spacing: 0
+
+                        // Team logo
+                        Item {
+                            Layout.preferredWidth: 28
+                            Layout.fillHeight: true
+
+                            Image {
+                                anchors.centerIn: parent
+                                width: 20
+                                height: 20
+                                source: root.teamIcons[modelData.team] || root.defaultTeamIcon
+                                fillMode: Image.PreserveAspectFit
+                                smooth: true
+                                mipmap: true
+                            }
+                        }
+
+                        // Driver name
+                        Text {
+                            Layout.preferredWidth: 170
+                            Layout.fillHeight: true
+                            text: modelData.name
+                            font.family: "Formula1"
+                            font.pixelSize: 10
+                            color: "white"
+                            horizontalAlignment: Text.AlignLeft
+                            verticalAlignment: Text.AlignVCenter
+                            elide: Text.ElideRight
+                        }
+
+                        // ERS mode
+                        Text {
+                            Layout.preferredWidth: 65
+                            Layout.fillHeight: true
+                            text: modelData.ersMode
+                            font.family: "B612 Mono"
+                            font.pixelSize: 9
+                            color: modelData.ersColor
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                        }
+
+                        // Relative distance
+                        Text {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            text: modelData.relDist
+                            font.family: "B612 Mono"
+                            font.pixelSize: 9
+                            color: modelData.relDistColor
+                            horizontalAlignment: Text.AlignRight
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+                }
+            }
+
+            // In-garage message
+            Text {
+                anchors.centerIn: parent
+                visible: root.viewState === "inGarage"
+                text: "IN GARAGE"
+                font.family: "Formula1"
+                font.pixelSize: 13
+                color: "#888888"
+            }
+        }
+    }
+
+    function updateData(rows) {
+        root.tableData = rows;
+        root.viewState = rows.length > 0 ? "table" : "empty";
+    }
+
+    function showInGarage() {
+        root.tableData = [];
+        root.viewState = "inGarage";
+    }
+
+    function showEmptyTable() {
+        root.tableData = [];
+        root.viewState = "empty";
+    }
+}

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
@@ -119,23 +119,47 @@ Rectangle {
                             Layout.fillHeight: true
                             text: modelData.name
                             font.family: "Formula1"
-                            font.pixelSize: 10
+                            font.pixelSize: 14
                             color: "white"
                             horizontalAlignment: Text.AlignLeft
                             verticalAlignment: Text.AlignVCenter
                             elide: Text.ElideRight
                         }
 
-                        // ERS mode
-                        Text {
+                        // ERS/DRS bar
+                        Item {
                             Layout.preferredWidth: 65
                             Layout.fillHeight: true
-                            text: modelData.ersMode
-                            font.family: "B612 Mono"
-                            font.pixelSize: 9
-                            color: modelData.ersColor
-                            horizontalAlignment: Text.AlignHCenter
-                            verticalAlignment: Text.AlignVCenter
+
+                            Rectangle {
+                                anchors.left: parent.left
+                                anchors.leftMargin: 1
+                                anchors.verticalCenter: parent.verticalCenter
+                                width: 6
+                                height: parent.height - 8
+                                radius: 2
+                                color: modelData.ersColor
+                            }
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: modelData.ersPercent
+                                font.family: "B612 Mono"
+                                font.pixelSize: 12
+                                color: "#dddddd"
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
+                            }
+
+                            Rectangle {
+                                anchors.right: parent.right
+                                anchors.rightMargin: 1
+                                anchors.verticalCenter: parent.verticalCenter
+                                width: 6
+                                height: parent.height - 8
+                                radius: 2
+                                color: modelData.drs ? "#00e676" : "#333333"
+                            }
                         }
 
                         // Relative distance
@@ -144,7 +168,7 @@ Rectangle {
                             Layout.fillHeight: true
                             text: modelData.relDist
                             font.family: "B612 Mono"
-                            font.pixelSize: 9
+                            font.pixelSize: 12
                             color: modelData.relDistColor
                             horizontalAlignment: Text.AlignRight
                             verticalAlignment: Text.AlignVCenter

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
@@ -201,18 +201,4 @@ Rectangle {
         }
     }
 
-    function updateData(rows) {
-        root.tableData = rows;
-        root.viewState = rows.length > 0 ? "table" : "empty";
-    }
-
-    function showInGarage() {
-        root.tableData = [];
-        root.viewState = "inGarage";
-    }
-
-    function showEmptyTable() {
-        root.tableData = [];
-        root.viewState = "empty";
-    }
 }

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/utils.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/utils.py
@@ -1,0 +1,95 @@
+# MIT License
+#
+# Copyright (c) [2026] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------- IMPORTS -----------------------------------------------------------------------
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from apps.hud.common import get_adjacent_positions
+from lib.track_segment_info import TrackSegmentsDatabase
+
+# -------------------------------------- FUNCTIONS ---------------------------------------------------------------------
+
+def sort_by_rel_distance(
+    table_entries: List[Dict[str, Any]],
+    ref_lap_dist: float,
+    circuit_len: float,
+) -> List[Tuple[float, Dict[str, Any]]]:
+    """Return (rel_dist, row) sorted ascending: most ahead (negative) → ref (0) → most behind (positive).
+
+    rel_dist = ref_pos - other_pos, normalized to (-circuit_len/2, +circuit_len/2] to handle lap boundary wrap.
+    """
+    ref_norm = ref_lap_dist % circuit_len
+    half_len = circuit_len / 2
+    result = []
+    for row in table_entries:
+        lap_dist = row.get("lap-info", {}).get("lap-distance")
+        if lap_dist is None:
+            continue
+        rel = ref_norm - (lap_dist % circuit_len)
+        if rel > half_len:
+            rel -= circuit_len
+        elif rel < -half_len:
+            rel += circuit_len
+        result.append((rel, row))
+    result.sort(key=lambda x: x[0])
+    return result
+
+
+def get_traffic_window(
+    sorted_entries: List[Tuple[float, Dict[str, Any]]],
+    ref_pos: int,
+    num_adjacent: int,
+) -> List[Tuple[float, Dict[str, Any]]]:
+    """Return up to num_adjacent ahead + ref + num_adjacent behind, clamped to available cars."""
+    total = len(sorted_entries)
+    lower_bound, upper_bound = get_adjacent_positions(ref_pos + 1, total, num_adjacent)
+    if lower_bound is None:
+        return [sorted_entries[ref_pos]]
+    return sorted_entries[lower_bound - 1 : upper_bound]
+
+
+def resolve_location(
+    tracks_db: TrackSegmentsDatabase,
+    circuit_num: Optional[int],
+    lap_dist: Optional[float],
+    sector: Optional[Any] = None,
+) -> str:
+    """Resolve a lap distance to a human-readable track location label (e.g. 'T3', 'T8-10').
+
+    Falls back to sector if no segment is found.
+    """
+    fallback = str(sector) if sector is not None else "---"
+    if circuit_num is None or lap_dist is None:
+        return fallback
+    segment = tracks_db.get_segment_info(circuit_num, lap_dist)
+    if segment is None:
+        return fallback
+    match segment.TYPE:
+        case "corner":
+            return f"T{segment.corner_number}"
+        case "complex_corner":
+            first, last = segment.corner_numbers[0], segment.corner_numbers[-1]
+            return f"T{first}-{last}"
+        case _:
+            return fallback
+

--- a/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
+++ b/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
@@ -27,7 +27,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, final
 
-from apps.hud.common import (ERS_MODE_COLOR_DEFAULT, ERS_MODE_COLORS,
+from apps.hud.common import (ERS_MODE_COLORS,
                              get_ref_row, get_relevant_race_table_rows,
                              insert_relative_deltas_race, is_race_type_session,
                              is_tt_session)
@@ -302,7 +302,7 @@ class TimingTowerOverlay(BaseOverlayQML):
             "tyreWear": self._format_tyre_wear(tyre_info, telemetry_public),
             "ers": self._format_ers(ers_info, telemetry_public),
             "ersMode": ers_mode,
-            "ersColor": ERS_MODE_COLORS.get(ers_mode, ERS_MODE_COLOR_DEFAULT),
+            "ersColor": ERS_MODE_COLORS[ers_mode],
             "drs": driver_info.get("drs", False),
             "penalties": self._format_penalties(warns_pens_info),
             "tlWarns": warns_pens_info.get("corner-cutting-warnings", 0),

--- a/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
+++ b/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
@@ -27,13 +27,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, final
 
-_ERS_MODE_COLORS: Dict[str, str] = {
-    "Medium":   "#e6d800",
-    "Hotlap":   "#00e676",
-    "Overtake": "#ff1744",
-}
-
-from apps.hud.common import (get_ref_row, get_relevant_race_table_rows,
+from apps.hud.common import (ERS_MODE_COLOR_DEFAULT, ERS_MODE_COLORS,
+                             get_ref_row, get_relevant_race_table_rows,
                              insert_relative_deltas_race, is_race_type_session,
                              is_tt_session)
 from apps.hud.ui.overlays.base import BaseOverlayQML
@@ -307,7 +302,7 @@ class TimingTowerOverlay(BaseOverlayQML):
             "tyreWear": self._format_tyre_wear(tyre_info, telemetry_public),
             "ers": self._format_ers(ers_info, telemetry_public),
             "ersMode": ers_mode,
-            "ersColor": _ERS_MODE_COLORS.get(ers_mode, "#444444"),
+            "ersColor": ERS_MODE_COLORS.get(ers_mode, ERS_MODE_COLOR_DEFAULT),
             "drs": driver_info.get("drs", False),
             "penalties": self._format_penalties(warns_pens_info),
             "tlWarns": warns_pens_info.get("corner-cutting-warnings", 0),

--- a/apps/save_viewer/save_viewer_state/get_telemetry_info.py
+++ b/apps/save_viewer/save_viewer_state/get_telemetry_info.py
@@ -551,7 +551,6 @@ def _create_driver_entry(
                     for_best_lap=True,
                 ),
             },
-            "lap-progress": None,
             "speed-trap-record-kmph": data_per_driver["lap-data"].get("speed-trap-fastest-speed"),
             "top-speed-kmph": data_per_driver.get("top-speed-kmph", 0.0),
         },

--- a/lib/config/schema/hud/mfd.py
+++ b/lib/config/schema/hud/mfd.py
@@ -41,6 +41,7 @@ class MfdPageId(str, Enum):
     PIT_REJOIN       = "pit_rejoin"
     TYRE_SETS        = "tyre_sets"
     PACE_COMP        = "pace_comp"
+    TRAFFIC_MONITOR  = "traffic_monitor"
 
 # -------------------------------------- CLASS  DEFINITIONS ------------------------------------------------------------
 
@@ -61,13 +62,14 @@ class MfdPageSettings(ConfigDiffMixin, BaseModel):
 
 
 DEFAULT_PAGES = {
-    MfdPageId.LAP_TIMES:        MfdPageSettings(enabled=True, position=1, description="Lap Times"),
-    MfdPageId.WEATHER_FORECAST: MfdPageSettings(enabled=True, position=2, description="Weather Forecast"),
-    MfdPageId.FUEL_INFO:        MfdPageSettings(enabled=True, position=3, description="Fuel Info"),
-    MfdPageId.TYRE_INFO:        MfdPageSettings(enabled=True, position=4, description="Tyre Info"),
-    MfdPageId.PIT_REJOIN:       MfdPageSettings(enabled=True, position=5, description="Pit Rejoin"),
-    MfdPageId.TYRE_SETS:        MfdPageSettings(enabled=True, position=6, description="Tyre Sets"),
-    MfdPageId.PACE_COMP:        MfdPageSettings(enabled=True, position=7, description="Pace Comparison"),
+    MfdPageId.LAP_TIMES:        MfdPageSettings(enabled=True,  position=1, description="Lap Times"),
+    MfdPageId.WEATHER_FORECAST: MfdPageSettings(enabled=True,  position=2, description="Weather Forecast"),
+    MfdPageId.FUEL_INFO:        MfdPageSettings(enabled=True,  position=3, description="Fuel Info"),
+    MfdPageId.TYRE_INFO:        MfdPageSettings(enabled=True,  position=4, description="Tyre Info"),
+    MfdPageId.PIT_REJOIN:       MfdPageSettings(enabled=True,  position=5, description="Pit Rejoin"),
+    MfdPageId.TYRE_SETS:        MfdPageSettings(enabled=True,  position=6, description="Tyre Sets"),
+    MfdPageId.PACE_COMP:        MfdPageSettings(enabled=True,  position=7, description="Pace Comparison"),
+    MfdPageId.TRAFFIC_MONITOR:  MfdPageSettings(enabled=False, position=8, description="Traffic Monitor"),
 }
 
 

--- a/lib/f1_types/base_pkt.py
+++ b/lib/f1_types/base_pkt.py
@@ -115,6 +115,8 @@ class F1CompareableEnum(F1BaseEnum):
         Only use this class for Enums where ordering of values makes sense.
     """
 
+    __hash__ = F1BaseEnum.__hash__
+
     def __eq__(self, other: Any) -> bool:
         """
         Check equality with another enum of the same type.

--- a/lib/f1_types/common.py
+++ b/lib/f1_types/common.py
@@ -472,7 +472,7 @@ class VisualTyreCompound(F1BaseEnum):
         """
         return self == VisualTyreCompound.INTER
 
-class SafetyCarType(F1CompareableEnum):
+class SafetyCarType(F1CompareableEnum):  # pylint: disable=invalid-enum-extension
     """
     Enumeration representing different safety car statuses.
 

--- a/lib/f1_types/packet_2_lap_data.py
+++ b/lib/f1_types/packet_2_lap_data.py
@@ -236,7 +236,7 @@ class LapData(F1SubPacketBase):
         PITTING = 1
         IN_PIT_AREA = 2
 
-    class Sector(F1CompareableEnum):
+    class Sector(F1CompareableEnum):  # pylint: disable=invalid-enum-extension
         """
         Enumeration representing the sector of a racing track.
         """

--- a/lib/f1_types/packet_2_lap_data.py
+++ b/lib/f1_types/packet_2_lap_data.py
@@ -22,7 +22,7 @@
 
 
 import struct
-from typing import Any, Dict, List
+from typing import Any, Dict, List, final
 
 from .base_pkt import (F1BaseEnum, F1CompareableEnum, F1PacketBase,
                        F1SubPacketBase)
@@ -245,6 +245,15 @@ class LapData(F1SubPacketBase):
         SECTOR2 = 1
         SECTOR3 = 2
 
+        @final
+        def __str__(self) -> str:
+            """Return a string representation of the Sector enumeration member.
+
+            Returns:
+                str: A string representing the sector (e.g., "Sector 1", "Sector 2", "Sector 3").
+            """
+            return f"S{self.value + 1}"
+
     def __init__(self, data: bytes, packet_format: int) -> None:
         """
         Initialize LapData instance by unpacking binary data.
@@ -260,6 +269,7 @@ class LapData(F1SubPacketBase):
         self.m_packetFormat = packet_format
         self._parse(data, packet_format)
         self._cast_enums()
+
 
     def _parse(self, data: bytes, packet_format: int) -> None:
         """Raw byte unpacking only. Dispatches to format-specific helpers."""

--- a/lib/f1_types/packet_2_lap_data.py
+++ b/lib/f1_types/packet_2_lap_data.py
@@ -250,7 +250,7 @@ class LapData(F1SubPacketBase):
             """Return a string representation of the Sector enumeration member.
 
             Returns:
-                str: A string representing the sector (e.g., "Sector 1", "Sector 2", "Sector 3").
+                str: A string representing the sector (e.g., "S1", "S2", "S3").
             """
             return f"S{self.value + 1}"
 

--- a/lib/track_segment_info/types.py
+++ b/lib/track_segment_info/types.py
@@ -46,6 +46,7 @@ class SectorBoundaries(BaseModel):
 class BaseSegmentInfo(BaseModel):
     model_config = ConfigDict(frozen=True)
 
+    TYPE: ClassVar[str]
     type: str
     name: str
     start_m: float

--- a/scripts/png.spec
+++ b/scripts/png.spec
@@ -140,6 +140,7 @@ datas.extend([
     qml_file("apps/hud/ui/overlays/mfd/pages/lap_times", "lap_times_page.qml"),
     qml_file("apps/hud/ui/overlays/mfd/pages/pace_comp", "pace_comp_page.qml"),
     qml_file("apps/hud/ui/overlays/mfd/pages/pit_rejoin", "pit_rejoin_page.qml"),
+    qml_file("apps/hud/ui/overlays/mfd/pages/traffic_monitor", "traffic_monitor_page.qml"),
     qml_file("apps/hud/ui/overlays/mfd/pages/tyre_sets", "tyre_sets_page.qml"),
     qml_file("apps/hud/ui/overlays/mfd/pages/tyre_wear", "tyre_wear_page.qml"),
     qml_file("apps/hud/ui/overlays/mfd/pages/weather", "weather_page.qml"),

--- a/tests/f1_types/tests_base.py
+++ b/tests/f1_types/tests_base.py
@@ -129,3 +129,16 @@ class TestF1SubPacketBase(F1TypesTest):
         p2 = OtherPacket(5)
         with self.assertRaises(TypeError):
             p1.diff_fields(p2)
+
+    def test_hashable(self):
+        # Since overriding __eq__ disables the builtin __hash__ method,
+        # this tc ensures that the explict __hash__ definition works and doesn't break
+        mapping = {
+            Severity.LOW: "low",
+            Severity.MEDIUM: "medium",
+            Severity.HIGH: "high",
+        }
+
+        self.assertEqual(mapping[Severity.LOW], "low")
+        self.assertEqual(mapping[Severity.MEDIUM], "medium")
+        self.assertEqual(mapping[Severity.HIGH], "high")

--- a/tests/tests_config/tests_hud_settings.py
+++ b/tests/tests_config/tests_hud_settings.py
@@ -382,6 +382,7 @@ class TestHudSettings(TestF1ConfigBase):
             MfdPageId.PIT_REJOIN,
             MfdPageId.TYRE_SETS,
             MfdPageId.PACE_COMP,
+            MfdPageId.TRAFFIC_MONITOR,
         }
 
         for page in expected_pages:

--- a/tests/tests_custom_markers.py
+++ b/tests/tests_custom_markers.py
@@ -66,7 +66,7 @@ class TestCustomMarkerEntry(CustomMarkersUT):
 
     def test_csv_conversion(self):
         csv_str = self.marker.toCSV()
-        expected = "Monaco, Overtake, 5, SECTOR1, 1:23.456, 45.67"
+        expected = "Monaco, Overtake, 5, S1, 1:23.456, 45.67"
         self.assertEqual(csv_str, expected)
 
     def test_string_representation(self):


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->

## 📝 Description

Adding a traffic monitor MFD page (similar to relatives table, but distance based)
Bringing back hash into F1ComparableEnum
MfdPageBase -> adding caching helper for setting properties

---

## 📂 Type of change

<!-- Check all that apply: -->

- [ ] Bug fix 🐞
- [ ] New feature 🚀
- [ ] Refactor 🔨
- [ ] Documentation 📚
- [ ] Tests ✅
- [ ] Other: <!-- please specify -->

---

## 🧪 Backend Test Reports (required for Python/backend changes)

> ⚠️ If your PR includes backend Python changes, please fill out the sections below.

### ✅ Integration Tests

* [ ] All integration tests pass
* Attach test command/output:

```
<paste result here>
```

To run the integration test
```bash
poetry run python tests/integration_test/runner.py
```

---

## 🧱 `lib/` Directory Changes

* [ ] This PR modifies or adds files under `lib/`
* [ ] I have updated or added unit tests to reflect those changes

Explain your test updates here:

```
Explain what was added/updated, or write "N/A" if not applicable.
```

---

## 📋 General Checklist

* [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
* [ ] My code follows project style conventions
* [ ] All new and existing tests pass
* [ ] I have added relevant documentation/comments
* [ ] I have reviewed my changes and believe they are ready to merge

---

<!-- Thank you for contributing to pits_n_giggles! -->

## Summary by Sourcery

Add a new distance-based Traffic Monitor MFD page and supporting infrastructure for track location and telemetry display.

New Features:
- Introduce a Traffic Monitor MFD page that shows nearby cars based on lap distance with ERS/DRS and location information.
- Expose circuit enum value and lap distance data needed to drive the new traffic monitor view.
- Add reusable ERS mode color mapping for HUD components.

Bug Fixes:
- Restore hashability for F1CompareableEnum so enum members can be used as dictionary keys.

Enhancements:
- Add diff-based caching for QML page property updates to reduce redundant HUD updates.
- Adjust lap info APIs and save viewer data to use raw lap distance instead of progress percentage.
- Provide string representations for Sector enums and align marker CSV expectations with the new format.
- Extend track segment info types with a TYPE discriminator to support location resolution.
- Update build configuration to include the new Traffic Monitor QML page in packaging.
- Ensure HUD timing tower uses the shared ERS mode color mapping for consistency.

Tests:
- Add tests to verify F1CompareableEnum hashability and updated marker CSV output.
- Extend HUD config tests to cover the new Traffic Monitor MFD default page entry.