### PR TITLE
Export race control message location metadata and refactor segments

### DIFF
--- a/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
@@ -1357,7 +1357,10 @@ class DataPerDriver:
                     new_value=new
                 )
                 if self.m_packet_copies.m_packet_lap_data:
-                    msg.lap_distance = self.m_packet_copies.m_packet_lap_data.m_lapDistance
+                    _lap_data = self.m_packet_copies.m_packet_lap_data
+                    msg.lap_distance = _lap_data.m_lapDistance
+                    msg.segment_info = self.m_state_ref._lookup_segment_info(msg.lap_distance)
+                    msg.sector = str(_lap_data.m_sector)
                 self.m_race_ctrl.add_message(msg)
 
                 self.m_logger.debug(

--- a/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
+++ b/apps/backend/state_mgmt_layer/data_per_driver/data_per_driver.py
@@ -1356,6 +1356,8 @@ class DataPerDriver:
                     old_value=old,
                     new_value=new
                 )
+                if self.m_packet_copies.m_packet_lap_data:
+                    msg.lap_distance = self.m_packet_copies.m_packet_lap_data.m_lapDistance
                 self.m_race_ctrl.add_message(msg)
 
                 self.m_logger.debug(

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -669,6 +669,8 @@ class SessionState:
                         old_state=old_ai,
                         new_state=new_ai,
                     )
+                    if obj_to_be_updated.m_packet_copies.m_packet_lap_data:
+                        msg.lap_distance = obj_to_be_updated.m_packet_copies.m_packet_lap_data.m_lapDistance
                     obj_to_be_updated.m_race_ctrl.add_message(msg)
 
             # Update pkt copy
@@ -1131,6 +1133,10 @@ class SessionState:
             lap_num = None
 
         if msg := race_ctrl_event_msg_factory(packet, lap_number=lap_num):
+            if msg.involved_drivers:
+                driver_obj = self._getObjectByIndex(msg.involved_drivers[0], create=False)
+                if driver_obj and driver_obj.m_packet_copies.m_packet_lap_data:
+                    msg.lap_distance = driver_obj.m_packet_copies.m_packet_lap_data.m_lapDistance
             self.m_race_ctrl.add_message(msg)
 
     def setChequeredFlagState(self, flag_val: bool) -> None:

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -1529,7 +1529,7 @@ class SessionState:
         if self.m_session_info.m_track is None:
             return None
         seg = self.m_track_segments_db.get_segment_info(self.m_session_info.m_track.value, lap_distance)
