### PR TITLE
Add fire-and-forget receipt acks and rename send() to request()

### DIFF
--- a/apps/mcp_server/mcp_server/tools/common.py
+++ b/apps/mcp_server/mcp_server/tools/common.py
@@ -96,7 +96,7 @@ async def fetch_driver_info(
     Centralizes all transport and backend errors.
     """
 
-    reply = await dealer.send(
+    reply = await dealer.request(
         str(PngAppId.BACKEND),
         "driver-info-request",
         {"index": driver_index},

--- a/lib/ipc/router_dealer/dealer/_wire.py
+++ b/lib/ipc/router_dealer/dealer/_wire.py
@@ -30,7 +30,7 @@ between the two implementations.
 Wire shapes::
 
     command:  [dest,        reply_flag, topic, payload]   # dealer -> router -> dealer
-    reply:    [orig_sender, payload]                       # answer to send()
+    reply:    [orig_sender, payload]                       # answer to request()
     ack:      [orig_sender, ACK_SENTINEL]                  # fire() receipt ack
 """
 
@@ -41,6 +41,6 @@ _REPLY_REQUIRED = b"\x01"
 _NO_REPLY       = b"\x00"
 
 # Single fixed byte marking a fire() receipt ack. A 2-frame message whose second
-# frame equals this is an ack; otherwise it is a send() reply (a JSON payload,
+# frame equals this is an ack; otherwise it is a request() reply (a JSON payload,
 # which always begins '{' / '[' / digit / quote, so the two can never collide).
 ACK_SENTINEL = b"\x06"

--- a/lib/ipc/router_dealer/dealer/_wire.py
+++ b/lib/ipc/router_dealer/dealer/_wire.py
@@ -1,0 +1,46 @@
+# MIT License
+#
+# Copyright (c) [2026] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Shared router/dealer wire-protocol constants.
+
+Single source of truth for the bytes that travel on the wire between the
+``IpcRouter`` and its dealer clients. Both the sync (``client.py``) and async
+(``async_client.py``) dealers import from here so the protocol can never drift
+between the two implementations.
+
+Wire shapes::
+
+    command:  [dest,        reply_flag, topic, payload]   # dealer -> router -> dealer
+    reply:    [orig_sender, payload]                       # answer to send()
+    ack:      [orig_sender, ACK_SENTINEL]                  # fire() receipt ack
+"""
+
+# -------------------------------------- CONSTANTS ---------------------------------------------------------------------
+
+# reply_flag values on a 4-frame command frame.
+_REPLY_REQUIRED = b"\x01"
+_NO_REPLY       = b"\x00"
+
+# Single fixed byte marking a fire() receipt ack. A 2-frame message whose second
+# frame equals this is an ack; otherwise it is a send() reply (a JSON payload,
+# which always begins '{' / '[' / digit / quote, so the two can never collide).
+ACK_SENTINEL = b"\x06"

--- a/lib/ipc/router_dealer/dealer/async_client.py
+++ b/lib/ipc/router_dealer/dealer/async_client.py
@@ -52,7 +52,7 @@ class IpcDealerAsync:
 
     **Request-response** — send and await reply::
 
-        stats = await dealer.send("hud", "get-stats", {})
+        stats = await dealer.request("hud", "get-stats", {})
 
     Inbound (optional): register handlers via ``route(topic)``.
 
@@ -61,11 +61,11 @@ class IpcDealerAsync:
 
         task = asyncio.create_task(dealer.start(), name="Dealer Recv")
 
-    ``start()`` must be called (and its task scheduled) before ``send()`` or
+    ``start()`` must be called (and its task scheduled) before ``request()`` or
     any inbound routing will work.
 
     Notes:
-      - Only one outbound ``send()`` may be in-flight at a time (protocol has
+      - Only one outbound ``request()`` may be in-flight at a time (protocol has
         no correlation ID). Enforced by an internal lock.
       - Async handlers should be ``async def``; sync handlers must be fast —
         anything that blocks stalls the recv loop.
@@ -84,7 +84,7 @@ class IpcDealerAsync:
         task = asyncio.create_task(dealer.start(), name="Dealer Recv")
 
         await dealer.fire("hud", "hud-toggle-notification", {"oid": "mfd"})
-        stats = await dealer.send("hud", "get-stats", {})
+        stats = await dealer.request("hud", "get-stats", {})
 
         await dealer.close()
     """
@@ -161,10 +161,10 @@ class IpcDealerAsync:
 
             task = asyncio.create_task(dealer.start(), name="Dealer Recv")
 
-        Must be called before ``send()`` or any inbound routing will work.
+        Must be called before ``request()`` or any inbound routing will work.
 
         Single reader for the DEALER socket. Demuxes by frame count:
-          - 2 frames → reply to a pending outbound send()
+          - 2 frames → reply to a pending outbound request()
           - 4 frames → unsolicited inbound command → dispatch to handler
         """
         self._recv_task = asyncio.current_task()
@@ -220,7 +220,7 @@ class IpcDealerAsync:
             return
 
         # Fire-and-forget: confirm receipt with a bare ack before running the handler.
-        # (send() gets its confirmation from the reply, so it is not acked here.)
+        # (request() gets its confirmation from the reply, so it is not acked here.)
         if not wants_reply:
             await self._send_ack(sender_id)
 
@@ -279,7 +279,7 @@ class IpcDealerAsync:
     # ---------------------------------------------------------
     # Request-response (awaits reply)
     # ---------------------------------------------------------
-    async def send(self, dest_identity: str, topic: str, data: dict) -> dict:
+    async def request(self, dest_identity: str, topic: str, data: dict) -> dict:
         """
         Send a command and await a reply from the recipient.
 
@@ -293,7 +293,7 @@ class IpcDealerAsync:
             Returns an error dict without raising on timeout or send failure.
         """
         assert self._recv_task is not None, \
-            "IpcDealerAsync.start() must be running before send() — schedule it as a task first"
+            "IpcDealerAsync.start() must be running before request() — schedule it as a task first"
         payload = orjson.dumps(data)
 
         async with self._send_lock:

--- a/lib/ipc/router_dealer/dealer/async_client.py
+++ b/lib/ipc/router_dealer/dealer/async_client.py
@@ -32,7 +32,7 @@ import zmq.asyncio
 
 from lib.event_counter import EventCounter
 
-from ._wire import _NO_REPLY, _REPLY_REQUIRED
+from ._wire import _NO_REPLY, _REPLY_REQUIRED, ACK_SENTINEL
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
@@ -177,6 +177,11 @@ class IpcDealerAsync:
                     continue
 
                 if len(frames) == 2:
+                    if frames[1] == ACK_SENTINEL:
+                        sender = frames[0].decode("utf-8", errors="replace")
+                        self.stats.track_event("__ACK__", sender)
+                        self.logger.debug("IpcDealerAsync [%s] fire ack from %r", self.identity, sender) # TODO: make it silent
+                        continue
                     pending = self._pending_reply
                     if pending is not None and not pending.done():
                         pending.set_result(frames)
@@ -213,6 +218,11 @@ class IpcDealerAsync:
                 await self._send_reply(sender_id, {"status": "error", "reason": f"unknown topic: {topic}"})
             return
 
+        # Fire-and-forget: confirm receipt with a bare ack before running the handler.
+        # (send() gets its confirmation from the reply, so it is not acked here.)
+        if not wants_reply:
+            await self._send_ack(sender_id)
+
         sender_str = sender_id.decode("utf-8", errors="replace")
         try:
             result = handler(data, sender_str)
@@ -226,6 +236,14 @@ class IpcDealerAsync:
             self.logger.exception("Handler error for topic %r: %s", topic, e)
             if wants_reply:
                 await self._send_reply(sender_id, {"status": "error", "reason": str(e)})
+
+    async def _send_ack(self, sender_id: bytes) -> None:
+        try:
+            await self.socket.send_multipart([sender_id, ACK_SENTINEL])
+            self.stats.track_event("__ACK_SENT__", sender_id.decode("utf-8", errors="replace"))
+        except zmq.ZMQError as e:
+            self.stats.track_event("__ERROR__", "ack_send_failed")
+            self.logger.warning("IpcDealerAsync [%s] failed to send ack: %s", self.identity, e)
 
     async def _send_reply(self, sender_id: bytes, reply: dict) -> None:
         try:

--- a/lib/ipc/router_dealer/dealer/async_client.py
+++ b/lib/ipc/router_dealer/dealer/async_client.py
@@ -32,10 +32,7 @@ import zmq.asyncio
 
 from lib.event_counter import EventCounter
 
-# -------------------------------------- CONSTANTS ---------------------------------------------------------------------
-
-_REPLY_REQUIRED = b"\x01"
-_NO_REPLY       = b"\x00"
+from ._wire import _NO_REPLY, _REPLY_REQUIRED
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 

--- a/lib/ipc/router_dealer/dealer/async_client.py
+++ b/lib/ipc/router_dealer/dealer/async_client.py
@@ -31,6 +31,7 @@ import zmq
 import zmq.asyncio
 
 from lib.event_counter import EventCounter
+from lib.logger import PngLogger
 
 from ._wire import _NO_REPLY, _REPLY_REQUIRED, ACK_SENTINEL
 
@@ -95,7 +96,7 @@ class IpcDealerAsync:
         host: str = "127.0.0.1",
         port: Optional[int] = None,
         identity: str = "",
-        logger: Optional[logging.Logger] = None,
+        logger: Optional[PngLogger] = None,
     ):
         assert port is not None
         assert identity
@@ -108,7 +109,7 @@ class IpcDealerAsync:
             logger = logging.getLogger(f"{__name__}.IpcDealerAsync")
             logger.addHandler(logging.NullHandler())
             logger.propagate = False
-        self.logger = logger
+        self.logger: PngLogger = logger
 
         self._ctx = zmq.asyncio.Context()
         self.socket: Optional[zmq.asyncio.Socket] = None
@@ -180,7 +181,7 @@ class IpcDealerAsync:
                     if frames[1] == ACK_SENTINEL:
                         sender = frames[0].decode("utf-8", errors="replace")
                         self.stats.track_event("__ACK__", sender)
-                        self.logger.debug("IpcDealerAsync [%s] fire ack from %r", self.identity, sender) # TODO: make it silent
+                        self.logger.silent("IpcDealerAsync [%s] fire ack from %r", self.identity, sender)
                         continue
                     pending = self._pending_reply
                     if pending is not None and not pending.done():

--- a/lib/ipc/router_dealer/dealer/async_client.py
+++ b/lib/ipc/router_dealer/dealer/async_client.py
@@ -23,7 +23,6 @@
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
 import asyncio
-import logging
 from typing import Callable, Dict, Optional
 
 import orjson
@@ -31,7 +30,7 @@ import zmq
 import zmq.asyncio
 
 from lib.event_counter import EventCounter
-from lib.logger import PngLogger
+from lib.logger import PngLogger, get_null_logger
 
 from ._wire import _NO_REPLY, _REPLY_REQUIRED, ACK_SENTINEL
 
@@ -105,11 +104,7 @@ class IpcDealerAsync:
         self.port = port
         self.identity = identity
 
-        if logger is None:
-            logger = logging.getLogger(f"{__name__}.IpcDealerAsync")
-            logger.addHandler(logging.NullHandler())
-            logger.propagate = False
-        self.logger: PngLogger = logger
+        self.logger: PngLogger = logger if logger is not None else get_null_logger()
 
         self._ctx = zmq.asyncio.Context()
         self.socket: Optional[zmq.asyncio.Socket] = None

--- a/lib/ipc/router_dealer/dealer/client.py
+++ b/lib/ipc/router_dealer/dealer/client.py
@@ -31,10 +31,9 @@ import zmq
 
 from lib.event_counter import EventCounter
 
-# -------------------------------------- CONSTANTS ---------------------------------------------------------------------
+from ._wire import _NO_REPLY, _REPLY_REQUIRED
 
-_REPLY_REQUIRED = b"\x01"
-_NO_REPLY       = b"\x00"
+# -------------------------------------- CONSTANTS ---------------------------------------------------------------------
 
 # Pipe command bytes — sent through the inproc PAIR pipe from caller threads to the loop thread.
 _PIPE_STOP  = b"\xff"

--- a/lib/ipc/router_dealer/dealer/client.py
+++ b/lib/ipc/router_dealer/dealer/client.py
@@ -66,10 +66,10 @@ class IpcDealerClient:
 
     **Request-response** (blocks caller thread until reply or timeout)::
 
-        reply = client.send("backend", "get-stats", {}, timeout=2.0)
+        reply = client.request("backend", "get-stats", {}, timeout=2.0)
 
-    ``send()`` is safe to call from any thread *except* the loop thread itself
-    (deadlock). Only one outbound ``send()`` may be in-flight at a time.
+    ``request()`` is safe to call from any thread *except* the loop thread itself
+    (deadlock). Only one outbound ``request()`` may be in-flight at a time.
 
     ZMQ sockets are not thread-safe, so outbound sends are marshalled through
     an inproc PAIR pipe that the loop thread drains alongside the DEALER socket.
@@ -92,7 +92,7 @@ class IpcDealerClient:
 
         threading.Thread(target=client.start, daemon=True).start()
         # ... later:
-        reply = client.send("backend", "query", {})
+        reply = client.request("backend", "query", {})
         client.close()
     """
 
@@ -120,7 +120,7 @@ class IpcDealerClient:
         self._running = False
         self.stats = EventCounter()
 
-        # Set when the loop thread starts; used by send() to detect deadlock-prone misuse.
+        # Set when the loop thread starts; used by request() to detect deadlock-prone misuse.
         self._loop_thread_id: Optional[int] = None
 
         self._ctx = zmq.Context()
@@ -139,9 +139,9 @@ class IpcDealerClient:
 
         # Serialises all writes to _pipe_write (ZMQ sockets are not thread-safe).
         self._pipe_lock = threading.Lock()
-        # Serialises concurrent send() callers (only one in-flight at a time).
+        # Serialises concurrent request() callers (only one in-flight at a time).
         self._send_lock = threading.Lock()
-        # Slot for the loop thread to deposit a send() reply.
+        # Slot for the loop thread to deposit a request() reply.
         self._reply_slot: Optional[dict] = None
         self._reply_event = threading.Event()
 
@@ -209,7 +209,7 @@ class IpcDealerClient:
     # ---------------------------------------------------------
     # Outbound: request-response
     # ---------------------------------------------------------
-    def send(
+    def request(
         self,
         dest_identity: str,
         topic: str,
@@ -220,7 +220,7 @@ class IpcDealerClient:
         Send a command and block until a reply arrives or timeout elapses.
 
         Safe to call from any thread *except* the loop thread (deadlock).
-        Only one send() may be in-flight at a time.
+        Only one request() may be in-flight at a time.
 
         Args:
             dest_identity: ZMQ identity of the target DEALER.
@@ -232,9 +232,9 @@ class IpcDealerClient:
             Reply dict from the remote handler, or an error dict on timeout/failure.
         """
         assert self._running, \
-            "IpcDealerClient.start() must be running before send() — run it in a thread first"
+            "IpcDealerClient.start() must be running before request() — run it in a thread first"
         assert threading.get_ident() != self._loop_thread_id, \
-            "IpcDealerClient.send() called from the loop thread — deadlock. Use fire() or a different thread."
+            "IpcDealerClient.request() called from the loop thread — deadlock. Use fire() or a different thread."
 
         payload = orjson.dumps(data)
 
@@ -335,7 +335,7 @@ class IpcDealerClient:
             self.logger.silent("IpcDealerClient [%s] fire ack from %r", self.identity, sender) # TODO: make it silent
             return awaiting_reply
 
-        # 2-frame reply to a pending send()
+        # 2-frame reply to a pending request()
         if len(frames) == 2 and awaiting_reply:
             try:
                 reply = orjson.loads(frames[-1])
@@ -372,7 +372,7 @@ class IpcDealerClient:
             return awaiting_reply
 
         # Fire-and-forget: confirm receipt with a bare ack before running the handler.
-        # (send() gets its confirmation from the reply, so it is not acked here.)
+        # (request() gets its confirmation from the reply, so it is not acked here.)
         if not wants_reply:
             self._send_ack(sender_id)
 

--- a/lib/ipc/router_dealer/dealer/client.py
+++ b/lib/ipc/router_dealer/dealer/client.py
@@ -31,7 +31,7 @@ import zmq
 
 from lib.event_counter import EventCounter
 
-from ._wire import _NO_REPLY, _REPLY_REQUIRED
+from ._wire import _NO_REPLY, _REPLY_REQUIRED, ACK_SENTINEL
 
 # -------------------------------------- CONSTANTS ---------------------------------------------------------------------
 
@@ -327,6 +327,13 @@ class IpcDealerClient:
                 awaiting_reply = False
             return awaiting_reply
 
+        # 2-frame ack for a prior fire() — disambiguated from a reply by the sentinel byte
+        if len(frames) == 2 and frames[1] == ACK_SENTINEL:
+            sender = frames[0].decode("utf-8", errors="replace")
+            self.stats.track_event("__ACK__", sender)
+            self.logger.debug("IpcDealerClient [%s] fire ack from %r", self.identity, sender) # TODO: make it silent
+            return awaiting_reply
+
         # 2-frame reply to a pending send()
         if len(frames) == 2 and awaiting_reply:
             try:
@@ -362,6 +369,11 @@ class IpcDealerClient:
             if wants_reply:
                 self._send_reply(sender_id, {"status": "error", "reason": f"unknown topic: {topic}"})
             return awaiting_reply
+
+        # Fire-and-forget: confirm receipt with a bare ack before running the handler.
+        # (send() gets its confirmation from the reply, so it is not acked here.)
+        if not wants_reply:
+            self._send_ack(sender_id)
 
         sender_str = sender_id.decode("utf-8", errors="replace")
         try:
@@ -409,6 +421,14 @@ class IpcDealerClient:
         self._loop_thread_id = None
         self._close_sockets(poller)
         self.logger.debug("IpcDealerClient [%s] stopped", self.identity)
+
+    def _send_ack(self, sender_id: bytes) -> None:
+        try:
+            self.socket.send_multipart([sender_id, ACK_SENTINEL], flags=zmq.NOBLOCK)
+            self.stats.track_event("__ACK_SENT__", sender_id.decode("utf-8", errors="replace"))
+        except zmq.ZMQError as e:
+            self.stats.track_event("__ERROR__", "ack_send_failed")
+            self.logger.warning("IpcDealerClient [%s] failed to send ack: %s", self.identity, e)
 
     def _send_reply(self, sender_id: bytes, reply: dict) -> None:
         try:

--- a/lib/ipc/router_dealer/dealer/client.py
+++ b/lib/ipc/router_dealer/dealer/client.py
@@ -30,6 +30,7 @@ import orjson
 import zmq
 
 from lib.event_counter import EventCounter
+from lib.logger import PngLogger
 
 from ._wire import _NO_REPLY, _REPLY_REQUIRED, ACK_SENTINEL
 
@@ -100,7 +101,7 @@ class IpcDealerClient:
         host: str = "127.0.0.1",
         port: Optional[int] = None,
         identity: str = "",
-        logger: Optional[logging.Logger] = None,
+        logger: Optional[PngLogger] = None,
     ):
         assert port is not None
         assert identity
@@ -113,7 +114,7 @@ class IpcDealerClient:
             logger = logging.getLogger(f"{__name__}.IpcDealerClient")
             logger.addHandler(logging.NullHandler())
             logger.propagate = False
-        self.logger = logger
+        self.logger: PngLogger = logger
 
         self._routes: Dict[str, Callable[[dict, str], object]] = {}
         self._running = False
@@ -331,7 +332,7 @@ class IpcDealerClient:
         if len(frames) == 2 and frames[1] == ACK_SENTINEL:
             sender = frames[0].decode("utf-8", errors="replace")
             self.stats.track_event("__ACK__", sender)
-            self.logger.debug("IpcDealerClient [%s] fire ack from %r", self.identity, sender) # TODO: make it silent
+            self.logger.silent("IpcDealerClient [%s] fire ack from %r", self.identity, sender) # TODO: make it silent
             return awaiting_reply
 
         # 2-frame reply to a pending send()

--- a/lib/ipc/router_dealer/dealer/client.py
+++ b/lib/ipc/router_dealer/dealer/client.py
@@ -22,7 +22,6 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
-import logging
 import threading
 from typing import Callable, Dict, Optional
 
@@ -30,7 +29,7 @@ import orjson
 import zmq
 
 from lib.event_counter import EventCounter
-from lib.logger import PngLogger
+from lib.logger import PngLogger, get_null_logger
 
 from ._wire import _NO_REPLY, _REPLY_REQUIRED, ACK_SENTINEL
 
@@ -110,11 +109,7 @@ class IpcDealerClient:
         self.port = port
         self.identity = identity
 
-        if logger is None:
-            logger = logging.getLogger(f"{__name__}.IpcDealerClient")
-            logger.addHandler(logging.NullHandler())
-            logger.propagate = False
-        self.logger: PngLogger = logger
+        self.logger: PngLogger = logger if logger is not None else get_null_logger()
 
         self._routes: Dict[str, Callable[[dict, str], object]] = {}
         self._running = False
@@ -332,7 +327,7 @@ class IpcDealerClient:
         if len(frames) == 2 and frames[1] == ACK_SENTINEL:
             sender = frames[0].decode("utf-8", errors="replace")
             self.stats.track_event("__ACK__", sender)
-            self.logger.silent("IpcDealerClient [%s] fire ack from %r", self.identity, sender) # TODO: make it silent
+            self.logger.silent("IpcDealerClient [%s] fire ack from %r", self.identity, sender)
             return awaiting_reply
 
         # 2-frame reply to a pending request()

--- a/lib/logger.py
+++ b/lib/logger.py
@@ -23,12 +23,13 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
-import os
-import logging
 import json
+import logging
+import os
 from datetime import datetime
 from typing import Optional
 
+from meta.meta import APP_NAME_SNAKE
 
 # -------------------------------------- CUSTOM LOG LEVEL ---------------------------------------------------------------
 
@@ -110,6 +111,20 @@ def get_logger(
 
     return logger
 
+def get_null_logger() -> PngLogger:
+    """Return a no-op :class:`PngLogger` that discards all records.
+
+    Use this as the default when no logger is injected into a component. A bare
+    ``logging.getLogger()`` is not guaranteed to return a ``PngLogger`` (so it
+    may lack ``silent()``); this always does.
+
+    Returns:
+        PngLogger: A logger whose records go nowhere.
+    """
+    logger = PngLogger(f"{APP_NAME_SNAKE}.null")
+    logger.addHandler(logging.NullHandler())
+    logger.propagate = False
+    return logger
 
 def _clearFileIfRequired(file_name: str, max_size: int) -> None:
     if os.path.exists(file_name):

--- a/tests/ipc/tests_router_dealer.py
+++ b/tests/ipc/tests_router_dealer.py
@@ -776,6 +776,95 @@ class TestIpcRouterDealer(TestIPC):
         self.assertIn({"n": 1}, bridge_received)
         self.assertIn({"n": 2}, sync_received)
 
+    # ------------------------------------------------------------------
+    # Fire-and-forget receipt ack (async dealer)
+    # ------------------------------------------------------------------
+
+    def test_async_fire_is_acked_by_async_receiver(self):
+        """A fire() to an async receiver yields a receipt ack on the sender + a sent-ack on the receiver."""
+        received = []
+
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="ack-recv")
+
+            @receiver.route("press")
+            def on_press(data, _sender):
+                received.append(data)
+
+            asyncio.create_task(receiver.start())
+
+            sender = IpcDealerAsync(port=self.port, identity="ack-send")
+            asyncio.create_task(sender.start())
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            await sender.fire("ack-recv", "press", {"btn": "mfd"})
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            s_stats = sender.get_stats()
+            r_stats = receiver.get_stats()
+            await sender.close()
+            await receiver.close()
+            return s_stats, r_stats
+
+        s_stats, r_stats = self._run_async(run())
+        self.assertIn({"btn": "mfd"}, received)
+        # Sender observed the receipt ack from the receiver's identity.
+        self.assertGreaterEqual(s_stats.get("__ACK__", {}).get("ack-recv", {}).get("count", 0), 1)
+        # Receiver recorded that it emitted the ack.
+        self.assertGreaterEqual(r_stats.get("__ACK_SENT__", {}).get("ack-send", {}).get("count", 0), 1)
+
+    def test_async_fire_to_unknown_topic_is_not_acked(self):
+        """A fire() to a known identity but unrouted topic is dropped, not acked."""
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="ack-recv-unrouted")
+            # No routes registered.
+            asyncio.create_task(receiver.start())
+
+            sender = IpcDealerAsync(port=self.port, identity="ack-send-unrouted")
+            asyncio.create_task(sender.start())
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            await sender.fire("ack-recv-unrouted", "no-such-topic", {})
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            s_stats = sender.get_stats()
+            await sender.close()
+            await receiver.close()
+            return s_stats
+
+        s_stats = self._run_async(run())
+        self.assertEqual(s_stats.get("__ACK__", {}), {})
+
+    def test_async_ack_does_not_corrupt_pending_send(self):
+        """An ack arriving from a prior fire() must not be mistaken for a send()'s reply."""
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="ack-recv-mix")
+
+            @receiver.route("press")
+            def on_press(_data, _sender):
+                return None
+
+            @receiver.route("query")
+            def on_query(data, _sender):
+                return {"answer": data.get("q")}
+
+            asyncio.create_task(receiver.start())
+
+            sender = IpcDealerAsync(port=self.port, identity="ack-send-mix")
+            asyncio.create_task(sender.start())
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            # Fire (will produce an ack) immediately followed by a send awaiting a reply.
+            await sender.fire("ack-recv-mix", "press", {})
+            reply = await sender.send("ack-recv-mix", "query", {"q": "hi"})
+
+            await sender.close()
+            await receiver.close()
+            return reply
+
+        reply = self._run_async(run())
+        self.assertEqual(reply.get("answer"), "hi")
+
     def test_async_dealer_close_cancels_recv_loop(self):
         """close() cleanly cancels the background recv task."""
         async def run():

--- a/tests/ipc/tests_router_dealer.py
+++ b/tests/ipc/tests_router_dealer.py
@@ -1110,6 +1110,102 @@ class TestIpcRouterDealer(TestIPC):
             self.assertIn({"seq": i}, received)
 
     # ------------------------------------------------------------------
+    # Fire-and-forget receipt ack (sync dealer)
+    # ------------------------------------------------------------------
+
+    def test_sync_fire_is_acked_by_sync_receiver(self):
+        """IpcDealerClient.fire() to a sync receiver yields a receipt ack on the sender."""
+        received = []
+        receiver = self._make_dealer_client("sync-ack-recv", {
+            "ping": lambda d, _sender: received.append(d),
+        })
+        sender = self._make_dealer_client("sync-ack-send", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        sender.fire("sync-ack-recv", "ping", {"v": 7})
+        time.sleep(PROPAGATION_DELAY * 3)
+
+        self.assertIn({"v": 7}, received)
+        s_stats = sender.get_stats()
+        r_stats = receiver.get_stats()
+        self.assertGreaterEqual(s_stats.get("__ACK__", {}).get("sync-ack-recv", {}).get("count", 0), 1)
+        self.assertGreaterEqual(r_stats.get("__ACK_SENT__", {}).get("sync-ack-send", {}).get("count", 0), 1)
+
+    def test_sync_fire_to_unknown_topic_is_not_acked(self):
+        """A sync fire() to a known identity but unrouted topic is dropped, not acked."""
+        self._make_dealer_client("sync-ack-recv-unrouted", {})
+        sender = self._make_dealer_client("sync-ack-send-unrouted", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        sender.fire("sync-ack-recv-unrouted", "no-such-topic", {})
+        time.sleep(PROPAGATION_DELAY * 3)
+
+        self.assertEqual(sender.get_stats().get("__ACK__", {}), {})
+
+    def test_sync_fire_ack_does_not_corrupt_following_send(self):
+        """A sync fire() ack arriving before a send()'s reply must not be mistaken for it."""
+        receiver = self._make_dealer_client("sync-ack-mix", {
+            "press": lambda d, _sender: None,
+            "echo": lambda d, _sender: {"echoed": d},
+        })
+        sender = self._make_dealer_client("sync-ack-mix-send", {})
+        time.sleep(PROPAGATION_DELAY)
+
+        sender.fire("sync-ack-mix", "press", {})
+        reply = sender.send("sync-ack-mix", "echo", {"x": 1})
+        self.assertEqual(reply.get("echoed"), {"x": 1})
+
+    def test_sync_fire_acked_by_async_receiver(self):
+        """IpcDealerClient.fire() to an async receiver gets an ack the sync sender records."""
+        received = []
+
+        async def run():
+            receiver = IpcDealerAsync(port=self.port, identity="async-ack-recv-x")
+
+            @receiver.route("press")
+            def on_press(data, _sender):
+                received.append(data)
+
+            asyncio.create_task(receiver.start())
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            sender = self._make_dealer_client("sync-ack-send-x", {})
+            time.sleep(PROPAGATION_DELAY)
+
+            sender.fire("async-ack-recv-x", "press", {"btn": "y"})
+            await asyncio.sleep(PROPAGATION_DELAY * 2)
+
+            await receiver.close()
+            return sender.get_stats()
+
+        s_stats = self._run_async(run())
+        self.assertIn({"btn": "y"}, received)
+        self.assertGreaterEqual(s_stats.get("__ACK__", {}).get("async-ack-recv-x", {}).get("count", 0), 1)
+
+    def test_async_fire_acked_by_sync_receiver(self):
+        """IpcDealerAsync.fire() to a sync receiver gets an ack the async sender records."""
+        received = []
+        self._make_dealer_client("sync-ack-recv-y", {
+            "press": lambda d, _sender: received.append(d),
+        })
+
+        async def run():
+            sender = IpcDealerAsync(port=self.port, identity="async-ack-send-y")
+            asyncio.create_task(sender.start())
+            await asyncio.sleep(PROPAGATION_DELAY)
+
+            await sender.fire("sync-ack-recv-y", "press", {"btn": "z"})
+            await asyncio.sleep(PROPAGATION_DELAY * 2)
+
+            s_stats = sender.get_stats()
+            await sender.close()
+            return s_stats
+
+        s_stats = self._run_async(run())
+        self.assertIn({"btn": "z"}, received)
+        self.assertGreaterEqual(s_stats.get("__ACK__", {}).get("sync-ack-recv-y", {}).get("count", 0), 1)
+
+    # ------------------------------------------------------------------
     # Bidirectional exchange: sync ↔ async, both sides send and receive
     # ------------------------------------------------------------------
 

--- a/tests/ipc/tests_router_dealer.py
+++ b/tests/ipc/tests_router_dealer.py
@@ -140,7 +140,7 @@ class TestIpcRouterDealer(TestIPC):
         self.assertIsInstance(stats, dict)
 
     # ------------------------------------------------------------------
-    # Request-response: send() awaits a reply
+    # Request-response: request() awaits a reply
     # ------------------------------------------------------------------
 
     def test_send_single_message_gets_ok_reply(self):
@@ -155,7 +155,7 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            reply = await dealer.send("hud", "toggle", {"oid": "mfd"})
+            reply = await dealer.request("hud", "toggle", {"oid": "mfd"})
             await dealer.close()
             return reply
 
@@ -178,7 +178,7 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            reply = await dealer.send("hud-rich", "get-stats", {})
+            reply = await dealer.request("hud-rich", "get-stats", {})
             await dealer.close()
             return reply
 
@@ -198,8 +198,8 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            r_a = await dealer.send("hud-multi", "topic-a", {"x": 1})
-            r_b = await dealer.send("hud-multi", "topic-b", {"y": 2})
+            r_a = await dealer.request("hud-multi", "topic-a", {"x": 1})
+            r_b = await dealer.request("hud-multi", "topic-b", {"y": 2})
 
             await dealer.close()
             return r_a, r_b
@@ -220,7 +220,7 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            reply = await dealer.send("hud-unknown", "no-such-topic", {})
+            reply = await dealer.request("hud-unknown", "no-such-topic", {})
             await dealer.close()
             return reply
 
@@ -239,7 +239,7 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            reply = await dealer.send("hud-exc", "crash", {})
+            reply = await dealer.request("hud-exc", "crash", {})
             await dealer.close()
             return reply
 
@@ -263,7 +263,7 @@ class TestIpcRouterDealer(TestIPC):
 
             replies = []
             for i in range(N):
-                r = await dealer.send("hud-rapid", "press", {"seq": i})
+                r = await dealer.request("hud-rapid", "press", {"seq": i})
                 replies.append(r)
 
             await dealer.close()
@@ -290,7 +290,7 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            reply = await dealer.send("ghost-client", "press", {"seq": 0})
+            reply = await dealer.request("ghost-client", "press", {"seq": 0})
             await dealer.close()
             return reply
 
@@ -320,7 +320,7 @@ class TestIpcRouterDealer(TestIPC):
             dealer = IpcDealerAsync(port=self.port, identity="sender-crash")
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
-            r = await dealer.send("hud-crash", "ping", {"phase": 1})
+            r = await dealer.request("hud-crash", "ping", {"phase": 1})
             await dealer.close()
             return r
 
@@ -342,7 +342,7 @@ class TestIpcRouterDealer(TestIPC):
             dealer.ACK_TIMEOUT = 0.2
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
-            r = await dealer.send("hud-crash", "ping", {"phase": 2})
+            r = await dealer.request("hud-crash", "ping", {"phase": 2})
             await dealer.close()
             return r
 
@@ -362,7 +362,7 @@ class TestIpcRouterDealer(TestIPC):
             dealer = IpcDealerAsync(port=self.port, identity="sender-crash3")
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
-            r = await dealer.send("hud-crash", "ping", {"phase": 3})
+            r = await dealer.request("hud-crash", "ping", {"phase": 3})
             await dealer.close()
             return r
 
@@ -475,8 +475,8 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            r_a = await dealer.send("hud-a", "msg", {"target": "a"})
-            r_b = await dealer.send("hud-b", "msg", {"target": "b"})
+            r_a = await dealer.request("hud-a", "msg", {"target": "a"})
+            r_b = await dealer.request("hud-b", "msg", {"target": "b"})
 
             await dealer.close()
             return r_a, r_b
@@ -505,7 +505,7 @@ class TestIpcRouterDealer(TestIPC):
             dealer = IpcDealerAsync(port=self.port, identity="sender-stats")
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
-            await dealer.send("hud-stats", "ping", {"v": 1})
+            await dealer.request("hud-stats", "ping", {"v": 1})
             await dealer.close()
 
         self._run_async(run())
@@ -522,7 +522,7 @@ class TestIpcRouterDealer(TestIPC):
             dealer = IpcDealerAsync(port=self.port, identity="sender-bstats")
             asyncio.create_task(dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
-            await dealer.send("hud-bstats", "x", {})
+            await dealer.request("hud-bstats", "x", {})
             await dealer.close()
 
         self._run_async(run())
@@ -563,7 +563,7 @@ class TestIpcRouterDealer(TestIPC):
         self.assertIn({"btn": "mfd"}, received)
 
     def test_async_dealer_receives_send_and_replies_with_dict(self):
-        """send() to an async dealer receiver gets the handler's dict reply."""
+        """request() to an async dealer receiver gets the handler's dict reply."""
         STATS = {"laps": 7, "tyre": "hard"}
 
         async def run():
@@ -579,7 +579,7 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(sender.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            reply = await sender.send("async-recv-send", "get-stats", {})
+            reply = await sender.request("async-recv-send", "get-stats", {})
 
             await sender.close()
             await receiver.close()
@@ -603,7 +603,7 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(sender.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            reply = await sender.send("async-recv-none", "ack", {})
+            reply = await sender.request("async-recv-none", "ack", {})
 
             await sender.close()
             await receiver.close()
@@ -628,7 +628,7 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(sender.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            reply = await sender.send("async-recv-coro", "slow", {"x": 1})
+            reply = await sender.request("async-recv-coro", "slow", {"x": 1})
 
             await sender.close()
             await receiver.close()
@@ -649,7 +649,7 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(sender.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            reply = await sender.send("async-recv-unknown", "no-such-topic", {})
+            reply = await sender.request("async-recv-unknown", "no-such-topic", {})
 
             await sender.close()
             await receiver.close()
@@ -674,14 +674,14 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(sender.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            reply = await sender.send("async-recv-exc", "crash", {})
+            reply = await sender.request("async-recv-exc", "crash", {})
 
             # Recv loop should still be alive after an exception — try again.
             @receiver.route("ok")
             def on_ok(_data, _sender):
                 return {"status": "ok", "after": "crash"}
 
-            reply2 = await sender.send("async-recv-exc", "ok", {})
+            reply2 = await sender.request("async-recv-exc", "ok", {})
 
             await sender.close()
             await receiver.close()
@@ -759,9 +759,9 @@ class TestIpcRouterDealer(TestIPC):
 
             # Other sends to bridge while bridge sends to sync — interleaved.
             other_task = asyncio.create_task(
-                other.send("bridge", "from-other", {"n": 1})
+                other.request("bridge", "from-other", {"n": 1})
             )
-            bridge_reply = await bridge.send("sync-peer", "from-bridge", {"n": 2})
+            bridge_reply = await bridge.request("sync-peer", "from-bridge", {"n": 2})
             other_reply = await other_task
 
             await other.close()
@@ -836,7 +836,7 @@ class TestIpcRouterDealer(TestIPC):
         self.assertEqual(s_stats.get("__ACK__", {}), {})
 
     def test_async_ack_does_not_corrupt_pending_send(self):
-        """An ack arriving from a prior fire() must not be mistaken for a send()'s reply."""
+        """An ack arriving from a prior fire() must not be mistaken for a request()'s reply."""
         async def run():
             receiver = IpcDealerAsync(port=self.port, identity="ack-recv-mix")
 
@@ -856,7 +856,7 @@ class TestIpcRouterDealer(TestIPC):
 
             # Fire (will produce an ack) immediately followed by a send awaiting a reply.
             await sender.fire("ack-recv-mix", "press", {})
-            reply = await sender.send("ack-recv-mix", "query", {"q": "hi"})
+            reply = await sender.request("ack-recv-mix", "query", {"q": "hi"})
 
             await sender.close()
             await receiver.close()
@@ -886,7 +886,7 @@ class TestIpcRouterDealer(TestIPC):
         self.assertIsNone(dealer._recv_task)
 
     def test_async_dealer_close_while_send_in_flight_unblocks(self):
-        """close() while awaiting a reply must not hang — send() returns error."""
+        """close() while awaiting a reply must not hang — request() returns error."""
         async def run():
             dealer = IpcDealerAsync(port=self.port, identity="async-close-inflight")
             dealer.ACK_TIMEOUT = 5.0  # we want close() to be the unblocker, not timeout
@@ -894,7 +894,7 @@ class TestIpcRouterDealer(TestIPC):
             await asyncio.sleep(PROPAGATION_DELAY)
 
             send_task = asyncio.create_task(
-                dealer.send("ghost-no-receiver", "press", {"x": 1})
+                dealer.request("ghost-no-receiver", "press", {"x": 1})
             )
             # Let the send actually post and start awaiting the reply.
             await asyncio.sleep(0.05)
@@ -910,12 +910,12 @@ class TestIpcRouterDealer(TestIPC):
         self.assertEqual(reply.get("status"), "error")
 
     def test_async_dealer_send_requires_start(self):
-        """send() raises AssertionError if start() has not been called."""
+        """request() raises AssertionError if start() has not been called."""
         async def run():
             dealer = IpcDealerAsync(port=self.port, identity="sender-no-start")
             await asyncio.sleep(PROPAGATION_DELAY)
             with self.assertRaises(AssertionError):
-                await dealer.send("ghost", "ping", {"v": 99})
+                await dealer.request("ghost", "ping", {"v": 99})
             await dealer.close()
 
         self._run_async(run())
@@ -931,7 +931,7 @@ class TestIpcRouterDealer(TestIPC):
         self._run_async(run())
 
     # ------------------------------------------------------------------
-    # IpcDealerClient outbound fire() / send()
+    # IpcDealerClient outbound fire() / request()
     # ------------------------------------------------------------------
 
     def test_dealer_client_fire_delivers_to_async_receiver(self):
@@ -975,10 +975,10 @@ class TestIpcRouterDealer(TestIPC):
         self.assertIn({"v": 42}, received)
 
     def test_dealer_client_send_gets_reply_from_async_dealer(self):
-        """IpcDealerClient.send() → IpcDealerAsync handler returns dict → sync caller gets it."""
+        """IpcDealerClient.request() → IpcDealerAsync handler returns dict → sync caller gets it."""
         STATS = {"laps": 5, "tyre": "medium"}
 
-        # Run the async receiver in a background event loop so sync send() can be called
+        # Run the async receiver in a background event loop so sync request() can be called
         # from the test thread without deadlocking the event loop.
         loop = asyncio.new_event_loop()
         stop_event = threading.Event()
@@ -1005,7 +1005,7 @@ class TestIpcRouterDealer(TestIPC):
         client = self._make_dealer_client("sync-send-rpc", {})
         time.sleep(PROPAGATION_DELAY)
 
-        reply = client.send("async-send-reply", "get-stats", {})
+        reply = client.request("async-send-reply", "get-stats", {})
 
         stop_event.set()
         loop_thread.join(timeout=2.0)
@@ -1014,21 +1014,21 @@ class TestIpcRouterDealer(TestIPC):
         self.assertEqual(reply, STATS)
 
     def test_dealer_client_send_gets_reply_from_sync_receiver(self):
-        """IpcDealerClient.send() → IpcDealerClient handler returns dict → caller gets it."""
+        """IpcDealerClient.request() → IpcDealerClient handler returns dict → caller gets it."""
         receiver = self._make_dealer_client("sync-recv-rpc", {
             "echo": lambda d, _sender: {"echoed": d},
         })
         sender = self._make_dealer_client("sync-send-rpc2", {})
         time.sleep(PROPAGATION_DELAY)
 
-        reply = sender.send("sync-recv-rpc", "echo", {"x": 7})
+        reply = sender.request("sync-recv-rpc", "echo", {"x": 7})
         self.assertEqual(reply.get("echoed"), {"x": 7})
 
     def test_dealer_client_send_requires_start(self):
-        """IpcDealerClient.send() raises AssertionError if start() has not been called."""
+        """IpcDealerClient.request() raises AssertionError if start() has not been called."""
         client = IpcDealerClient(port=self.port, identity="sync-send-no-start")
         with self.assertRaises(AssertionError):
-            client.send("ghost", "ping", {})
+            client.request("ghost", "ping", {})
         client.close()
 
     def test_dealer_client_fire_requires_start(self):
@@ -1039,11 +1039,11 @@ class TestIpcRouterDealer(TestIPC):
         client.close()
 
     def test_dealer_client_send_timeout_on_no_receiver(self):
-        """IpcDealerClient.send() to a non-existent identity returns error dict, no hang."""
+        """IpcDealerClient.request() to a non-existent identity returns error dict, no hang."""
         sender = self._make_dealer_client("sync-timeout-sender", {})
         time.sleep(PROPAGATION_DELAY)
 
-        reply = sender.send("ghost-identity", "press", {}, timeout=0.2)
+        reply = sender.request("ghost-identity", "press", {}, timeout=0.2)
         self.assertEqual(reply.get("status"), "error")
         self.assertIn("timeout", reply.get("reason", ""))
 
@@ -1053,13 +1053,13 @@ class TestIpcRouterDealer(TestIPC):
         sender = self._make_dealer_client("sync-send-unknown2", {})
         time.sleep(PROPAGATION_DELAY)
 
-        reply = sender.send("sync-recv-unknown2", "no-such-topic", {})
+        reply = sender.request("sync-recv-unknown2", "no-such-topic", {})
         self.assertEqual(reply.get("status"), "error")
         self.assertIn("unknown topic", reply.get("reason", ""))
 
     def test_dealer_client_send_does_not_block_inbound_receive(self):
         """
-        While one thread calls send(), the loop must still process inbound commands.
+        While one thread calls request(), the loop must still process inbound commands.
         Verify by having an inbound fire arrive during an outbound send.
         """
         inbound_received = []
@@ -1079,7 +1079,7 @@ class TestIpcRouterDealer(TestIPC):
         time.sleep(0.02)
 
         # Now do a send — the loop must deliver the inbound fire AND the reply.
-        reply = sender.send("sync-bidir-loop", "echo", {"x": 1})
+        reply = sender.request("sync-bidir-loop", "echo", {"x": 1})
         time.sleep(PROPAGATION_DELAY)
 
         self.assertEqual(reply.get("echoed"), {"x": 1})
@@ -1143,7 +1143,7 @@ class TestIpcRouterDealer(TestIPC):
         self.assertEqual(sender.get_stats().get("__ACK__", {}), {})
 
     def test_sync_fire_ack_does_not_corrupt_following_send(self):
-        """A sync fire() ack arriving before a send()'s reply must not be mistaken for it."""
+        """A sync fire() ack arriving before a request()'s reply must not be mistaken for it."""
         receiver = self._make_dealer_client("sync-ack-mix", {
             "press": lambda d, _sender: None,
             "echo": lambda d, _sender: {"echoed": d},
@@ -1152,7 +1152,7 @@ class TestIpcRouterDealer(TestIPC):
         time.sleep(PROPAGATION_DELAY)
 
         sender.fire("sync-ack-mix", "press", {})
-        reply = sender.send("sync-ack-mix", "echo", {"x": 1})
+        reply = sender.request("sync-ack-mix", "echo", {"x": 1})
         self.assertEqual(reply.get("echoed"), {"x": 1})
 
     def test_sync_fire_acked_by_async_receiver(self):
@@ -1210,7 +1210,7 @@ class TestIpcRouterDealer(TestIPC):
     # ------------------------------------------------------------------
 
     def test_bidir_sync_sends_async_replies(self):
-        """Sync client calls send() → async dealer handles it → reply received."""
+        """Sync client calls request() → async dealer handles it → reply received."""
         loop = asyncio.new_event_loop()
         stop_event = threading.Event()
 
@@ -1233,7 +1233,7 @@ class TestIpcRouterDealer(TestIPC):
         sync_client = self._make_dealer_client("bidir-sync-a", {})
         time.sleep(PROPAGATION_DELAY)
 
-        reply = sync_client.send("bidir-async-a", "query", {"q": "hello"})
+        reply = sync_client.request("bidir-async-a", "query", {"q": "hello"})
 
         stop_event.set()
         loop_thread.join(timeout=2.0)
@@ -1242,7 +1242,7 @@ class TestIpcRouterDealer(TestIPC):
         self.assertEqual(reply.get("answer"), "hello-response")
 
     def test_bidir_async_sends_sync_replies(self):
-        """Async dealer calls send() → sync client handles it → reply received."""
+        """Async dealer calls request() → sync client handles it → reply received."""
         sync_client = self._make_dealer_client("bidir-sync-b", {
             "ping": lambda d, _sender: {"pong": d.get("n", 0) * 2},
         })
@@ -1252,7 +1252,7 @@ class TestIpcRouterDealer(TestIPC):
             asyncio.create_task(async_dealer.start())
             await asyncio.sleep(PROPAGATION_DELAY)
 
-            reply = await async_dealer.send("bidir-sync-b", "ping", {"n": 21})
+            reply = await async_dealer.request("bidir-sync-b", "ping", {"n": 21})
             await async_dealer.close()
             return reply
 
@@ -1312,13 +1312,13 @@ class TestIpcRouterDealer(TestIPC):
 
             def do_sync_send():
                 sync_reply_holder.append(
-                    sync_client.send("bidir-sim-async", "async-echo", {"from": "sync"})
+                    sync_client.request("bidir-sim-async", "async-echo", {"from": "sync"})
                 )
 
             t = threading.Thread(target=do_sync_send)
             t.start()
 
-            async_reply = await async_dealer.send("bidir-sim-sync", "sync-echo", {"from": "async"})
+            async_reply = await async_dealer.request("bidir-sim-sync", "sync-echo", {"from": "async"})
             t.join(timeout=5.0)
 
             await async_dealer.close()
@@ -1351,12 +1351,12 @@ class TestIpcRouterDealer(TestIPC):
             results = []
             for i in range(N):
                 # Async → sync
-                r1 = await async_dealer.send("bidir-rapid-sync", "increment", {"n": i})
+                r1 = await async_dealer.request("bidir-rapid-sync", "increment", {"n": i})
                 results.append(("async→sync", i, r1))
                 # Sync → async (from a thread to avoid blocking the event loop)
                 loop = asyncio.get_event_loop()
                 r2 = await loop.run_in_executor(
-                    None, sync_client.send, "bidir-rapid-async", "double", {"n": i}
+                    None, sync_client.request, "bidir-rapid-async", "double", {"n": i}
                 )
                 results.append(("sync→async", i, r2))
 
@@ -1376,7 +1376,7 @@ class TestIpcRouterDealer(TestIPC):
     # ------------------------------------------------------------------
 
     def test_dealer_connects_before_router(self):
-        """Sync client started before router; first send() succeeds once router is up."""
+        """Sync client started before router; first request() succeeds once router is up."""
         # Grab a free port by letting a temporary router bind and immediately close.
         tmp_router = IpcRouter(port=0)
         free_port = tmp_router.port
@@ -1400,7 +1400,7 @@ class TestIpcRouterDealer(TestIPC):
             sender = IpcDealerAsync(port=free_port, identity="late-sender")
             asyncio.create_task(sender.start())
             await asyncio.sleep(PROPAGATION_DELAY)
-            reply = await sender.send("early-client", "pong", {})
+            reply = await sender.request("early-client", "pong", {})
             await sender.close()
             return reply
 
@@ -1438,7 +1438,7 @@ class TestIpcRouterDealer(TestIPC):
         deadline = time.monotonic() + 5.0
         reply = {"status": "error", "reason": "not started"}
         while time.monotonic() < deadline:
-            reply = client_a.send("pre-b", "hi", {"n": 1}, timeout=0.5)
+            reply = client_a.request("pre-b", "hi", {"n": 1}, timeout=0.5)
             if reply.get("got") is not None:
                 break
             time.sleep(0.1)
@@ -1457,7 +1457,7 @@ class TestIpcRouterDealer(TestIPC):
             sender = IpcDealerAsync(port=self.port, identity="reconnect-sender1")
             asyncio.create_task(sender.start())
             await asyncio.sleep(PROPAGATION_DELAY)
-            r = await sender.send("reconnect-client", "echo", {"phase": 1})
+            r = await sender.request("reconnect-client", "echo", {"phase": 1})
             await sender.close()
             return r
 
@@ -1476,7 +1476,7 @@ class TestIpcRouterDealer(TestIPC):
             sender = IpcDealerAsync(port=old_port, identity="reconnect-sender2")
             asyncio.create_task(sender.start())
             await asyncio.sleep(PROPAGATION_DELAY)
-            r = await sender.send("reconnect-client", "echo", {"phase": 2})
+            r = await sender.request("reconnect-client", "echo", {"phase": 2})
             await sender.close()
             return r
 
@@ -1488,7 +1488,7 @@ class TestIpcRouterDealer(TestIPC):
     # ------------------------------------------------------------------
 
     def test_sync_dealer_crash_send_returns_error(self):
-        """Async dealer sends to a crashed sync client → send() times out, no exception."""
+        """Async dealer sends to a crashed sync client → request() times out, no exception."""
         client = IpcDealerClient(port=self.port, identity="crash-sync-client")
         client.route("noop")(lambda d, _sender: None)
         t = threading.Thread(target=client.start, daemon=True)
@@ -1510,7 +1510,7 @@ class TestIpcRouterDealer(TestIPC):
             sender.ACK_TIMEOUT = 0.3
             asyncio.create_task(sender.start())
             await asyncio.sleep(PROPAGATION_DELAY)
-            reply = await sender.send("crash-sync-client", "noop", {})
+            reply = await sender.request("crash-sync-client", "noop", {})
             await sender.close()
             return reply
 
@@ -1518,7 +1518,7 @@ class TestIpcRouterDealer(TestIPC):
         self.assertEqual(reply.get("status"), "error")
 
     def test_async_dealer_crash_send_returns_error(self):
-        """Sync client sends to a crashed async dealer → send() times out, no exception.
+        """Sync client sends to a crashed async dealer → request() times out, no exception.
 
         Note: this test intentionally simulates an unclean crash (socket closed without
         ctx.term()), so a ResourceWarning about an unclosed ZMQ context is expected.
@@ -1543,11 +1543,11 @@ class TestIpcRouterDealer(TestIPC):
         client = self._make_dealer_client("crash-sync-sender", {})
         time.sleep(PROPAGATION_DELAY)
 
-        reply = client.send("crash-async-dealer", "noop", {}, timeout=0.3)
+        reply = client.request("crash-async-dealer", "noop", {}, timeout=0.3)
         self.assertEqual(reply.get("status"), "error")
 
     def test_sync_dealer_crash_and_reconnect(self):
-        """Sync client crashes and reconnects with same identity; next send() succeeds."""
+        """Sync client crashes and reconnects with same identity; next request() succeeds."""
         # Phase 1: healthy.
         client1 = IpcDealerClient(port=self.port, identity="resilient-sync")
         client1.route("echo")(lambda d, _sender: {"echoed": d})
@@ -1562,7 +1562,7 @@ class TestIpcRouterDealer(TestIPC):
             sender.ACK_TIMEOUT = timeout
             asyncio.create_task(sender.start())
             await asyncio.sleep(PROPAGATION_DELAY)
-            r = await sender.send("resilient-sync", "echo", data)
+            r = await sender.request("resilient-sync", "echo", data)
             await sender.close()
             return r
 
@@ -1595,7 +1595,7 @@ class TestIpcRouterDealer(TestIPC):
     def test_async_dealer_late_reply_after_timeout_does_not_corrupt_next_send(self):
         """
         Scenario: sender times out waiting for reply, late reply arrives after timeout,
-        then a subsequent send() to a healthy handler completes successfully.
+        then a subsequent request() to a healthy handler completes successfully.
 
         Verifies that the stale reply is silently dropped (tracked as unexpected_reply)
         and does not corrupt the pending-reply state for the next call.
@@ -1624,7 +1624,7 @@ class TestIpcRouterDealer(TestIPC):
             # Phase 1: send with a very short timeout; handler will reply late.
             slow_reply_delay[0] = 0.5
             dealer.ACK_TIMEOUT = 0.1
-            r1 = await dealer.send("slow-responder", "echo", {"phase": 1})
+            r1 = await dealer.request("slow-responder", "echo", {"phase": 1})
             self.assertEqual(r1.get("status"), "error")  # timed out
 
             # Wait for the late reply to arrive and be dropped.
@@ -1633,7 +1633,7 @@ class TestIpcRouterDealer(TestIPC):
             # Phase 2: now use a generous timeout; handler replies promptly.
             slow_reply_delay[0] = 0.0
             dealer.ACK_TIMEOUT = ACK_TIMEOUT
-            r2 = await dealer.send("slow-responder", "echo", {"phase": 2})
+            r2 = await dealer.request("slow-responder", "echo", {"phase": 2})
 
             stats = dealer.get_stats()
             await dealer.close()


### PR DESCRIPTION
## What and why

In fire and forget messages, the receiver will now send a proto level ACK.
Also, send() has been renamed to request()

## Test plan

- [ ] Integration tests pass — `poetry run python tests/integration_test/runner.py`

  ```
  paste output here
  ```

- [x] Manually tested in the app

  ```
  $ grep "fire ack" png.log
  [2026-06-26T00:45:45.742] [CORE] [SILENT] [logger.py:47] IpcDealerAsync [backend] fire ack from 'hud'
  [2026-06-26T00:45:52.766] [CORE] [SILENT] [logger.py:47] IpcDealerAsync [backend] fire ack from 'hud'
  ```

- [ ] No testable change

## Summary by Sourcery

Introduce wire-level receipt acknowledgements for fire-and-forget IPC messages, standardize the request-response API naming to request(), and align router/dealer protocol constants and observability across sync and async dealer implementations.

New Features:
- Add proto-level receipt acknowledgements for fire-and-forget messages across sync and async dealer clients.

Bug Fixes:
- Ensure fire-and-forget acknowledgements do not interfere with or corrupt pending request-response replies.

Enhancements:
- Introduce a shared wire-protocol constants module for router/dealer communication to keep sync and async implementations aligned.
- Rename the blocking request-response API from send() to request() in dealer clients and async dealers, updating usage and docs for clearer semantics.
- Extend dealer stats tracking to record received and emitted fire acknowledgements, and integrate structured logging with the dealer clients.

Tests:
- Add comprehensive async and sync tests covering fire-and-forget acknowledgements, unrouted topics, and interaction between acks and request-response flows.