-        return seg.render() if seg else None
+        return seg.to_dict() if seg else None
 
     def _getRaceCtrlHelperDict(self) -> Dict[str, Any]:
         """Get the race control messages helper dictionary. This is a mapping of index against driver info JSON,

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -24,6 +24,7 @@
 
 import json
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from apps.backend.state_mgmt_layer.data_per_driver import DataPerDriver
@@ -56,6 +57,7 @@ from lib.pending_events import DriverPendingEvents
 from lib.race_analyzer import getFastestTimesJson, getTyreStintRecordsDict
 from lib.race_ctrl import (DriverAiStatusChange, SessionRaceControlManager,
                            race_ctrl_event_msg_factory)
+from lib.track_segment_info import TrackSegmentsDatabase
 from lib.tyre_wear_extrapolator import TyreWearPerLap
 
 # -------------------------------------- CLASS DEFINITIONS -------------------------------------------------------------
@@ -333,6 +335,7 @@ class SessionState:
         'm_race_ctrl',
         'm_flashback_occurred',
         'm_in_menu',
+        'm_track_segments_db',
     )
 
     def __init__(self,
@@ -383,6 +386,9 @@ class SessionState:
 
         self.m_race_ctrl: SessionRaceControlManager = SessionRaceControlManager()
         self.m_flashback_occurred: bool = False
+        self.m_track_segments_db = TrackSegmentsDatabase(
+            Path(__file__).parents[3] / "assets/track-segments"
+        )
 
     ####### Control Methods ########
 
@@ -670,7 +676,10 @@ class SessionState:
                         new_state=new_ai,
                     )
                     if obj_to_be_updated.m_packet_copies.m_packet_lap_data:
-                        msg.lap_distance = obj_to_be_updated.m_packet_copies.m_packet_lap_data.m_lapDistance
+                        _lap_data = obj_to_be_updated.m_packet_copies.m_packet_lap_data
+                        msg.lap_distance = _lap_data.m_lapDistance
+                        msg.segment_info = self._lookup_segment_info(msg.lap_distance)
+                        msg.sector = str(_lap_data.m_sector)
                     obj_to_be_updated.m_race_ctrl.add_message(msg)
 
             # Update pkt copy
@@ -1136,7 +1145,10 @@ class SessionState:
             if msg.involved_drivers:
                 driver_obj = self._getObjectByIndex(msg.involved_drivers[0], create=False)
                 if driver_obj and driver_obj.m_packet_copies.m_packet_lap_data:
-                    msg.lap_distance = driver_obj.m_packet_copies.m_packet_lap_data.m_lapDistance
+                    _lap_data = driver_obj.m_packet_copies.m_packet_lap_data
+                    msg.lap_distance = _lap_data.m_lapDistance
+                    msg.segment_info = self._lookup_segment_info(msg.lap_distance)
+                    msg.sector = str(_lap_data.m_sector)
             self.m_race_ctrl.add_message(msg)
 
     def setChequeredFlagState(self, flag_val: bool) -> None:
@@ -1511,6 +1523,13 @@ class SessionState:
         return False
 
     ##### Internal Helpers #####
+
+    def _lookup_segment_info(self, lap_distance: float) -> Optional[Dict[str, str]]:
+        """Return rendered segment info for the current track at lap_distance, or None."""
+        if self.m_session_info.m_track is None:
+            return None
+        seg = self.m_track_segments_db.get_segment_info(self.m_session_info.m_track.value, lap_distance)
+        return seg.render() if seg else None
 
     def _getRaceCtrlHelperDict(self) -> Dict[str, Any]:
         """Get the race control messages helper dictionary. This is a mapping of index against driver info JSON,

--- a/apps/backend/state_mgmt_layer/session_state.py
+++ b/apps/backend/state_mgmt_layer/session_state.py
@@ -1524,7 +1524,7 @@ class SessionState:
 
     ##### Internal Helpers #####
 
-    def _lookup_segment_info(self, lap_distance: float) -> Optional[Dict[str, str]]:
+    def _lookup_segment_info(self, lap_distance: float) -> Optional[Dict[str, Any]]:
         """Return rendered segment info for the current track at lap_distance, or None."""
         if self.m_session_info.m_track is None:
             return None

--- a/apps/frontend/js/populateRaceControlMessagesTab.js
+++ b/apps/frontend/js/populateRaceControlMessagesTab.js
@@ -231,12 +231,12 @@ function populateRaceControlMessagesTab(containerElement, initialRowData) {
         { headerName: 'Lap Number', field: 'lap-number', sortable: true, filter: false, width: 150 },
         {
             headerName: 'Location',
-            field: 'location',
             sortable: false,
             filter: false,
             width: 200,
-            cellRenderer: params => formatRaceCtrlLocation(params.data),
-            getQuickFilterText: params => formatRaceCtrlLocation(params.data),
+            valueGetter: params => formatRaceCtrlLocation(params.data),
+            cellRenderer: params => params.value,
+            getQuickFilterText: params => params.value,
         },
         {
             headerName: 'Details',

--- a/apps/frontend/js/populateRaceControlMessagesTab.js
+++ b/apps/frontend/js/populateRaceControlMessagesTab.js
@@ -152,16 +152,22 @@ function formatRaceCtrlLocation(msg) {
 
     if (!seg) return sectorLabel ?? '---';
 
-    const type  = seg['type']  || '';
-    const name  = seg['name']  || '';
-    const turns = seg['turns'] || '';
+    const type = seg['type'] || '';
+    const name = seg['name'] || '';
 
     if (type === 'straight') {
         return name || sectorLabel || '---';
     }
-    // corner (single or complex)
-    if (name && turns) return `${turns} - ${name}`;
-    return turns || name || sectorLabel || '---';
+    // corner - single vs complex distinguished by key presence
+    let turns;
+    if (seg['corner_number'] != null) {
+        turns = `T${seg['corner_number']}`;
+    } else if (seg['corner_numbers']?.length) {
+        const nums = seg['corner_numbers'];
+        turns = `T${nums[0]}-${nums[nums.length - 1]}`;
+    }
+    if (turns) return name ? `${turns} - ${name}` : turns;
+    return name || sectorLabel || '---';
 }
 
 /**

--- a/apps/frontend/js/populateRaceControlMessagesTab.js
+++ b/apps/frontend/js/populateRaceControlMessagesTab.js
@@ -144,6 +144,26 @@ const detailRenderers = {
   DEFAULT: msg => `Type: ${msg['message-type']} - Placeholder details.`
 };
 
+function formatRaceCtrlLocation(msg) {
+    const seg = msg['segment-info'];
+    const sector = msg['sector'];
+
+    const sectorLabel = sector ? `Sector ${sector.slice(1)}` : null;
+
+    if (!seg) return sectorLabel ?? '---';
+
+    const type  = seg['type']  || '';
+    const name  = seg['name']  || '';
+    const turns = seg['turns'] || '';
+
+    if (type === 'straight') {
+        return name || sectorLabel || '---';
+    }
+    // corner (single or complex)
+    if (name && turns) return `${turns} - ${name}`;
+    return turns || name || sectorLabel || '---';
+}
+
 /**
  * Populates the Race Control Messages tab with an AG Grid.
  * This function will fetch race control messages and display them in a sortable, paginated grid.
@@ -203,6 +223,15 @@ function populateRaceControlMessagesTab(containerElement, initialRowData) {
         { headerName: 'ID', field: 'id', sortable: true, filter: false, width: 80 },
         { headerName: 'Message Type', field: 'message-type', sortable: true, filter: false, width: 150 },
         { headerName: 'Lap Number', field: 'lap-number', sortable: true, filter: false, width: 150 },
+        {
+            headerName: 'Location',
+            field: 'location',
+            sortable: false,
+            filter: false,
+            width: 200,
+            cellRenderer: params => formatRaceCtrlLocation(params.data),
+            getQuickFilterText: params => formatRaceCtrlLocation(params.data),
+        },
         {
             headerName: 'Details',
             field: 'details',

--- a/apps/hud/ui/overlays/circuit_info/circuit_info.py
+++ b/apps/hud/ui/overlays/circuit_info/circuit_info.py
@@ -24,14 +24,15 @@
 
 import logging
 from pathlib import Path
-from typing import Optional, final
+from typing import Any, Dict, Optional, final
 
 from apps.hud.common import get_ref_row
 from apps.hud.ui.infra.hf_types import HudOverlayData
 from apps.hud.ui.overlays.base import BaseOverlay
 from lib.config import OverlayId, OverlayPosition
 from lib.f1_types import F1Utils
-from lib.track_segment_info.database import TrackSegmentsDatabase
+from lib.track_segment_info import (ComplexCornerSegmentInfo,
+                                    CornerSegmentInfo, TrackSegmentsDatabase)
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
@@ -147,22 +148,47 @@ class CircuitInfoOverlay(BaseOverlay):
         if not data:
             return
 
-        segment_info = self.tracks_db.get_segment_info(data.circuit_num, data.circuit_pos_m)
-        sectors = self.tracks_db.get_sectors(data.circuit_num)
-
         self.set_qml_property("circuitPosM", data.circuit_pos_m)
         self.set_qml_property("circuitLength", data.circuit_length or self.circuit_info_length)
+
+        sectors = self.tracks_db.get_sectors(data.circuit_num)
         self.set_qml_property(
             "sectorsInfo",
             {"s1": sectors.s1, "s2": sectors.s2} if sectors else None,
         )
 
-        if segment_info:
-            rendered = segment_info.render()
-            self.set_qml_property("segmentInfo", {
-                "type": rendered["type"],
-                "above": rendered["name"],
-                "below": rendered["turns"],
-            })
-        else:
-            self.set_qml_property("segmentInfo", None)
+        self.set_qml_property("segmentInfo", self._get_segment_dict(data))
+
+    def _get_segment_dict(self, data: HudOverlayData) -> Optional[Dict[str, Any]]:
+        """Get the segment info for the current circuit position.
+           Dict will contain "type", "above" and "below" keys.
+        """
+        qml_segment = None
+        if segment_info := self.tracks_db.get_segment_info(data.circuit_num, data.circuit_pos_m):
+            match segment_info.TYPE:
+                case "straight":
+                    qml_segment = {
+                        "type": "straight",
+                        "above": segment_info.name,
+                        "below": "",
+                    }
+                case "corner":
+                    corner_segment: CornerSegmentInfo = segment_info
+                    if segment_info.name:
+                        below = f"T{corner_segment.corner_number}"
+                    else:
+                        below = f"Turn {corner_segment.corner_number}"
+                    qml_segment = {
+                        "type": "corner",
+                        "above": corner_segment.name,
+                        "below": below,
+                    }
+                case "complex_corner":
+                    complex_segment: ComplexCornerSegmentInfo = segment_info
+                    first, last = complex_segment.corner_numbers[0], complex_segment.corner_numbers[-1]
+                    qml_segment = {
+                        "type": "corner",
+                        "above": complex_segment.name,
+                        "below": f"Turns {first}-{last}",
+                    }
+        return qml_segment

--- a/lib/race_ctrl/messages/base.py
+++ b/lib/race_ctrl/messages/base.py
@@ -77,6 +77,7 @@ class RaceCtrlMsgBase:
     lap_number: Optional[int] = None
     lap_distance: Optional[float] = None
     segment_info: Optional[Dict[str, str]] = None
+    sector: Optional[str] = None
     _id: Optional[int] = None
 
     def toJSON(self, _driver_info_dict: Optional[Dict[int, dict]] = None) -> Dict[str, Any]:
@@ -89,4 +90,5 @@ class RaceCtrlMsgBase:
             "involved-drivers": list(self.involved_drivers),
             "lap-distance": self.lap_distance,
             "segment-info": self.segment_info,
+            "sector": self.sector,
         }

--- a/lib/race_ctrl/messages/base.py
+++ b/lib/race_ctrl/messages/base.py
@@ -82,13 +82,15 @@ class RaceCtrlMsgBase:
 
     def toJSON(self, _driver_info_dict: Optional[Dict[int, dict]] = None) -> Dict[str, Any]:
         """Export the message as a JSON-ready dict."""
-        return {
+        d: Dict[str, Any] = {
             "id": self._id,
             "lap-number": self.lap_number,
             "timestamp": self.timestamp,
             "message-type": str(self.message_type),
             "involved-drivers": list(self.involved_drivers),
-            "lap-distance": self.lap_distance,
-            "segment-info": self.segment_info,
-            "sector": self.sector,
         }
+        if self.lap_distance is not None or self.sector is not None or self.segment_info is not None:
+            d["lap-distance"] = self.lap_distance
+            d["segment-info"] = self.segment_info
+            d["sector"] = self.sector
+        return d

--- a/lib/race_ctrl/messages/base.py
+++ b/lib/race_ctrl/messages/base.py
@@ -68,11 +68,15 @@ class RaceCtrlMsgBase:
         timestamp (float): Time at which the message was issued (seconds).
         message_type (MessageType): Type of race control message.
         involved_drivers (List[int]): List of driver indices involved in the message.
+        lap_distance (Optional[float]): Lap distance in metres at the time of the event.
+        segment_info (Optional[Dict[str, str]]): Track segment info at the event location.
     """
     timestamp: float
     message_type: MessageType
     involved_drivers: List[int] = field(default_factory=list)
     lap_number: Optional[int] = None
+    lap_distance: Optional[float] = None
+    segment_info: Optional[Dict[str, str]] = None
     _id: Optional[int] = None
 
     def toJSON(self, _driver_info_dict: Optional[Dict[int, dict]] = None) -> Dict[str, Any]:
@@ -83,4 +87,6 @@ class RaceCtrlMsgBase:
             "timestamp": self.timestamp,
             "message-type": str(self.message_type),
             "involved-drivers": list(self.involved_drivers),
+            "lap-distance": self.lap_distance,
+            "segment-info": self.segment_info,
         }

--- a/lib/track_segment_info/__init__.py
+++ b/lib/track_segment_info/__init__.py
@@ -24,10 +24,16 @@
 
 from .database import TrackSegmentsDatabase
 from .segments import TrackSegments
+from .types import (ComplexCornerSegmentInfo, CornerSegmentInfo,
+                    StraightSegmentInfo)
 
 # -------------------------------------- EXPORTS -----------------------------------------------------------------------
 
 __all__ = [
     "TrackSegments",
     "TrackSegmentsDatabase",
+
+    "ComplexCornerSegmentInfo",
+    "CornerSegmentInfo",
+    "StraightSegmentInfo",
 ]

--- a/lib/track_segment_info/types.py
+++ b/lib/track_segment_info/types.py
@@ -22,9 +22,11 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
-from typing import Annotated, ClassVar, Dict, List, Literal, Optional, Tuple, Union
+from typing import (Annotated, Any, ClassVar, Dict, List, Literal, Optional,
+                    Tuple, Union)
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (BaseModel, ConfigDict, Field, field_validator,
+                      model_validator)
 
 # -------------------------------------- EXPORTS -----------------------------------------------------------------------
 
@@ -58,7 +60,7 @@ class BaseSegmentInfo(BaseModel):
             raise ValueError(f"start_m ({self.start_m}) must be less than end_m ({self.end_m})")
         return self
 
-    def render(self) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, Any]:
         raise NotImplementedError
 
 
@@ -73,8 +75,11 @@ class StraightSegmentInfo(BaseSegmentInfo):
             raise ValueError("name is required for straight segments")
         return v
 
-    def render(self) -> Dict[str, str]:
-        return {"type": "straight", "name": self.name, "turns": ""}
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": "straight",
+            "name": self.name,
+        }
 
 
 class CornerSegmentInfo(BaseSegmentInfo):
@@ -83,12 +88,12 @@ class CornerSegmentInfo(BaseSegmentInfo):
     name: str = ""
     corner_number: int
 
-    def render(self) -> Dict[str, str]:
-        if self.name:
-            turns = f"T{self.corner_number}"
-        else:
-            turns = f"Turn {self.corner_number}"
-        return {"type": "corner", "name": self.name, "turns": turns}
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": "corner",
+            "name": self.name,
+            "corner_number": self.corner_number,
+        }
 
 
 class ComplexCornerSegmentInfo(BaseSegmentInfo):
@@ -110,10 +115,12 @@ class ComplexCornerSegmentInfo(BaseSegmentInfo):
                 )
         return v
 
-    def render(self) -> Dict[str, str]:
-        first, last = self.corner_numbers[0], self.corner_numbers[-1]
-        turns = f"Turns {first}-{last}"
-        return {"type": "corner", "name": self.name, "turns": turns}
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "type": "corner",
+            "name": self.name,
+            "corner_numbers": list(self.corner_numbers),
+        }
 
 
 SegmentInfo = Annotated[

--- a/lib/track_segment_info/types.py
+++ b/lib/track_segment_info/types.py
@@ -117,7 +117,7 @@ class ComplexCornerSegmentInfo(BaseSegmentInfo):
 
     def to_dict(self) -> Dict[str, object]:
         return {
-            "type": "corner",
+            "type": "complex_corner",
             "name": self.name,
             "corner_numbers": list(self.corner_numbers),
         }

--- a/tests/tests_race_ctrl.py
+++ b/tests/tests_race_ctrl.py
@@ -197,3 +197,27 @@ class TestRaceControlMessages(F1TelemetryUnitTestsBase):
         self.assertEqual(len(self.driver1_mgr.messages), 1)
         self.assertEqual(len(self.session_mgr.messages), 1)
         self.assertEqual(self.driver1_mgr.messages[0], self.session_mgr.messages[0])
+
+    async def test_location_fields_absent_when_not_set(self):
+        msg = DriverPittingRaceCtrlMsg(timestamp=1.0, driver_index=1, lap_number=5)
+        self.session_mgr.add_message(msg)
+        exported = self.session_mgr.toJSON()[0]
+
+        self.assertNotIn("lap-distance", exported)
+        self.assertNotIn("segment-info", exported)
+        self.assertNotIn("sector", exported)
+
+    async def test_location_fields_present_when_lap_distance_set(self):
+        msg = OvertakeRaceCtrlMsg(timestamp=2.0, overtaker_index=1, overtaken_index=2, lap_number=3)
+        msg.lap_distance = 512.5
+        msg.sector = "S2"
+        # segment_info left as None — partial population still triggers the block
+        self.session_mgr.add_message(msg)
+        exported = self.session_mgr.toJSON()[0]
+
+        self.assertIn("lap-distance", exported)
+        self.assertIn("segment-info", exported)
+        self.assertIn("sector", exported)
+        self.assertAlmostEqual(exported["lap-distance"], 512.5)
+        self.assertEqual(exported["sector"], "S2")
+        self.assertIsNone(exported["segment-info"])

--- a/tests/tests_track_segment_info.py
+++ b/tests/tests_track_segment_info.py
@@ -402,29 +402,29 @@ class TestSegmentDict(F1TelemetryUnitTestsBase):
         self.assertEqual(seg.to_dict(), {"type": "corner", "name": "", "corner_number": 3})
 
     def test_complex_corner_named_dict(self):
-        """Named complex corner dict contains type=corner, name, and corner_numbers list."""
+        """Named complex corner dict contains type=complex_corner, name, and corner_numbers list."""
         seg = ComplexCornerSegmentInfo(name="Pouhon", start_m=1400, end_m=1800, corner_numbers=(6, 7))
-        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "Pouhon", "corner_numbers": [6, 7]})
+        self.assertEqual(seg.to_dict(), {"type": "complex_corner", "name": "Pouhon", "corner_numbers": [6, 7]})
 
     def test_complex_corner_unnamed_dict(self):
-        """Unnamed complex corner dict contains with type=corner, empty name, and corner_numbers list."""
+        """Unnamed complex corner dict contains with type=complex_corner, empty name, and corner_numbers list."""
         seg = ComplexCornerSegmentInfo(name="", start_m=0, end_m=500, corner_numbers=(1, 2, 3))
-        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "", "corner_numbers": [1, 2, 3]})
+        self.assertEqual(seg.to_dict(), {"type": "complex_corner", "name": "", "corner_numbers": [1, 2, 3]})
 
     def test_complex_corner_unnamed_two_turns_dict(self):
         """Unnamed complex corner with 2 turns dict contains corner_numbers list."""
         seg = ComplexCornerSegmentInfo(name="", start_m=0, end_m=500, corner_numbers=(3, 4))
-        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "", "corner_numbers": [3, 4]})
+        self.assertEqual(seg.to_dict(), {"type": "complex_corner", "name": "", "corner_numbers": [3, 4]})
 
     def test_complex_corner_two_turns_dict(self):
         """Complex corner with exactly 2 turns dict contains corner_numbers list."""
         seg = ComplexCornerSegmentInfo(name="Esses", start_m=0, end_m=500, corner_numbers=(3, 4))
-        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "Esses", "corner_numbers": [3, 4]})
+        self.assertEqual(seg.to_dict(), {"type": "complex_corner", "name": "Esses", "corner_numbers": [3, 4]})
 
     def test_complex_corner_many_turns_dict(self):
         """Complex corner with >2 turns dict contains corner_numbers list."""
         seg = ComplexCornerSegmentInfo(name="Maggotts-Becketts", start_m=0, end_m=800, corner_numbers=(5, 6, 7, 8))
-        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "Maggotts-Becketts", "corner_numbers": [5, 6, 7, 8]})
+        self.assertEqual(seg.to_dict(), {"type": "complex_corner", "name": "Maggotts-Becketts", "corner_numbers": [5, 6, 7, 8]})
 
     # --- name optionality rules -------------------------------------------------------
 

--- a/tests/tests_track_segment_info.py
+++ b/tests/tests_track_segment_info.py
@@ -374,12 +374,12 @@ class TestTrackSegments(F1TelemetryUnitTestsBase):
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-class TestSegmentRender(F1TelemetryUnitTestsBase):
+class TestSegmentDict(F1TelemetryUnitTestsBase):
 
-    def test_straight_named_render(self):
-        """Named straight renders with type=straight and name set."""
+    def test_straight_named_Dict(self):
+        """Named straight dict contains type and name."""
         seg = StraightSegmentInfo(name="Kemmel Straight", start_m=400, end_m=1200)
-        self.assertEqual(seg.render(), {"type": "straight", "name": "Kemmel Straight", "turns": ""})
+        self.assertEqual(seg.to_dict(), {"type": "straight", "name": "Kemmel Straight"})
 
     def test_straight_empty_name_raises(self):
         """Empty name on a straight raises ValidationError."""
@@ -391,40 +391,40 @@ class TestSegmentRender(F1TelemetryUnitTestsBase):
         with self.assertRaises(ValidationError):
             StraightSegmentInfo(start_m=0, end_m=100)
 
-    def test_corner_named_render(self):
-        """Named corner renders with type=corner, name, and turn number."""
+    def test_corner_named_dict(self):
+        """Named corner dict contains type, name, and corner_number."""
         seg = CornerSegmentInfo(name="La Source", start_m=0, end_m=200, corner_number=1)
-        self.assertEqual(seg.render(), {"type": "corner", "name": "La Source", "turns": "T1"})
+        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "La Source", "corner_number": 1})
 
-    def test_corner_unnamed_render(self):
-        """Unnamed corner renders with empty name and full 'Turn N' label."""
+    def test_corner_unnamed_dict(self):
+        """Unnamed corner dict contains with type, empty name, and corner_number."""
         seg = CornerSegmentInfo(name="", start_m=0, end_m=200, corner_number=3)
-        self.assertEqual(seg.render(), {"type": "corner", "name": "", "turns": "Turn 3"})
+        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "", "corner_number": 3})
 
-    def test_complex_corner_named_render(self):
-        """Named complex corner renders with type=corner, name, and spaced turn numbers."""
+    def test_complex_corner_named_dict(self):
+        """Named complex corner dict contains type=corner, name, and corner_numbers list."""
         seg = ComplexCornerSegmentInfo(name="Pouhon", start_m=1400, end_m=1800, corner_numbers=(6, 7))
-        self.assertEqual(seg.render(), {"type": "corner", "name": "Pouhon", "turns": "Turns 6-7"})
+        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "Pouhon", "corner_numbers": [6, 7]})
 
-    def test_complex_corner_unnamed_render(self):
-        """Unnamed complex corner with >2 turns renders with 'Turns' range format."""
+    def test_complex_corner_unnamed_dict(self):
+        """Unnamed complex corner dict contains with type=corner, empty name, and corner_numbers list."""
         seg = ComplexCornerSegmentInfo(name="", start_m=0, end_m=500, corner_numbers=(1, 2, 3))
-        self.assertEqual(seg.render(), {"type": "corner", "name": "", "turns": "Turns 1-3"})
+        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "", "corner_numbers": [1, 2, 3]})
 
-    def test_complex_corner_unnamed_two_turns_render(self):
-        """Unnamed complex corner with 2 turns renders with 'Turn' slash format."""
+    def test_complex_corner_unnamed_two_turns_dict(self):
+        """Unnamed complex corner with 2 turns dict contains corner_numbers list."""
         seg = ComplexCornerSegmentInfo(name="", start_m=0, end_m=500, corner_numbers=(3, 4))
-        self.assertEqual(seg.render(), {"type": "corner", "name": "", "turns": "Turns 3-4"})
+        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "", "corner_numbers": [3, 4]})
 
-    def test_complex_corner_two_turns_render(self):
-        """Complex corner with exactly 2 turns renders with slash format."""
+    def test_complex_corner_two_turns_dict(self):
+        """Complex corner with exactly 2 turns dict contains corner_numbers list."""
         seg = ComplexCornerSegmentInfo(name="Esses", start_m=0, end_m=500, corner_numbers=(3, 4))
-        self.assertEqual(seg.render(), {"type": "corner", "name": "Esses", "turns": "Turns 3-4"})
+        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "Esses", "corner_numbers": [3, 4]})
 
-    def test_complex_corner_many_turns_render(self):
-        """Complex corner with >2 turns renders with range format."""
+    def test_complex_corner_many_turns_dict(self):
+        """Complex corner with >2 turns dict contains corner_numbers list."""
         seg = ComplexCornerSegmentInfo(name="Maggotts-Becketts", start_m=0, end_m=800, corner_numbers=(5, 6, 7, 8))
-        self.assertEqual(seg.render(), {"type": "corner", "name": "Maggotts-Becketts", "turns": "Turns 5-8"})
+        self.assertEqual(seg.to_dict(), {"type": "corner", "name": "Maggotts-Becketts", "corner_numbers": [5, 6, 7, 8]})
 
     # --- name optionality rules -------------------------------------------------------
 


### PR DESCRIPTION
## What and why

Export location info for compatible race control messages
Decouple render() of Track segment from the format that circuit info expects.
    now renamed to to_dict(), it just populates a dict with appropriate fields. nothing clever

Fixes #287 

## Test plan

- [x] Integration tests pass — `poetry run python tests/integration_test/runner.py`

  ```
  2026-06-23 18:57:48,038 [TEST] [runner.py:281] - TEST STATISTICS
  2026-06-23 18:57:48,038 [TEST] [runner.py:282] - ================================================================================
  2026-06-23 18:57:48,038 [TEST] [runner.py:283] - Files processed:        36
  2026-06-23 18:57:48,038 [TEST] [runner.py:284] - Telemetry sent:         36
  2026-06-23 18:57:48,039 [TEST] [runner.py:285] - Telemetry failed:       0
  2026-06-23 18:57:48,039 [TEST] [runner.py:286] - Endpoint checks passed: 936
  2026-06-23 18:57:48,039 [TEST] [runner.py:287] - Endpoint checks failed: 0
  2026-06-23 18:57:48,039 [TEST] [runner.py:294] - Telemetry success rate: 100.0%
  2026-06-23 18:57:48,039 [TEST] [runner.py:298] - Endpoint success rate:  100.0%
  2026-06-23 18:57:48,039 [TEST] [runner.py:300] - ================================================================================
  2026-06-23 18:57:48,039 [TEST] [runner.py:404] - 
  ```

- [ ] Manually tested in the app

  ```
  paste steps / observations here
  ```

- [ ] No testable change

## Summary by Sourcery

Export track segment location metadata into race control messages and update consumers to use a generic segment dictionary representation.

New Features:
- Include lap distance, sector, and track segment info in serialized race control messages and display a formatted Location column in the Race Control Messages grid.

Enhancements:
- Refactor track segment types to expose a generic to_dict() representation and decouple HUD circuit overlay formatting from segment models.
- Add a shared track segments database to session state for lookup and reuse, and export segment info types from the track_segment_info package.

Tests:
- Update track segment info tests to assert the new dictionary structure for straight, corner, and complex corner segments.