### PR TITLE
Row-level table patching for HUD overlays

### DIFF
--- a/apps/hud/ui/overlays/base/DiffedTableModel.qml
+++ b/apps/hud/ui/overlays/base/DiffedTableModel.qml
@@ -1,11 +1,15 @@
 // ListModel driven by lib/table_differ.TableDiffer on the Python side.
 //
-// Python writes two root properties per table and this model turns them into
-// the matching ListModel operations:
-//   tableRows -> clear() + append() of every row  (whole-table reset)
-//   rowPatch  -> set(index, row)                  (one row changed)
+// Python writes one property per table -- the payload returned by
+// TableDiffer.update() -- and this model turns it into ListModel operations:
+//   { kind: "reset", rows: [row, ...] }           -> clear() + append() each
+//   { kind: "patch", rows: [{index, row}, ...] }  -> set(index, row) each
 //
-// The point is that set() re-renders only the one affected delegate, whereas
+// One property means one write per tick however many rows moved, and a reset can
+// never overtake patches produced before it. The "reset"/"patch" strings are
+// TableDiffer.RESET / TableDiffer.PATCH.
+//
+// The point is that set() re-renders only the affected delegate, whereas
 // re-assigning a view's model destroys and re-creates all of them. Views bind
 // `model:` to this object and read row fields as delegate roles.
 //
@@ -22,29 +26,27 @@ import QtQuick
 ListModel {
     id: tableModel
 
-    // Whole table, as pushed by the differ's reset hook.
-    property var tableRows: []
+    // Latest payload from TableDiffer.update(). Null until the first one lands.
+    property var tableUpdate: null
 
-    // Latest single-row update: { index: int, row: object }.
-    property var rowPatch: ({})
-
-    onTableRowsChanged: {
-        clear();
-        if (!tableRows)
-            return;
-        for (let i = 0; i < tableRows.length; ++i)
-            append(tableRows[i]);
-    }
-
-    // Patches only ever apply to the table they were diffed against. A patch
-    // arriving against a stale/empty model is dropped; Python re-syncs by
-    // calling TableDiffer.invalidate() whenever the QML target is re-created.
-    onRowPatchChanged: {
-        if (!rowPatch || rowPatch.row === undefined)
-            return;
-        if (rowPatch.index < 0 || rowPatch.index >= count)
+    onTableUpdateChanged: {
+        if (!tableUpdate || !tableUpdate.rows)
             return;
 
-        set(rowPatch.index, rowPatch.row);
+        if (tableUpdate.kind === "reset") {
+            clear();
+            for (let i = 0; i < tableUpdate.rows.length; ++i)
+                append(tableUpdate.rows[i]);
+            return;
+        }
+
+        // Patches only ever apply to the table they were diffed against. One
+        // aimed at a stale or empty model is dropped; Python re-syncs by calling
+        // TableDiffer.invalidate() whenever the QML target is re-created.
+        for (let i = 0; i < tableUpdate.rows.length; ++i) {
+            const patch = tableUpdate.rows[i];
+            if (patch && patch.row !== undefined && patch.index >= 0 && patch.index < count)
+                set(patch.index, patch.row);
+        }
     }
 }

--- a/apps/hud/ui/overlays/base/DiffedTableModel.qml
+++ b/apps/hud/ui/overlays/base/DiffedTableModel.qml
@@ -9,10 +9,14 @@
 // re-assigning a view's model destroys and re-creates all of them. Views bind
 // `model:` to this object and read row fields as delegate roles.
 //
-// Two constraints inherited from ListModel (dynamicRoles is off — it is slow):
+// Three constraints inherited from ListModel (dynamicRoles is off - it is slow):
 //   - roles are fixed by the first append(), so every row must carry the same
-//     key set; pad optional fields rather than omitting them.
+//     key set with the same value types; pad optional fields rather than
+//     omitting them, and don't mix e.g. a QML color with a Python "#rrggbb".
 //   - keys must be valid property names, so no hyphens.
+//   - rows must be flat. An array-valued field becomes a nested ListModel that
+//     delegates bind to by object identity, and set() does not reliably reach
+//     it - flatten such rows into one field per cell instead.
 import QtQuick
 
 ListModel {
@@ -38,7 +42,9 @@ ListModel {
     onRowPatchChanged: {
         if (!rowPatch || rowPatch.row === undefined)
             return;
-        if (rowPatch.index >= 0 && rowPatch.index < count)
-            set(rowPatch.index, rowPatch.row);
+        if (rowPatch.index < 0 || rowPatch.index >= count)
+            return;
+
+        set(rowPatch.index, rowPatch.row);
     }
 }

--- a/apps/hud/ui/overlays/base/DiffedTableModel.qml
+++ b/apps/hud/ui/overlays/base/DiffedTableModel.qml
@@ -1,0 +1,44 @@
+// ListModel driven by lib/table_differ.TableDiffer on the Python side.
+//
+// Python writes two root properties per table and this model turns them into
+// the matching ListModel operations:
+//   tableRows -> clear() + append() of every row  (whole-table reset)
+//   rowPatch  -> set(index, row)                  (one row changed)
+//
+// The point is that set() re-renders only the one affected delegate, whereas
+// re-assigning a view's model destroys and re-creates all of them. Views bind
+// `model:` to this object and read row fields as delegate roles.
+//
+// Two constraints inherited from ListModel (dynamicRoles is off — it is slow):
+//   - roles are fixed by the first append(), so every row must carry the same
+//     key set; pad optional fields rather than omitting them.
+//   - keys must be valid property names, so no hyphens.
+import QtQuick
+
+ListModel {
+    id: tableModel
+
+    // Whole table, as pushed by the differ's reset hook.
+    property var tableRows: []
+
+    // Latest single-row update: { index: int, row: object }.
+    property var rowPatch: ({})
+
+    onTableRowsChanged: {
+        clear();
+        if (!tableRows)
+            return;
+        for (let i = 0; i < tableRows.length; ++i)
+            append(tableRows[i]);
+    }
+
+    // Patches only ever apply to the table they were diffed against. A patch
+    // arriving against a stale/empty model is dropped; Python re-syncs by
+    // calling TableDiffer.invalidate() whenever the QML target is re-created.
+    onRowPatchChanged: {
+        if (!rowPatch || rowPatch.row === undefined)
+            return;
+        if (rowPatch.index >= 0 && rowPatch.index < count)
+            set(rowPatch.index, rowPatch.row);
+    }
+}

--- a/apps/hud/ui/overlays/base/DiffedTableModel.qml
+++ b/apps/hud/ui/overlays/base/DiffedTableModel.qml
@@ -30,8 +30,13 @@ ListModel {
     property var tableUpdate: null
 
     onTableUpdateChanged: {
-        if (!tableUpdate || !tableUpdate.rows)
+        if (!tableUpdate)
             return;
+
+        if (!tableUpdate.rows) {
+            console.warn("DiffedTableModel: payload has no rows:", JSON.stringify(tableUpdate));
+            return;
+        }
 
         if (tableUpdate.kind === "reset") {
             clear();
@@ -40,13 +45,26 @@ ListModel {
             return;
         }
 
-        // Patches only ever apply to the table they were diffed against. One
-        // aimed at a stale or empty model is dropped; Python re-syncs by calling
-        // TableDiffer.invalidate() whenever the QML target is re-created.
+        if (tableUpdate.kind !== "patch") {
+            console.warn("DiffedTableModel: unknown payload kind:", tableUpdate.kind);
+            return;
+        }
+
+        // A patch aimed at a stale or empty model is dropped rather than applied
+        // to the wrong row. That leaves this model behind Python's table until
+        // the next reset, so say so -- once per payload, since a desynced table
+        // would otherwise warn per row per tick.
+        let dropped = 0;
         for (let i = 0; i < tableUpdate.rows.length; ++i) {
             const patch = tableUpdate.rows[i];
             if (patch && patch.row !== undefined && patch.index >= 0 && patch.index < count)
                 set(patch.index, patch.row);
+            else
+                ++dropped;
         }
+        if (dropped > 0)
+            console.warn("DiffedTableModel: dropped", dropped, "of", tableUpdate.rows.length,
+                         "patches against a model of", count,
+                         "rows -- this table is now behind Python until the next reset");
     }
 }

--- a/apps/hud/ui/overlays/base/qml_bridge.py
+++ b/apps/hud/ui/overlays/base/qml_bridge.py
@@ -40,8 +40,9 @@ class QmlBridge:
 
     Provides three things:
     - Stats: single EventCounter per component; get_stats(), _track_event().
-    - Diff-based QML property caching: set_qml_property(), invalidate_qml_cache(),
-      _on_target_changed() (clears cache).
+    - QML property writes: push_qml_property() (always writes) and
+      set_qml_property() (writes only on change), plus invalidate_qml_cache()
+      and _on_target_changed() (clears cache).
     - Event handler registry: on_event() decorator (always guarded on
       _qml_target is not None), dispatch_event(), get_handled_event_types(),
       handles_event().
@@ -73,22 +74,38 @@ class QmlBridge:
         """Call when qml_target changes to a new object; clears the prop cache."""
         self._props.clear()
 
-    def set_qml_property(self, name: str, value) -> None:
-        """Write a property to qml_target with diff-based caching.
+    def push_qml_property(self, name: str, value) -> bool:
+        """Write a property to qml_target unconditionally. Returns True if it landed.
 
-        Silently does nothing when qml_target is None or the value is unchanged.
+        For structured, high-churn values (table resets and row patches) where
+        Python-side logic already guarantees every write is a real change.
+        Caching those would be a correctness trap: a patch, then a reset, then
+        an identical patch is three distinct instructions to QML, and the
+        second patch must not be swallowed as a repeat of the first.
+
+        Silently does nothing when qml_target is None.
         """
         target = self._qml_target
         if target is None:
             self._stats.track_event("__PROPS_NO_TARGET__", name)
-            return
-        if self._props.get(name, _UNSET) == value:
-            self._stats.track_event("__PROPS_CACHED__", name)
-            return
-        self._props[name] = value
+            return False
         target.setProperty(name, value)
         self._stats.track_event("__PROPS__", name)
         self._notify_qml_content_changed()
+        return True
+
+    def set_qml_property(self, name: str, value) -> None:
+        """Write a property to qml_target with diff-based caching.
+
+        Silently does nothing when qml_target is None or the value is unchanged.
+        The cache only records writes that actually reached QML, so a write
+        dropped for want of a target cannot suppress the one that follows it.
+        """
+        if self._props.get(name, _UNSET) == value:
+            self._stats.track_event("__PROPS_CACHED__", name)
+            return
+        if self.push_qml_property(name, value):
+            self._props[name] = value
 
     def _notify_qml_content_changed(self) -> None:
         """Hook invoked after a real (non-cached) QML write. Default no-op.

--- a/apps/hud/ui/overlays/mfd/pages/lap_times/lap_times.py
+++ b/apps/hud/ui/overlays/mfd/pages/lap_times/lap_times.py
@@ -57,7 +57,13 @@ class LapTimesPage(MfdPageBase):
         # Seeding the blanks here also fixes the model's role types (all string)
         # before any telemetry arrives.
         self._differ.invalidate()
-        self._differ.update([self._blank_row() for _ in range(self.NUM_ROWS)])
+        self._sync_table([self._blank_row() for _ in range(self.NUM_ROWS)])
+
+    def _sync_table(self, rows: List[Dict[str, Any]]) -> None:
+        """Diff rows and, if anything moved, write the one payload QML applies."""
+        update = self._differ.update(rows)
+        if update:
+            self.push_qml_property("tableUpdate", update)
 
     def _blank_row(self) -> Dict[str, str]:
         """A placeholder row of dashes, for padding and for the pre-telemetry table."""
@@ -72,14 +78,6 @@ class LapTimesPage(MfdPageBase):
     @final
     def setup_page(self):
         self._differ = TableDiffer(self._stats)
-
-        @self._differ.on_reset
-        def _push_table(rows: List[Dict[str, Any]]) -> None:
-            self.push_qml_property("tableRows", rows)
-
-        @self._differ.on_row_patch
-        def _push_row(index: int, row: Dict[str, Any]) -> None:
-            self.push_qml_property("rowPatch", {"index": index, "row": row})
 
         @self.on_event("stream_overlay_update")
         def _handle_stream_overlay_update(data: Dict[str, Any]):
@@ -156,7 +154,7 @@ class LapTimesPage(MfdPageBase):
             while len(all_rows) < self.NUM_ROWS:
                 all_rows.insert(0, self._blank_row())
 
-            self._differ.update(all_rows)
+            self._sync_table(all_rows)
 
     def _get_cell_text_colour(self, lap_num: int, time_ms: int, global_best_time_ms: int,
                             pb_lap_num: int, isValid: bool) -> str:

--- a/apps/hud/ui/overlays/mfd/pages/lap_times/lap_times.py
+++ b/apps/hud/ui/overlays/mfd/pages/lap_times/lap_times.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, final
 
 from apps.hud.ui.overlays.mfd.pages.base_page import MfdPageBase
 from lib.config import MfdPageId, OverlayId, PngSettings
+from lib.table_differ import TableDiffer
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
@@ -37,6 +38,8 @@ class LapTimesPage(MfdPageBase):
     PAGE_QML_FILE: Path = Path(__file__).parent / "lap_times_page.qml"
 
     NUM_ROWS = 5
+    BLANK_TEXT = "---"
+    BLANK_COLOUR = "#808080"
 
     LAP_VALID_MASK = 1
     S1_VALID_MASK = 2
@@ -49,21 +52,40 @@ class LapTimesPage(MfdPageBase):
 
     @final
     def on_page_activated(self):
-        # Invalidate the cache
-        self._last_processed_data = []
+        # The page item is new and its table model is empty, so the next update
+        # must repopulate it in full rather than patch rows that aren't there.
+        # Seeding the blanks here also fixes the model's role types (all string)
+        # before any telemetry arrives.
+        self._differ.invalidate()
+        self._differ.update([self._blank_row() for _ in range(self.NUM_ROWS)])
+
+    def _blank_row(self) -> Dict[str, str]:
+        """A placeholder row of dashes, for padding and for the pre-telemetry table."""
+        return {
+            'lapText': self.BLANK_TEXT, 'lapColour': self.BLANK_COLOUR,
+            's1Text': self.BLANK_TEXT, 's1Colour': self.BLANK_COLOUR,
+            's2Text': self.BLANK_TEXT, 's2Colour': self.BLANK_COLOUR,
+            's3Text': self.BLANK_TEXT, 's3Colour': self.BLANK_COLOUR,
+            'timeText': self.BLANK_TEXT, 'timeColour': self.BLANK_COLOUR,
+        }
 
     @final
     def setup_page(self):
-        self._last_processed_data: List[Dict[str, Any]] = []
+        self._differ = TableDiffer(self._stats)
+
+        @self._differ.on_reset
+        def _push_table(rows: List[Dict[str, Any]]) -> None:
+            self.push_qml_property("tableRows", rows)
+
+        @self._differ.on_row_patch
+        def _push_row(index: int, row: Dict[str, Any]) -> None:
+            self.push_qml_property("rowPatch", {"index": index, "row": row})
 
         @self.on_event("stream_overlay_update")
         def _handle_stream_overlay_update(data: Dict[str, Any]):
             """Populate the lap table with up to the last 5 laps. Leave remaining rows blank."""
             lap_time_history = data.get("lap-time-history", {})
             if not lap_time_history:
-                return
-
-            if self._last_processed_data == lap_time_history:
                 return
 
             history_data = lap_time_history.get("lap-time-history-data", [])
@@ -122,43 +144,22 @@ class LapTimesPage(MfdPageBase):
                 lap_time_col = self._get_cell_text_colour(
                                 lap_num, lap_time_ms, glob_best_lap_ms, pb_lap_num, lap_valid)
 
-                row = [
-                    {'text': str(lap_num), 'color': lap_num_col},
-                    {'text': s1_disp, 'color': s1_col},
-                    {'text': s2_disp, 'color': s2_col},
-                    {'text': s3_disp, 'color': s3_col},
-                    {'text': lap_disp, 'color': lap_time_col}
-                ]
-                all_rows.append(row)
+                all_rows.append({
+                    'lapText': str(lap_num), 'lapColour': lap_num_col,
+                    's1Text': s1_disp, 's1Colour': s1_col,
+                    's2Text': s2_disp, 's2Colour': s2_col,
+                    's3Text': s3_disp, 's3Colour': s3_col,
+                    'timeText': lap_disp, 'timeColour': lap_time_col,
+                })
 
             # Pad with empty rows if we have fewer than NUM_ROWS
             while len(all_rows) < self.NUM_ROWS:
-                all_rows.insert(0, [
-                    {'text': '---', 'color': '#808080'},
-                    {'text': '---', 'color': '#808080'},
-                    {'text': '---', 'color': '#808080'},
-                    {'text': '---', 'color': '#808080'},
-                    {'text': '---', 'color': '#808080'}
-                ])
+                all_rows.insert(0, self._blank_row())
 
-            self.set_qml_property("rows", all_rows)
-
-            # Update the cache
-            self._last_processed_data = lap_time_history
+            self._differ.update(all_rows)
 
     def _get_cell_text_colour(self, lap_num: int, time_ms: int, global_best_time_ms: int,
                             pb_lap_num: int, isValid: bool) -> str:
-        """Get the text colour for a cell"""
-        if global_best_time_ms and (time_ms == global_best_time_ms):
-            return "magenta"
-        if pb_lap_num and (lap_num == pb_lap_num):
-            return "lime"
-        if not isValid:
-            return "red"
-        return "#e0e0e0"
-
-    def _get_cell_text_colour(self, lap_num: int, time_ms: int, global_best_time_ms: int,
-                              pb_lap_num: int, isValid: bool) -> SyntaxError:
         """Get the text colour for a cell"""
         if global_best_time_ms and (time_ms == global_best_time_ms):
             return "magenta"

--- a/apps/hud/ui/overlays/mfd/pages/lap_times/lap_times_page.qml
+++ b/apps/hud/ui/overlays/mfd/pages/lap_times/lap_times_page.qml
@@ -34,17 +34,15 @@ Item {
      * Python updates this ONLY
      * ----------------------------- */
 
-    // Whole table (reset) and single-row update (patch), written by Python via
-    // TableDiffer. Python seeds the blank rows on page activation, so every
-    // value in the model is a string and the roles keep the types they were
-    // given by the first append().
-    property var tableRows: []
-    property var rowPatch: ({})
+    // One payload per tick from TableDiffer, applied by DiffedTableModel.
+    // Python seeds the blank rows on page activation, so every value in the
+    // model is a string and the roles keep the types the first append() gave
+    // them.
+    property var tableUpdate: null
 
     DiffedTableModel {
         id: tableModel
-        tableRows: root.tableRows
-        rowPatch: root.rowPatch
+        tableUpdate: root.tableUpdate
     }
 
     /* -----------------------------

--- a/apps/hud/ui/overlays/mfd/pages/lap_times/lap_times_page.qml
+++ b/apps/hud/ui/overlays/mfd/pages/lap_times/lap_times_page.qml
@@ -1,5 +1,6 @@
 pragma ComponentBehavior: Bound
 import QtQuick 2.15
+import "../../../base"
 
 Item {
     id: root
@@ -9,7 +10,6 @@ Item {
      * CONFIG
      * ----------------------------- */
     readonly property int numRows: 5
-    readonly property int numCols: 5
 
     readonly property var headers: ["Lap", "S1", "S2", "S3", "Time"]
 
@@ -17,7 +17,6 @@ Item {
     readonly property var columnWidthRatios: [0.12, 0.22, 0.22, 0.22, 0.22]  // Lap, S1, S2, S3, Time
 
     readonly property color colText: "#e0e0e0"
-    readonly property color colDim: "#808080"
     readonly property color colGrid: "#333333"
     readonly property color colAltRow: "#252525"
 
@@ -35,18 +34,17 @@ Item {
      * Python updates this ONLY
      * ----------------------------- */
 
-    property var rows: [
-        emptyRow(), emptyRow(), emptyRow(), emptyRow(), emptyRow()
-    ]
+    // Whole table (reset) and single-row update (patch), written by Python via
+    // TableDiffer. Python seeds the blank rows on page activation, so every
+    // value in the model is a string and the roles keep the types they were
+    // given by the first append().
+    property var tableRows: []
+    property var rowPatch: ({})
 
-    function emptyRow() {
-        return [
-            { text: "---", color: colDim },
-            { text: "---", color: colDim },
-            { text: "---", color: colDim },
-            { text: "---", color: colDim },
-            { text: "---", color: colDim }
-        ]
+    DiffedTableModel {
+        id: tableModel
+        tableRows: root.tableRows
+        rowPatch: root.rowPatch
     }
 
     /* -----------------------------
@@ -94,45 +92,59 @@ Item {
             /* ---------- ROWS ---------- */
             Repeater {
                 id: rowRepeater
-                model: root.numRows
+                model: tableModel
 
                 Rectangle {
                     id: rowRect
                     required property int index
+                    required property string lapText
+                    required property string lapColour
+                    required property string s1Text
+                    required property string s1Colour
+                    required property string s2Text
+                    required property string s2Colour
+                    required property string s3Text
+                    required property string s3Colour
+                    required property string timeText
+                    required property string timeColour
+
+                    // Roles are flat (one per cell) because ListModel.set()
+                    // cannot patch a nested list role; the columns are gathered
+                    // back into a list here purely to drive the cell Repeater.
+                    readonly property var cells: [
+                        { text: rowRect.lapText,  colour: rowRect.lapColour  },
+                        { text: rowRect.s1Text,   colour: rowRect.s1Colour   },
+                        { text: rowRect.s2Text,   colour: rowRect.s2Colour   },
+                        { text: rowRect.s3Text,   colour: rowRect.s3Colour   },
+                        { text: rowRect.timeText, colour: rowRect.timeColour }
+                    ]
 
                     width: container.width
                     height: (container.height - 35) / root.numRows
                     color: (rowRect.index % 2 === 0) ? "transparent" : root.colAltRow
                     border.color: root.colGrid
 
-                    property int rowIndex: rowRect.index
-                    property var rowData: (root.rows && root.rows.length > rowIndex) ? root.rows[rowIndex] : root.emptyRow()
-
                     Row {
                         anchors.fill: parent
 
                         Repeater {
                             id: cellRepeater
-                            model: root.numCols
+                            model: rowRect.cells
 
                             Rectangle {
                                 id: cellRect
                                 required property int index
+                                required property var modelData
 
                                 width: container.width * root.columnWidthRatios[cellRect.index]
                                 height: parent ? parent.height : 0
                                 color: "transparent"
                                 border.color: root.colGrid
 
-                                property int colIndex: cellRect.index
-                                property var cellData: (rowRect.rowData && rowRect.rowData.length > colIndex) ?
-                                                       rowRect.rowData[colIndex] :
-                                                       { text: "???", color: root.colDim }
-
                                 Text {
                                     anchors.centerIn: parent
-                                    text: cellRect.cellData.text
-                                    color: cellRect.cellData.color
+                                    text: cellRect.modelData.text
+                                    color: cellRect.modelData.colour
                                     font.family: root.fontFamily
                                     font.pixelSize: root.fontSize
                                     horizontalAlignment: Text.AlignHCenter

--- a/apps/hud/ui/overlays/mfd/pages/pace_comp/pace_comp.py
+++ b/apps/hud/ui/overlays/mfd/pages/pace_comp/pace_comp.py
@@ -30,6 +30,7 @@ from apps.hud.common import (get_ref_row, get_relevant_race_table_rows,
 from apps.hud.ui.overlays.mfd.pages.base_page import MfdPageBase
 from lib.config import MfdPageId, OverlayId, PngSettings
 from lib.f1_types import F1Utils
+from lib.table_differ import TableDiffer
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
@@ -49,7 +50,23 @@ class PaceCompPage(MfdPageBase):
     # -- Event wiring ----------------------------------------------------------
 
     @final
+    def on_page_activated(self):
+        # Fresh page item, so its table model is empty; the next update has to
+        # rebuild it rather than patch rows that aren't there.
+        self._differ.invalidate()
+
+    @final
     def setup_page(self):
+        self._differ = TableDiffer(self._stats)
+
+        @self._differ.on_reset
+        def _push_table(rows: List[Dict[str, Any]]) -> None:
+            self.push_qml_property("tableRows", rows)
+
+        @self._differ.on_row_patch
+        def _push_row(index: int, row: Dict[str, Any]) -> None:
+            self.push_qml_property("rowPatch", {"index": index, "row": row})
+
         @self.on_event("race_table_update")
         def _handle_race_table_update(data: Dict[str, Any]) -> None:
             session_type = data.get("event-type", "")
@@ -253,5 +270,5 @@ class PaceCompPage(MfdPageBase):
         self._set_rows([])
 
     def _set_rows(self, rows: List[Dict[str, Any]]) -> None:
-        """Push row data to QML."""
-        self.set_qml_property("rows", rows)
+        """Diff row data against the last table; QML gets a reset or single-row patches."""
+        self._differ.update(rows)

--- a/apps/hud/ui/overlays/mfd/pages/pace_comp/pace_comp.py
+++ b/apps/hud/ui/overlays/mfd/pages/pace_comp/pace_comp.py
@@ -59,14 +59,6 @@ class PaceCompPage(MfdPageBase):
     def setup_page(self):
         self._differ = TableDiffer(self._stats)
 
-        @self._differ.on_reset
-        def _push_table(rows: List[Dict[str, Any]]) -> None:
-            self.push_qml_property("tableRows", rows)
-
-        @self._differ.on_row_patch
-        def _push_row(index: int, row: Dict[str, Any]) -> None:
-            self.push_qml_property("rowPatch", {"index": index, "row": row})
-
         @self.on_event("race_table_update")
         def _handle_race_table_update(data: Dict[str, Any]) -> None:
             session_type = data.get("event-type", "")
@@ -270,5 +262,7 @@ class PaceCompPage(MfdPageBase):
         self._set_rows([])
 
     def _set_rows(self, rows: List[Dict[str, Any]]) -> None:
-        """Diff row data against the last table; QML gets a reset or single-row patches."""
-        self._differ.update(rows)
+        """Diff rows and, if anything moved, write the one payload QML applies."""
+        update = self._differ.update(rows)
+        if update:
+            self.push_qml_property("tableUpdate", update)

--- a/apps/hud/ui/overlays/mfd/pages/pace_comp/pace_comp_page.qml
+++ b/apps/hud/ui/overlays/mfd/pages/pace_comp/pace_comp_page.qml
@@ -72,8 +72,8 @@ Item {
     /* ─────────────────────────────────────────────────────
      * DATA  (Python sets these)
      *
-     * Written by Python via TableDiffer: tableRows is the whole table,
-     * rowPatch is { index, row } for a single changed row.
+     * Written by Python as one TableDiffer payload per tick; DiffedTableModel
+     * applies it as a whole-table reset or a set of single-row patches.
      *
      * Each row is {
      *   position: string,
@@ -84,13 +84,11 @@ Item {
      * }
      * Not padded - the model holds exactly as many rows as Python sent.
      * ───────────────────────────────────────────────────── */
-    property var tableRows: []
-    property var rowPatch: ({})
+    property var tableUpdate: null
 
     DiffedTableModel {
         id: tableModel
-        tableRows: root.tableRows
-        rowPatch: root.rowPatch
+        tableUpdate: root.tableUpdate
     }
 
     /* ─────────────────────────────────────────────────────

--- a/apps/hud/ui/overlays/mfd/pages/pace_comp/pace_comp_page.qml
+++ b/apps/hud/ui/overlays/mfd/pages/pace_comp/pace_comp_page.qml
@@ -1,5 +1,6 @@
 pragma ComponentBehavior: Bound
 import QtQuick 2.15
+import "../../../base"
 
 Item {
     id: root
@@ -71,16 +72,26 @@ Item {
     /* ─────────────────────────────────────────────────────
      * DATA  (Python sets these)
      *
-     * rows: list of {
+     * Written by Python via TableDiffer: tableRows is the whole table,
+     * rowPatch is { index, row } for a single changed row.
+     *
+     * Each row is {
      *   position: string,
      *   team:     string  (team name for icon lookup),
      *   name:     string,
      *   s1, s2, s3, lap: string  (absolute for ref, signed delta for others),
      *   isRef:    bool
      * }
-     * Not padded — Repeater model matches rows.length exactly.
+     * Not padded - the model holds exactly as many rows as Python sent.
      * ───────────────────────────────────────────────────── */
-    property var rows: []
+    property var tableRows: []
+    property var rowPatch: ({})
+
+    DiffedTableModel {
+        id: tableModel
+        tableRows: root.tableRows
+        rowPatch: root.rowPatch
+    }
 
     /* ─────────────────────────────────────────────────────
      * HELPERS
@@ -107,12 +118,12 @@ Item {
         color: "transparent"
 
         readonly property int  headerH: 28
-        readonly property real rowH: root.rows.length > 0 ? (height - headerH) / root.rows.length : 0
+        readonly property real rowH: tableModel.count > 0 ? (height - headerH) / tableModel.count : 0
 
         // Waiting for data
         Text {
             anchors.centerIn: parent
-            visible: root.rows.length === 0
+            visible: tableModel.count === 0
             text: "WAITING FOR DATA"
             font.family: "Formula1"
             font.pixelSize: 11
@@ -122,7 +133,7 @@ Item {
         Column {
             anchors.fill: parent
             spacing: 0
-            visible: root.rows.length > 0
+            visible: tableModel.count > 0
 
             /* ── HEADER ── */
             Row {
@@ -156,18 +167,22 @@ Item {
 
             /* ── DATA ROWS ── */
             Repeater {
-                model: root.rows.length
+                model: tableModel
 
                 delegate: Item {
                     id: rowItem
                     required property int index
+                    required property string position
+                    required property string team
+                    required property string name
+                    required property string s1
+                    required property string s2
+                    required property string s3
+                    required property string lap
+                    required property bool isRef
 
                     width: container.width
                     height: container.rowH
-
-                    property int  rowIndex: rowItem.index
-                    property var  rd:       root.rows[rowItem.rowIndex] || {}
-                    property bool isRef:    rd.isRef === true
 
                     // Row background
                     Rectangle {
@@ -195,7 +210,7 @@ Item {
 
                                 Text {
                                     anchors.centerIn: parent
-                                    text:  rowItem.rd.position || "—"
+                                    text:  rowItem.position || "—"
                                     color: rowItem.isRef ? "white" : root.colText
                                     font.family: root.fontFamily
                                     font.pixelSize: root.fontSizeLabel
@@ -220,7 +235,7 @@ Item {
                                     }
                                     width: 16
                                     height: 16
-                                    source: root.teamIcons[rowItem.rd.team] || root.defaultTeamIcon
+                                    source: root.teamIcons[rowItem.team] || root.defaultTeamIcon
                                     fillMode: Image.PreserveAspectFit
                                     smooth: true
                                     mipmap: true
@@ -234,7 +249,7 @@ Item {
                                         rightMargin:    4
                                         verticalCenter: parent.verticalCenter
                                     }
-                                    text:  rowItem.rd.name || "—"
+                                    text:  rowItem.name || "—"
                                     color: rowItem.isRef ? "white" : root.colText
                                     font.family: root.fontFamily
                                     font.pixelSize: root.fontSizeLabel
@@ -252,8 +267,8 @@ Item {
 
                                 Text {
                                     anchors.centerIn: parent
-                                    text:  rowItem.rd.s1 || "—"
-                                    color: root.deltaColor(rowItem.rd.s1, rowItem.isRef)
+                                    text:  rowItem.s1 || "—"
+                                    color: root.deltaColor(rowItem.s1, rowItem.isRef)
                                     font.family: root.monoFontFamily
                                     font.pixelSize: root.fontSizeMono
                                 }
@@ -268,8 +283,8 @@ Item {
 
                                 Text {
                                     anchors.centerIn: parent
-                                    text:  rowItem.rd.s2 || "—"
-                                    color: root.deltaColor(rowItem.rd.s2, rowItem.isRef)
+                                    text:  rowItem.s2 || "—"
+                                    color: root.deltaColor(rowItem.s2, rowItem.isRef)
                                     font.family: root.monoFontFamily
                                     font.pixelSize: root.fontSizeMono
                                 }
@@ -284,8 +299,8 @@ Item {
 
                                 Text {
                                     anchors.centerIn: parent
-                                    text:  rowItem.rd.s3 || "—"
-                                    color: root.deltaColor(rowItem.rd.s3, rowItem.isRef)
+                                    text:  rowItem.s3 || "—"
+                                    color: root.deltaColor(rowItem.s3, rowItem.isRef)
                                     font.family: root.monoFontFamily
                                     font.pixelSize: root.fontSizeMono
                                 }
@@ -300,8 +315,8 @@ Item {
 
                                 Text {
                                     anchors.centerIn: parent
-                                    text:  rowItem.rd.lap || "—"
-                                    color: root.deltaColor(rowItem.rd.lap, rowItem.isRef)
+                                    text:  rowItem.lap || "—"
+                                    color: root.deltaColor(rowItem.lap, rowItem.isRef)
                                     font.family: root.monoFontFamily
                                     font.pixelSize: root.fontSizeMono
                                     font.bold: true

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
@@ -62,14 +62,6 @@ class TrafficMonitorPage(MfdPageBase):
         self.tracks_db = TrackSegmentsDatabase(Path(__file__).parents[7] / "assets/track-segments")
         self._differ = TableDiffer(self._stats)
 
-        @self._differ.on_reset
-        def _push_table(rows: List[Dict[str, Any]]) -> None:
-            self.push_qml_property("tableRows", rows)
-
-        @self._differ.on_row_patch
-        def _push_row(index: int, row: Dict[str, Any]) -> None:
-            self.push_qml_property("rowPatch", {"index": index, "row": row})
-
         @self.on_event("race_table_update")
         def _handle_race_table_update(data: Dict[str, Any]) -> None:
             table_entries: Optional[List] = data.get("table-entries")
@@ -118,15 +110,21 @@ class TrafficMonitorPage(MfdPageBase):
                 return
 
             window = get_traffic_window(sorted_entries, ref_pos, self.NUM_BEHIND)
-            self._differ.update(self._build_rows(window, ref_index, circuit_num))
+            self._sync_table(self._build_rows(window, ref_index, circuit_num))
             self.set_qml_property("viewState", "table")
 
+    def _sync_table(self, rows: List[Dict[str, Any]]) -> None:
+        """Diff rows and, if anything moved, write the one payload QML applies."""
+        update = self._differ.update(rows)
+        if update:
+            self.push_qml_property("tableUpdate", update)
+
     def _show_empty(self) -> None:
-        self._differ.update([])
+        self._sync_table([])
         self.set_qml_property("viewState", "empty")
 
     def _show_in_garage(self) -> None:
-        self._differ.update([])
+        self._sync_table([])
         self.set_qml_property("viewState", "inGarage")
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, List, Optional, Tuple, final
 from apps.hud.common import get_ers_mode_color, get_ref_row_index
 from apps.hud.ui.overlays.mfd.pages.base_page import MfdPageBase
 from lib.config import MfdPageId, OverlayId, PngSettings
+from lib.table_differ import TableDiffer
 from lib.track_segment_info import TrackSegmentsDatabase
 
 from .utils import get_traffic_window, resolve_location, sort_by_rel_distance
@@ -52,11 +53,22 @@ class TrafficMonitorPage(MfdPageBase):
 
     @final
     def on_page_activated(self):
-        pass
+        # Fresh page item, so its table model is empty; the next update has to
+        # rebuild it rather than patch rows that aren't there.
+        self._differ.invalidate()
 
     @final
     def setup_page(self):
         self.tracks_db = TrackSegmentsDatabase(Path(__file__).parents[7] / "assets/track-segments")
+        self._differ = TableDiffer(self._stats)
+
+        @self._differ.on_reset
+        def _push_table(rows: List[Dict[str, Any]]) -> None:
+            self.push_qml_property("tableRows", rows)
+
+        @self._differ.on_row_patch
+        def _push_row(index: int, row: Dict[str, Any]) -> None:
+            self.push_qml_property("rowPatch", {"index": index, "row": row})
 
         @self.on_event("race_table_update")
         def _handle_race_table_update(data: Dict[str, Any]) -> None:
@@ -106,15 +118,15 @@ class TrafficMonitorPage(MfdPageBase):
                 return
 
             window = get_traffic_window(sorted_entries, ref_pos, self.NUM_BEHIND)
-            self.set_qml_property("tableData", self._build_rows(window, ref_index, circuit_num))
+            self._differ.update(self._build_rows(window, ref_index, circuit_num))
             self.set_qml_property("viewState", "table")
 
     def _show_empty(self) -> None:
-        self.set_qml_property("tableData", [])
+        self._differ.update([])
         self.set_qml_property("viewState", "empty")
 
     def _show_in_garage(self) -> None:
-        self.set_qml_property("tableData", [])
+        self._differ.update([])
         self.set_qml_property("viewState", "inGarage")
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
+import "../../../base"
 
 Rectangle {
     id: root
@@ -9,7 +10,17 @@ Rectangle {
 
     // States: "table" | "inGarage" | "empty"
     property string viewState: "empty"
-    property var tableData: []
+
+    // Written by Python via TableDiffer: tableRows is the whole table,
+    // rowPatch is { index, row } for a single changed row.
+    property var tableRows: []
+    property var rowPatch: ({})
+
+    DiffedTableModel {
+        id: tableModel
+        tableRows: root.tableRows
+        rowPatch: root.rowPatch
+    }
 
     property string iconSourcePrefixTeam: "../../../../../../../assets/team-logos/"
     readonly property var teamIcons: ({
@@ -83,21 +94,29 @@ Rectangle {
             ListView {
                 id: tableView
                 anchors.fill: parent
-                model: root.tableData
+                model: tableModel
                 interactive: false
                 clip: true
                 visible: root.viewState === "table"
 
                 delegate: Rectangle {
                     id: trafficRow
-                    required property var modelData
+                    required property string team
+                    required property string name
+                    required property string ersColor
+                    required property string ersPercent
+                    required property bool drs
+                    required property string relDist
+                    required property string relDistColor
+                    required property bool isRef
+                    required property string location
 
                     width: tableView.width
                     height: 35
                     color: "#80000000"
 
-                    border.color: trafficRow.modelData.isRef ? "white" : "transparent"
-                    border.width: trafficRow.modelData.isRef ? 2 : 0
+                    border.color: trafficRow.isRef ? "white" : "transparent"
+                    border.width: trafficRow.isRef ? 2 : 0
 
                     Rectangle {
                         anchors.top: parent.top
@@ -121,7 +140,7 @@ Rectangle {
                                 anchors.centerIn: parent
                                 width: 20
                                 height: 20
-                                source: root.teamIcons[trafficRow.modelData.team] || root.defaultTeamIcon
+                                source: root.teamIcons[trafficRow.team] || root.defaultTeamIcon
                                 fillMode: Image.PreserveAspectFit
                                 smooth: true
                                 mipmap: true
@@ -132,7 +151,7 @@ Rectangle {
                         Text {
                             Layout.preferredWidth: 170
                             Layout.fillHeight: true
-                            text: trafficRow.modelData.name
+                            text: trafficRow.name
                             font.family: "Formula1"
                             font.pixelSize: 14
                             color: "white"
@@ -153,12 +172,12 @@ Rectangle {
                                 width: 6
                                 height: parent.height - 8
                                 radius: 2
-                                color: trafficRow.modelData.ersColor
+                                color: trafficRow.ersColor
                             }
 
                             Text {
                                 anchors.centerIn: parent
-                                text: trafficRow.modelData.ersPercent
+                                text: trafficRow.ersPercent
                                 font.family: "B612 Mono"
                                 font.pixelSize: 12
                                 color: "#dddddd"
@@ -173,7 +192,7 @@ Rectangle {
                                 width: 6
                                 height: parent.height - 8
                                 radius: 2
-                                color: trafficRow.modelData.drs ? "#00e676" : "#333333"
+                                color: trafficRow.drs ? "#00e676" : "#333333"
                             }
                         }
 
@@ -181,10 +200,10 @@ Rectangle {
                         Text {
                             Layout.preferredWidth: 55
                             Layout.fillHeight: true
-                            text: trafficRow.modelData.relDist
+                            text: trafficRow.relDist
                             font.family: "B612 Mono"
                             font.pixelSize: 12
-                            color: trafficRow.modelData.relDistColor
+                            color: trafficRow.relDistColor
                             horizontalAlignment: Text.AlignRight
                             verticalAlignment: Text.AlignVCenter
                         }
@@ -193,7 +212,7 @@ Rectangle {
                         Text {
                             Layout.fillWidth: true
                             Layout.fillHeight: true
-                            text: trafficRow.modelData.location
+                            text: trafficRow.location
                             font.family: "B612 Mono"
                             font.pixelSize: 12
                             color: "#aaaaaa"

--- a/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
+++ b/apps/hud/ui/overlays/mfd/pages/traffic_monitor/traffic_monitor_page.qml
@@ -11,15 +11,13 @@ Rectangle {
     // States: "table" | "inGarage" | "empty"
     property string viewState: "empty"
 
-    // Written by Python via TableDiffer: tableRows is the whole table,
-    // rowPatch is { index, row } for a single changed row.
-    property var tableRows: []
-    property var rowPatch: ({})
+    // Written by Python as one TableDiffer payload per tick; DiffedTableModel
+    // applies it as a whole-table reset or a set of single-row patches.
+    property var tableUpdate: null
 
     DiffedTableModel {
         id: tableModel
-        tableRows: root.tableRows
-        rowPatch: root.rowPatch
+        tableUpdate: root.tableUpdate
     }
 
     property string iconSourcePrefixTeam: "../../../../../../../assets/team-logos/"

--- a/apps/hud/ui/overlays/mfd/pages/tyre_wear/tyre_wear_page.py
+++ b/apps/hud/ui/overlays/mfd/pages/tyre_wear/tyre_wear_page.py
@@ -29,6 +29,7 @@ from apps.hud.common import get_ref_row
 from apps.hud.ui.overlays.mfd.pages.base_page import MfdPageBase
 from lib.config import MfdPageId, MfdTyreWearRateType, OverlayId, PngSettings
 from lib.logger import PngLogger
+from lib.table_differ import TableDiffer
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
@@ -39,6 +40,9 @@ class TyreInfoPage(MfdPageBase):
     PAGE_QML_FILE: Path = Path(__file__).parent / "tyre_wear_page.qml"
 
     NUM_DECIMAL_PLACES = 2
+    NUM_WEAR_ROWS = 3
+    NO_LAP = -1              # lap_num on rows that are not a prediction
+    NO_WEAR = float('-inf')  # sentinel for "no data"; QML checks isFinite()
 
     KEY_LABELS = {
         'front-left':  'FL',
@@ -67,7 +71,14 @@ class TyreInfoPage(MfdPageBase):
         super().__init__(logger)
 
     @final
+    def on_page_activated(self):
+        # Fresh page item, so its table model is empty; the next update has to
+        # rebuild it rather than patch rows that aren't there.
+        self._differ.invalidate()
+
+    @final
     def setup_page(self):
+        self._differ = TableDiffer(self._stats)
 
         @self.on_event("race_table_update")
         def _handle_race_table_update(data: Dict[str, Any]) -> None:
@@ -189,6 +200,7 @@ class TyreInfoPage(MfdPageBase):
         """Update the wear table with current and predicted values."""
         rows_data = [{
             'label': 'curr',
+            'lap_num': curr_lap,
             'fl': curr_wear.get('front-left-wear', 0.0),
             'fr': curr_wear.get('front-right-wear', 0.0),
             'rl': curr_wear.get('rear-left-wear', 0.0),
@@ -226,20 +238,27 @@ class TyreInfoPage(MfdPageBase):
 
         # Sort non-curr rows by ascending lap number (closest-prediction snapping
         # can produce out-of-order results when predictions are sparse).
-        rows_data = rows_data[:1] + sorted(rows_data[1:], key=lambda r: r.get('lap_num', float('inf')))
+        rows_data = rows_data[:1] + sorted(rows_data[1:], key=lambda r: r['lap_num'])
 
         # Ensure we always have exactly 3 rows
-        while len(rows_data) < 3:
-            rows_data.append({
-                'label': '',
-                'fl': float('-inf'),  # Use -inf as sentinel for null/no data
-                'fr': float('-inf'),
-                'rl': float('-inf'),
-                'rr': float('-inf'),
-            })
+        while len(rows_data) < self.NUM_WEAR_ROWS:
+            rows_data.append(self._blank_row())
 
-        # Update QML table data
-        self.set_qml_property("wearTableData", rows_data[:3])
+        update = self._differ.update(rows_data[:self.NUM_WEAR_ROWS])
+        if update:
+            self.push_qml_property("tableUpdate", update)
+
+    def _blank_row(self) -> Dict[str, Any]:
+        """Padding row. Every key the real rows carry must be present: ListModel
+        roles are fixed by the first append(), so an absent one is unsettable."""
+        return {
+            'label': '',
+            'lap_num': self.NO_LAP,
+            'fl': self.NO_WEAR,
+            'fr': self.NO_WEAR,
+            'rl': self.NO_WEAR,
+            'rr': self.NO_WEAR,
+        }
 
     def _find_closest_prediction(self, predictions: List[Dict], target_lap: int) -> Optional[Dict]:
         """Find the prediction closest to the target lap."""

--- a/apps/hud/ui/overlays/mfd/pages/tyre_wear/tyre_wear_page.qml
+++ b/apps/hud/ui/overlays/mfd/pages/tyre_wear/tyre_wear_page.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
+import "../../../base"
 
 Item {
     id: root
@@ -24,7 +25,14 @@ Item {
     property real   wearRate: 0.0
     property string wearRateTyre: ""
     property bool   telemetryDisabled: false
-    property var    wearTableData: []
+    // One TableDiffer payload per tick; DiffedTableModel applies it as a
+    // whole-table reset or a set of single-row patches.
+    property var    tableUpdate: null
+
+    DiffedTableModel {
+        id: wearTableModel
+        tableUpdate: root.tableUpdate
+    }
     property var    tyreCounts: ({
         "Soft": 0, "Medium": 0, "Hard": 0,
         "Super Soft": 0, "Inters": 0, "Wet": 0
@@ -254,7 +262,7 @@ Item {
                 clip: true
 
                 readonly property int    headerH: 28
-                readonly property int    numRows: root.wearTableData.length
+                readonly property int    numRows: wearTableModel.count
                 readonly property real   rowH:    numRows > 0 ? (height - headerH) / numRows : 36
                 readonly property real   colW:    width / 5
 
@@ -291,12 +299,16 @@ Item {
 
                     // Data rows
                     Repeater {
-                        model: root.wearTableData
+                        model: wearTableModel
 
                         delegate: Rectangle {
                             id: rowRect
-                            required property var modelData
                             required property int index
+                            required property string label
+                            required property real fl
+                            required property real fr
+                            required property real rl
+                            required property real rr
 
                             width: tableRect.width
                             height: tableRect.rowH
@@ -312,7 +324,7 @@ Item {
 
                                     Text {
                                         anchors.centerIn: parent
-                                        text: rowRect.modelData.label
+                                        text: rowRect.label
                                         font.family: "Formula1"
                                         font.pixelSize: 12
                                         font.bold: true
@@ -321,10 +333,10 @@ Item {
                                 }
 
                                 // FL FR RL RR
-                                WearCell { width: tableRect.colW; height: parent.height; value: rowRect.modelData.fl }
-                                WearCell { width: tableRect.colW; height: parent.height; value: rowRect.modelData.fr }
-                                WearCell { width: tableRect.colW; height: parent.height; value: rowRect.modelData.rl }
-                                WearCell { width: tableRect.colW; height: parent.height; value: rowRect.modelData.rr }
+                                WearCell { width: tableRect.colW; height: parent.height; value: rowRect.fl }
+                                WearCell { width: tableRect.colW; height: parent.height; value: rowRect.fr }
+                                WearCell { width: tableRect.colW; height: parent.height; value: rowRect.rl }
+                                WearCell { width: tableRect.colW; height: parent.height; value: rowRect.rr }
                             }
                         }
                     }

--- a/apps/hud/ui/overlays/timing_tower/timing_tower.qml
+++ b/apps/hud/ui/overlays/timing_tower/timing_tower.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Window
 import QtQuick.Layouts
+import "../base"
 
 Window {
     id: root
@@ -89,7 +90,7 @@ Window {
         Text {
             property var rowData
             anchors.fill: parent
-            text: rowData ? rowData["delta-to-leader"] : ""
+            text: rowData ? rowData.deltaToLeader : ""
             font.family: "Consolas"
             font.pixelSize: 13
             color: "#ffffff"
@@ -277,7 +278,7 @@ Window {
         }
     }
 
-    readonly property int effectiveRows: Math.min(numRows, tableData.length)
+    readonly property int effectiveRows: Math.min(numRows, raceTableModel.count)
     readonly property bool colHeaderVisible: showColHeader && !showError && mode === "race"
     readonly property int baseHeight: headerHeight + (colHeaderVisible ? colHeaderHeight : 0) + (rowHeight * effectiveRows) + margins
 
@@ -288,12 +289,25 @@ Window {
 
     // Exposed properties for Python to set
     property string sessionInfo: "-- / --"
-    property var tableData: []
     property int referenceRow: -1
     property string errorMessage: ""
     property bool showError: false
     property string mode: "race"  // "race" or "tt"
-    property var ttTableData: []
+
+    // One TableDiffer payload per table per tick; DiffedTableModel applies each
+    // as a whole-table reset or a set of single-row patches.
+    property var tableUpdate: null
+    property var ttTableUpdate: null
+
+    DiffedTableModel {
+        id: raceTableModel
+        tableUpdate: root.tableUpdate
+    }
+
+    DiffedTableModel {
+        id: ttTableModel
+        tableUpdate: root.ttTableUpdate
+    }
 
     // TT mode column widths and dimensions
     readonly property int ttColLabel: 52
@@ -472,12 +486,72 @@ Window {
                         reuseItems: true
                         visible: !root.showError && root.mode === "race"
 
-                        model: root.tableData
+                        model: raceTableModel
 
                         delegate: Item {
                             id: rowItem
-                            required property var modelData
-                            property var rowData: rowItem.modelData
+
+                            // One required property per ListModel role. The
+                            // column components at root level read a single
+                            // rowData object, so the roles are gathered back
+                            // into one here; that keeps those components (and
+                            // the Loader wiring below) unchanged.
+                            required property int position
+                            required property string teamIcon
+                            required property string name
+                            required property string delta
+                            required property string deltaToLeader
+                            required property string tyreIcon
+                            required property string tyreWear
+                            required property string ers
+                            required property string ersMode
+                            required property string ersColor
+                            required property string overtakeBarColor
+                            required property string penalties
+                            required property int tlWarns
+                            required property bool isReference
+                            required property string bestLap
+                            required property string bestLapColor
+                            required property string lastLap
+                            required property string lastLapColor
+                            required property string wingDmg
+                            required property string wingDmgColor
+                            required property string speedTrap
+                            required property string fuel
+                            required property string fuelColor
+                            required property string driverStatus
+                            required property bool isSb
+                            required property bool isPb
+
+                            readonly property var rowData: ({
+                                position: rowItem.position,
+                                teamIcon: rowItem.teamIcon,
+                                name: rowItem.name,
+                                delta: rowItem.delta,
+                                deltaToLeader: rowItem.deltaToLeader,
+                                tyreIcon: rowItem.tyreIcon,
+                                tyreWear: rowItem.tyreWear,
+                                ers: rowItem.ers,
+                                ersMode: rowItem.ersMode,
+                                ersColor: rowItem.ersColor,
+                                overtakeBarColor: rowItem.overtakeBarColor,
+                                penalties: rowItem.penalties,
+                                tlWarns: rowItem.tlWarns,
+                                isReference: rowItem.isReference,
+                                bestLap: rowItem.bestLap,
+                                bestLapColor: rowItem.bestLapColor,
+                                lastLap: rowItem.lastLap,
+                                lastLapColor: rowItem.lastLapColor,
+                                wingDmg: rowItem.wingDmg,
+                                wingDmgColor: rowItem.wingDmgColor,
+                                speedTrap: rowItem.speedTrap,
+                                fuel: rowItem.fuel,
+                                fuelColor: rowItem.fuelColor,
+                                driverStatus: rowItem.driverStatus,
+                                isSb: rowItem.isSb,
+                                isPb: rowItem.isPb
+                            })
+
                             width: tableView.width
                             height: 28
 
@@ -668,12 +742,16 @@ Window {
                         }
 
                         Repeater {
-                            model: root.ttTableData
+                            model: ttTableModel
 
                             delegate: Item {
                                 id: ttRow
-                                required property var modelData
                                 required property int index
+                                required property string label
+                                required property string lapTimeStr
+                                required property string s1TimeStr
+                                required property string s2TimeStr
+                                required property string s3TimeStr
                                 width: parent ? parent.width : 0
                                 height: 28
 
@@ -701,7 +779,7 @@ Window {
                                     Text {
                                         width: root.ttColLabel
                                         height: parent.height
-                                        text: ttRow.modelData.label
+                                        text: ttRow.label
                                         font.family: "Formula1"
                                         font.pixelSize: 12
                                         color: "#aaaaaa"
@@ -710,7 +788,7 @@ Window {
                                     Text {
                                         width: root.ttColLapTime
                                         height: parent.height
-                                        text: ttRow.modelData["lap-time-str"]
+                                        text: ttRow.lapTimeStr
                                         font.family: "Consolas"
                                         font.pixelSize: 13
                                         color: "#ffffff"
@@ -720,7 +798,7 @@ Window {
                                     Text {
                                         width: root.ttColSector
                                         height: parent.height
-                                        text: ttRow.modelData["s1-time-str"]
+                                        text: ttRow.s1TimeStr
                                         font.family: "Consolas"
                                         font.pixelSize: 12
                                         color: "#cccccc"
@@ -730,7 +808,7 @@ Window {
                                     Text {
                                         width: root.ttColSector
                                         height: parent.height
-                                        text: ttRow.modelData["s2-time-str"]
+                                        text: ttRow.s2TimeStr
                                         font.family: "Consolas"
                                         font.pixelSize: 12
                                         color: "#cccccc"
@@ -740,7 +818,7 @@ Window {
                                     Text {
                                         width: root.ttColSector
                                         height: parent.height
-                                        text: ttRow.modelData["s3-time-str"]
+                                        text: ttRow.s3TimeStr
                                         font.family: "Consolas"
                                         font.pixelSize: 12
                                         color: "#cccccc"

--- a/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
+++ b/apps/hud/ui/overlays/timing_tower/timing_tower_overlay.py
@@ -37,6 +37,7 @@ from lib.config import (OverlayId, OverlaysFuelEstimationMode,
                         OverlaysSpeedUnit, PngSettings)
 from lib.f1_types import F1Utils
 from lib.logger import PngLogger
+from lib.table_differ import TableDiffer
 
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
@@ -84,8 +85,19 @@ class TimingTowerOverlay(BaseOverlay):
         self.tyre_icon_uris = load_tyre_icons_uri_dict()
 
     @final
+    def pre_setup(self):
+        """Create the table differs before the window (and post_setup) exists."""
+        self._race_differ = TableDiffer(self._stats)
+        self._tt_differ = TableDiffer(self._stats)
+
+    @final
     def post_setup(self):
         """Set QML properties after the window is ready."""
+        # The window (and with it both table models) is new and empty, so the
+        # next update of each table has to rebuild it rather than patch rows.
+        self._race_differ.invalidate()
+        self._tt_differ.invalidate()
+
         self.set_qml_property("numRows", self.total_rows)
         self.set_qml_property("columnOrder", self.column_order)
         self.set_qml_property("showColHeader", self.show_col_header)
@@ -165,12 +177,18 @@ class TimingTowerOverlay(BaseOverlay):
     def _set_race_mode(self) -> None:
         """Switch QML to race mode and clear TT table."""
         self.set_qml_property("mode", "race")
-        self.set_qml_property("ttTableData", [])
+        self._sync_table(self._tt_differ, "ttTableUpdate", [])
 
     def _set_tt_mode(self, table_data: list) -> None:
         """Switch QML to time-trial mode and populate TT table."""
         self.set_qml_property("mode", "tt")
-        self.set_qml_property("ttTableData", table_data)
+        self._sync_table(self._tt_differ, "ttTableUpdate", table_data)
+
+    def _sync_table(self, differ: TableDiffer, name: str, rows: List[Dict[str, Any]]) -> None:
+        """Diff rows and, if anything moved, write the one payload QML applies."""
+        update = differ.update(rows)
+        if update:
+            self.push_qml_property(name, update)
 
     def _update_session_info(self, text: str):
         """Update the session info label in QML.
@@ -188,7 +206,7 @@ class TimingTowerOverlay(BaseOverlay):
         """
         self.set_qml_property("showError", True)
         self.set_qml_property("errorMessage", message)
-        self.set_qml_property("tableData", [])
+        self._sync_table(self._race_differ, "tableUpdate", [])
 
     def _update_table_data(self,
                            relevant_rows: List[Dict[str, Any]],
@@ -209,7 +227,7 @@ class TimingTowerOverlay(BaseOverlay):
         """
         # Hide error message
         self.set_qml_property("showError", False)
-        self.set_qml_property("tableData", [
+        self._sync_table(self._race_differ, "tableUpdate", [
             self._create_driver_row(
                 row_data, ref_index, session_type, fastest_index,
                 ref_best_lap_ms, ref_last_lap_ms,
@@ -256,7 +274,10 @@ class TimingTowerOverlay(BaseOverlay):
         is_sb = driver_idx == fastest_index
         last_lap_ms = last_lap_info.get("lap-time-ms")
         best_lap_ms = best_lap_info.get("lap-time-ms")
-        is_pb = (last_lap_ms and best_lap_ms and last_lap_ms == best_lap_ms)
+        # bool(), not just the and-chain: with no last lap yet this is None, and
+        # a None never creates its ListModel role, which breaks every delegate
+        # that requires it.
+        is_pb = bool(last_lap_ms and best_lap_ms and last_lap_ms == best_lap_ms)
 
         ers_mode = self._get_ers_mode(row_data)
         wing_dmg = self._format_wing_dmg(dmg_info, telemetry_public)
@@ -268,7 +289,7 @@ class TimingTowerOverlay(BaseOverlay):
             "teamIcon": self.team_logo_uris[driver_info.get("team", "UNKNOWN")],
             "name": driver_info.get("name", "UNKNOWN"),
             "delta": self._format_delta(driver_info, delta_info, driver_idx, ref_index, session_type),
-            "delta-to-leader": self._format_delta_to_leader(driver_info, delta_info, driver_idx, 0, session_type),
+            "deltaToLeader": self._format_delta_to_leader(driver_info, delta_info, driver_idx, 0, session_type),
             "tyreIcon": self.tyre_icon_uris.get(tyre_info.get("visual-tyre-compound", "UNKNOWN"), ""),
             "tyreWear": self._format_tyre_wear(tyre_info, telemetry_public),
             "ers": self._format_ers(ers_info, telemetry_public),
@@ -542,7 +563,7 @@ class TimingTowerOverlay(BaseOverlay):
     def clear(self):
         """Clear all timing data."""
         self.set_qml_property("sessionInfo", "TIMING TOWER")
-        self.set_qml_property("tableData", [])
+        self._sync_table(self._race_differ, "tableUpdate", [])
         self.set_qml_property("showError", False)
         self._set_race_mode()
 
@@ -704,25 +725,25 @@ class TimingTowerOverlay(BaseOverlay):
         if not dataset or not dataset.get("is-valid"):
             return {
                 "label": label,
-                "lap-time-str": "---",
-                "s1-time-str": "---",
-                "s2-time-str": "---",
-                "s3-time-str": "---",
+                "lapTimeStr": "---",
+                "s1TimeStr": "---",
+                "s2TimeStr": "---",
+                "s3TimeStr": "---",
             }
         if pb_ms is not None and pb_ms["lap"] is not None:
             return {
                 "label": label,
-                "lap-time-str": self._format_tt_delta(dataset.get("lap-time-ms"), pb_ms["lap"]),
-                "s1-time-str": self._format_tt_delta(dataset.get("sector-1-time-ms"), pb_ms["s1"]),
-                "s2-time-str": self._format_tt_delta(dataset.get("sector-2-time-in-ms"), pb_ms["s2"]),
-                "s3-time-str": self._format_tt_delta(dataset.get("sector3-time-in-ms"), pb_ms["s3"]),
+                "lapTimeStr": self._format_tt_delta(dataset.get("lap-time-ms"), pb_ms["lap"]),
+                "s1TimeStr": self._format_tt_delta(dataset.get("sector-1-time-ms"), pb_ms["s1"]),
+                "s2TimeStr": self._format_tt_delta(dataset.get("sector-2-time-in-ms"), pb_ms["s2"]),
+                "s3TimeStr": self._format_tt_delta(dataset.get("sector3-time-in-ms"), pb_ms["s3"]),
             }
         return {
             "label": label,
-            "lap-time-str": dataset.get("lap-time-str", "---"),
-            "s1-time-str": dataset.get("sector-1-time-str", "---"),
-            "s2-time-str": dataset.get("sector-2-time-str", "---"),
-            "s3-time-str": dataset.get("sector-3-time-str", "---"),
+            "lapTimeStr": dataset.get("lap-time-str", "---"),
+            "s1TimeStr": dataset.get("sector-1-time-str", "---"),
+            "s2TimeStr": dataset.get("sector-2-time-str", "---"),
+            "s3TimeStr": dataset.get("sector-3-time-str", "---"),
         }
 
     def _get_tt_curr_lap(self, tt_data_outer: dict) -> dict:
@@ -738,10 +759,10 @@ class TimingTowerOverlay(BaseOverlay):
         if not current_lap_info:
             return {
                 "label": "Current",
-                "lap-time-str": "---",
-                "s1-time-str": "---",
-                "s2-time-str": "---",
-                "s3-time-str": "---",
+                "lapTimeStr": "---",
+                "s1TimeStr": "---",
+                "s2TimeStr": "---",
+                "s3TimeStr": "---",
             }
 
         lap_time_ms = current_lap_info.get("lap-time-ms")
@@ -751,10 +772,10 @@ class TimingTowerOverlay(BaseOverlay):
 
         return {
             "label": "Current",
-            "lap-time-str": F1Utils.getLapTimeStr(lap_time_ms) if lap_time_ms is not None else "---",
-            "s1-time-str": F1Utils.millisecondsToSecondsMilliseconds(sector1_time_ms) if sector1_time_ms is not None else "---",
-            "s2-time-str": F1Utils.millisecondsToSecondsMilliseconds(sector2_time_ms) if sector2_time_ms is not None else "---",
-            "s3-time-str": F1Utils.millisecondsToSecondsMilliseconds(sector3_time_ms) if sector3_time_ms is not None else "---",
+            "lapTimeStr": F1Utils.getLapTimeStr(lap_time_ms) if lap_time_ms is not None else "---",
+            "s1TimeStr": F1Utils.millisecondsToSecondsMilliseconds(sector1_time_ms) if sector1_time_ms is not None else "---",
+            "s2TimeStr": F1Utils.millisecondsToSecondsMilliseconds(sector2_time_ms) if sector2_time_ms is not None else "---",
+            "s3TimeStr": F1Utils.millisecondsToSecondsMilliseconds(sector3_time_ms) if sector3_time_ms is not None else "---",
         }
 
     def _get_tt_pb_lap(self, tt_data: dict) -> dict:

--- a/integration_test_cfg.json
+++ b/integration_test_cfg.json
@@ -18,7 +18,6 @@
         "post_fp_data_autosave": true,
         "post_tt_data_autosave": true,
         "save_race_ctrl_msg": true,
-        "drop_pit_otk_msg": true,
         "just_in_case_autosave": true,
         "session_dir": "data"
     },
@@ -173,6 +172,7 @@
         "show_circuit_info": true,
         "circuit_info_toggle_udp_action_code": null,
         "circuit_info_length": 800,
+        "circuit_info_minimal": false,
         "show_pu_info": true,
         "pu_display_harvest_info": true,
         "pu_toggle_udp_action_code": null,

--- a/lib/README.md
+++ b/lib/README.md
@@ -28,6 +28,7 @@ This directory contains shared code used across multiple apps in the Pits N Gigg
 | `overtake_analyzer.py` | Overtake detection |
 | `rolling_history.py` | Rolling window data history |
 | `rate_limiter.py` | Rate limiting for event emissions |
+| `table_differ.py` | Row-granularity diffing of table data for UI patching |
 | `button_debouncer.py` | Debounce logic for UDP-triggered actions |
 | `event_counter.py` | Event counting utilities |
 | `custom_marker_tracker.py` | User-defined marker tracking |

--- a/lib/table_differ.py
+++ b/lib/table_differ.py
@@ -22,7 +22,7 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
-from typing import Any, Callable, List, Optional
+from typing import Any, Dict, List, Optional
 
 from lib.event_counter import EventCounter
 
@@ -32,12 +32,20 @@ class TableDiffer:
     """Row-granularity differ for table data pushed to a UI.
 
     A row is any `==`-comparable object; no particular shape is assumed. Each
-    `update()` either fires the reset hooks with the whole table, or fires the
-    row-patch hooks once per changed row index:
+    `update()` returns one payload describing everything that changed, or None
+    when nothing did:
 
     - no stored table (fresh, or after `invalidate()`), or a row-count change
-      -> reset
-    - same row count -> one patch per index where the row compares unequal
+      -> {"kind": "reset", "rows": [row, ...]}
+    - same row count -> {"kind": "patch", "rows": [{"index": i, "row": row}, ...]}
+      carrying only the indices whose row compares unequal
+
+    One payload per update means one QML property write per tick however many
+    rows moved, and resets and patches cannot arrive out of order, since they
+    travel through the same property.
+
+    Note that {"kind": "reset", "rows": []} means "empty the table" and is quite
+    different from None, which means "nothing to do".
 
     Contract: callers must pass a freshly built list of freshly built rows and
     must not mutate either after the call. The list is stored by reference, so
@@ -45,11 +53,15 @@ class TableDiffer:
 
     Counts what it decided under __TABLE_DIFFER__ in the caller's EventCounter, which
     nests under the owning overlay in the stats tree:
-        __RESET__       whole-table pushes (page activation, row-count change)
-        __PATCH__       rows patched, summed over all updates
-        __UNCHANGED__   updates that produced no work at all
-        __INVALIDATED__ times the stored table was dropped
+        __RESET__           whole-table pushes (page activation, row-count change)
+        __PATCH_NUM_ROWS__  rows patched, summed over all updates
+        __UNCHANGED__       updates that produced no work at all
+        __INVALIDATED__     times the stored table was dropped
     """
+
+    # Payload discriminator. The QML side compares against these same strings.
+    RESET = "reset"
+    PATCH = "patch"
 
     def __init__(self, stats: EventCounter) -> None:
         """
@@ -57,47 +69,30 @@ class TableDiffer:
         """
         self._stats = stats
         self._rows: Optional[List[Any]] = None
-        self._reset_cbs: List[Callable[[List[Any]], None]] = []
-        self._patch_cbs: List[Callable[[int, Any], None]] = []
-
-    # ------------------------------------------------------------------
-    # Callback registration (usable as a decorator or a plain call)
-    # ------------------------------------------------------------------
-    def on_reset(self, fn: Callable[[List[Any]], None]) -> Callable[[List[Any]], None]:
-        """Register a whole-table callback. Returns fn unchanged."""
-        self._reset_cbs.append(fn)
-        return fn
-
-    def on_row_patch(self, fn: Callable[[int, Any], None]) -> Callable[[int, Any], None]:
-        """Register a single-row callback, called as (index, row). Returns fn unchanged."""
-        self._patch_cbs.append(fn)
-        return fn
 
     # ------------------------------------------------------------------
     # Diffing
     # ------------------------------------------------------------------
-    def update(self, new_rows: List[Any]) -> None:
-        """Diff new_rows against the stored table and fire the matching hooks."""
+    def update(self, new_rows: List[Any]) -> Optional[Dict[str, Any]]:
+        """Diff new_rows against the stored table. Returns the payload, or None."""
         old_rows = self._rows
         self._rows = new_rows
 
         if old_rows is None or len(old_rows) != len(new_rows):
             self._stats.track_event("__TABLE_DIFFER__", "__RESET__")
-            for cb in self._reset_cbs:
-                cb(new_rows)
-            return
+            return {"kind": self.RESET, "rows": new_rows}
 
-        patched = 0
-        for index, (old_row, new_row) in enumerate(zip(old_rows, new_rows)):
-            if old_row != new_row:
-                patched += 1
-                for cb in self._patch_cbs:
-                    cb(index, new_row)
-
-        if patched:
-            self._stats.track_event("__TABLE_DIFFER__", "__PATCH__", count=patched)
-        else:
+        patches = [
+            {"index": index, "row": new_row}
+            for index, (old_row, new_row) in enumerate(zip(old_rows, new_rows))
+            if old_row != new_row
+        ]
+        if not patches:
             self._stats.track_event("__TABLE_DIFFER__", "__UNCHANGED__")
+            return None
+
+        self._stats.track_event("__TABLE_DIFFER__", "__PATCH_NUM_ROWS__", count=len(patches))
+        return {"kind": self.PATCH, "rows": patches}
 
     def invalidate(self) -> None:
         """Drop the stored table so the next update() always fires a reset.

--- a/lib/table_differ.py
+++ b/lib/table_differ.py
@@ -1,0 +1,86 @@
+# MIT License
+#
+# Copyright (c) [2026] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------- IMPORTS -----------------------------------------------------------------------
+
+from typing import Any, Callable, List, Optional
+
+# -------------------------------------- CLASSES -----------------------------------------------------------------------
+
+class TableDiffer:
+    """Row-granularity differ for table data pushed to a UI.
+
+    A row is any `==`-comparable object; no particular shape is assumed. Each
+    `update()` either fires the reset hooks with the whole table, or fires the
+    row-patch hooks once per changed row index:
+
+    - no stored table (fresh, or after `invalidate()`), or a row-count change
+      -> reset
+    - same row count -> one patch per index where the row compares unequal
+
+    Contract: callers must pass a freshly built list of freshly built rows and
+    must not mutate either after the call. The list is stored by reference, so
+    any later mutation silently corrupts the next diff.
+    """
+
+    def __init__(self) -> None:
+        self._rows: Optional[List[Any]] = None
+        self._reset_cbs: List[Callable[[List[Any]], None]] = []
+        self._patch_cbs: List[Callable[[int, Any], None]] = []
+
+    # ------------------------------------------------------------------
+    # Callback registration (usable as a decorator or a plain call)
+    # ------------------------------------------------------------------
+    def on_reset(self, fn: Callable[[List[Any]], None]) -> Callable[[List[Any]], None]:
+        """Register a whole-table callback. Returns fn unchanged."""
+        self._reset_cbs.append(fn)
+        return fn
+
+    def on_row_patch(self, fn: Callable[[int, Any], None]) -> Callable[[int, Any], None]:
+        """Register a single-row callback, called as (index, row). Returns fn unchanged."""
+        self._patch_cbs.append(fn)
+        return fn
+
+    # ------------------------------------------------------------------
+    # Diffing
+    # ------------------------------------------------------------------
+    def update(self, new_rows: List[Any]) -> None:
+        """Diff new_rows against the stored table and fire the matching hooks."""
+        old_rows = self._rows
+        self._rows = new_rows
+
+        if old_rows is None or len(old_rows) != len(new_rows):
+            for cb in self._reset_cbs:
+                cb(new_rows)
+            return
+
+        for index, (old_row, new_row) in enumerate(zip(old_rows, new_rows)):
+            if old_row != new_row:
+                for cb in self._patch_cbs:
+                    cb(index, new_row)
+
+    def invalidate(self) -> None:
+        """Drop the stored table so the next update() always fires a reset.
+
+        Call this whenever the UI target is (re)created and has lost its rows.
+        """
+        self._rows = None

--- a/lib/table_differ.py
+++ b/lib/table_differ.py
@@ -24,6 +24,8 @@
 
 from typing import Any, Callable, List, Optional
 
+from lib.event_counter import EventCounter
+
 # -------------------------------------- CLASSES -----------------------------------------------------------------------
 
 class TableDiffer:
@@ -40,9 +42,20 @@ class TableDiffer:
     Contract: callers must pass a freshly built list of freshly built rows and
     must not mutate either after the call. The list is stored by reference, so
     any later mutation silently corrupts the next diff.
+
+    Counts what it decided under __TABLE_DIFFER__ in the caller's EventCounter, which
+    nests under the owning overlay in the stats tree:
+        __RESET__       whole-table pushes (page activation, row-count change)
+        __PATCH__       rows patched, summed over all updates
+        __UNCHANGED__   updates that produced no work at all
+        __INVALIDATED__ times the stored table was dropped
     """
 
-    def __init__(self) -> None:
+    def __init__(self, stats: EventCounter) -> None:
+        """
+        stats : the owning component's counter, so table stats land beside its others
+        """
+        self._stats = stats
         self._rows: Optional[List[Any]] = None
         self._reset_cbs: List[Callable[[List[Any]], None]] = []
         self._patch_cbs: List[Callable[[int, Any], None]] = []
@@ -69,18 +82,27 @@ class TableDiffer:
         self._rows = new_rows
 
         if old_rows is None or len(old_rows) != len(new_rows):
+            self._stats.track_event("__TABLE_DIFFER__", "__RESET__")
             for cb in self._reset_cbs:
                 cb(new_rows)
             return
 
+        patched = 0
         for index, (old_row, new_row) in enumerate(zip(old_rows, new_rows)):
             if old_row != new_row:
+                patched += 1
                 for cb in self._patch_cbs:
                     cb(index, new_row)
+
+        if patched:
+            self._stats.track_event("__TABLE_DIFFER__", "__PATCH__", count=patched)
+        else:
+            self._stats.track_event("__TABLE_DIFFER__", "__UNCHANGED__")
 
     def invalidate(self) -> None:
         """Drop the stored table so the next update() always fires a reset.
 
         Call this whenever the UI target is (re)created and has lost its rows.
         """
+        self._stats.track_event("__TABLE_DIFFER__", "__INVALIDATED__")
         self._rows = None

--- a/scripts/png.spec
+++ b/scripts/png.spec
@@ -128,6 +128,7 @@ def qml_file(path, filename):
 
 datas.extend([
     qml_file("apps/hud/ui/overlays/base", "OverlayBorder.qml"),
+    qml_file("apps/hud/ui/overlays/base", "DiffedTableModel.qml"),
     qml_file("apps/hud/ui/overlays/track_radar", "track_radar.qml"),
     qml_file("apps/hud/ui/overlays/input_telemetry", "input_telemetry.qml"),
     qml_file("apps/hud/ui/overlays/timing_tower", "timing_tower.qml"),

--- a/scripts/qmllint.py
+++ b/scripts/qmllint.py
@@ -39,6 +39,7 @@ def main() -> int:
         [str(qmllint), "--max-warnings", "0", *[str(f) for f in qml_files]],
         stdin=subprocess.DEVNULL,
     )
+    print(f"Linted {len(qml_files)} QML files under {QML_ROOT}. Return code: {result.returncode}")
     return result.returncode
 
 

--- a/tests/tests_table_differ.py
+++ b/tests/tests_table_differ.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, NamedTuple, Union
 
 import pytest
 
+from lib.event_counter import EventCounter
 from lib.table_differ import TableDiffer
 
 # -------------------------------------- TYPES -------------------------------------------------------------------------
@@ -51,8 +52,12 @@ def calls() -> CallLog:
     return []
 
 @pytest.fixture
-def differ(calls: CallLog) -> TableDiffer:
-    obj = TableDiffer()
+def stats() -> EventCounter:
+    return EventCounter()
+
+@pytest.fixture
+def differ(calls: CallLog, stats: EventCounter) -> TableDiffer:
+    obj = TableDiffer(stats)
     obj.on_reset(lambda table: calls.append(Reset(table)))
     obj.on_row_patch(lambda index, row: calls.append(Patch(index, row)))
     return obj
@@ -144,7 +149,7 @@ def test_invalidate_on_a_fresh_differ_is_harmless(differ: TableDiffer, calls: Ca
 # -------------------------------------- TESTS: registration ---------------------------------------------------------
 
 def test_all_registered_callbacks_fire_in_registration_order() -> None:
-    differ = TableDiffer()
+    differ = TableDiffer(EventCounter())
     calls: List[Any] = []
     differ.on_reset(lambda table: calls.append(("first", Reset(table))))
     differ.on_reset(lambda table: calls.append(("second", Reset(table))))
@@ -162,7 +167,7 @@ def test_all_registered_callbacks_fire_in_registration_order() -> None:
     ]
 
 def test_registration_works_as_a_decorator_and_returns_fn_unchanged() -> None:
-    differ = TableDiffer()
+    differ = TableDiffer(EventCounter())
     calls: CallLog = []
 
     @differ.on_reset
@@ -181,7 +186,7 @@ def test_registration_works_as_a_decorator_and_returns_fn_unchanged() -> None:
     assert handle_patch.__name__ == "handle_patch"
 
 def test_differ_with_no_callbacks_still_tracks_state() -> None:
-    differ = TableDiffer()
+    differ = TableDiffer(EventCounter())
     differ.update(rows("a"))
 
     calls: CallLog = []

--- a/tests/tests_table_differ.py
+++ b/tests/tests_table_differ.py
@@ -22,7 +22,7 @@
 
 # -------------------------------------- IMPORTS -----------------------------------------------------------------------
 
-from typing import Any, Dict, List, NamedTuple, Union
+from typing import Any, Dict, List
 
 import pytest
 
@@ -33,164 +33,91 @@ from lib.table_differ import TableDiffer
 
 Row = Dict[str, str]
 
-class Reset(NamedTuple):
-    """A whole-table push, as seen by an on_reset callback."""
-    table: List[Any]
-
-class Patch(NamedTuple):
-    """A single-row push, as seen by an on_row_patch callback."""
-    index: int
-    row: Any
-
-CallLog = List[Union[Reset, Patch]]
-
 # -------------------------------------- FIXTURES ----------------------------------------------------------------------
 
 @pytest.fixture
-def calls() -> CallLog:
-    """Ordered log of everything the differ emitted. Empty means it stayed silent."""
-    return []
-
-@pytest.fixture
-def stats() -> EventCounter:
-    return EventCounter()
-
-@pytest.fixture
-def differ(calls: CallLog, stats: EventCounter) -> TableDiffer:
-    obj = TableDiffer(stats)
-    obj.on_reset(lambda table: calls.append(Reset(table)))
-    obj.on_row_patch(lambda index, row: calls.append(Patch(index, row)))
-    return obj
+def differ() -> TableDiffer:
+    return TableDiffer(EventCounter())
 
 def rows(*names: str) -> List[Row]:
     return [{"name": name} for name in names]
 
+def reset(*names: str) -> Dict[str, Any]:
+    return {"kind": "reset", "rows": rows(*names)}
+
+def patch(*entries: Any) -> Dict[str, Any]:
+    """patch((1, "x"), ...) -> the payload for those index/name pairs."""
+    return {"kind": "patch", "rows": [{"index": i, "row": {"name": n}} for i, n in entries]}
+
 # -------------------------------------- TESTS: reset ----------------------------------------------------------------
 
-def test_first_update_fires_reset(differ: TableDiffer, calls: CallLog) -> None:
-    differ.update(rows("a", "b"))
-    assert calls == [Reset(rows("a", "b"))]
+def test_first_update_returns_reset(differ: TableDiffer) -> None:
+    assert differ.update(rows("a", "b")) == reset("a", "b")
 
-def test_first_update_with_empty_table_fires_reset(differ: TableDiffer, calls: CallLog) -> None:
-    differ.update([])
-    assert calls == [Reset([])]
+def test_first_update_with_empty_table_returns_reset(differ: TableDiffer) -> None:
+    assert differ.update([]) == {"kind": "reset", "rows": []}
 
-def test_row_count_growth_fires_reset(differ: TableDiffer, calls: CallLog) -> None:
+def test_row_count_growth_returns_reset(differ: TableDiffer) -> None:
     differ.update(rows("a"))
-    calls.clear()
-    differ.update(rows("a", "b"))
-    assert calls == [Reset(rows("a", "b"))]
+    assert differ.update(rows("a", "b")) == reset("a", "b")
 
-def test_row_count_shrink_fires_reset(differ: TableDiffer, calls: CallLog) -> None:
+def test_row_count_shrink_returns_reset(differ: TableDiffer) -> None:
     differ.update(rows("a", "b"))
-    calls.clear()
-    differ.update(rows("a"))
-    assert calls == [Reset(rows("a"))]
+    assert differ.update(rows("a")) == reset("a")
 
-def test_clearing_to_empty_fires_reset(differ: TableDiffer, calls: CallLog) -> None:
+def test_clearing_to_empty_returns_an_empty_reset_not_none(differ: TableDiffer) -> None:
     differ.update(rows("a", "b"))
-    calls.clear()
-    differ.update([])
-    assert calls == [Reset([])]
+    assert differ.update([]) == {"kind": "reset", "rows": []}
 
-def test_empty_to_empty_fires_nothing(differ: TableDiffer, calls: CallLog) -> None:
+def test_empty_to_empty_returns_none(differ: TableDiffer) -> None:
     differ.update([])
-    calls.clear()
-    differ.update([])
-    assert calls == []
+    assert differ.update([]) is None
+
+def test_reset_payload_carries_the_caller_rows(differ: TableDiffer) -> None:
+    table = rows("a", "b")
+    assert differ.update(table)["rows"] is table
 
 # -------------------------------------- TESTS: patches --------------------------------------------------------------
 
-def test_identical_update_fires_nothing(differ: TableDiffer, calls: CallLog) -> None:
+def test_identical_update_returns_none(differ: TableDiffer) -> None:
     differ.update(rows("a", "b"))
-    calls.clear()
-    differ.update(rows("a", "b"))
-    assert calls == []
+    assert differ.update(rows("a", "b")) is None
 
-def test_single_changed_row_fires_one_patch(differ: TableDiffer, calls: CallLog) -> None:
+def test_single_changed_row_returns_one_patch(differ: TableDiffer) -> None:
     differ.update(rows("a", "b", "c"))
-    calls.clear()
-    differ.update(rows("a", "x", "c"))
-    assert calls == [Patch(1, {"name": "x"})]
+    assert differ.update(rows("a", "x", "c")) == patch((1, "x"))
 
-def test_multiple_changed_rows_patch_in_index_order(differ: TableDiffer, calls: CallLog) -> None:
+def test_multiple_changed_rows_are_listed_in_index_order(differ: TableDiffer) -> None:
     differ.update(rows("a", "b", "c"))
-    calls.clear()
-    differ.update(rows("x", "b", "y"))
-    assert calls == [Patch(0, {"name": "x"}), Patch(2, {"name": "y"})]
+    assert differ.update(rows("x", "b", "y")) == patch((0, "x"), (2, "y"))
 
-def test_patches_compare_against_the_latest_table(differ: TableDiffer, calls: CallLog) -> None:
+def test_patches_compare_against_the_latest_table(differ: TableDiffer) -> None:
     differ.update(rows("a", "b"))
-    calls.clear()
     differ.update(rows("a", "x"))
-    differ.update(rows("a", "x"))
-    assert calls == [Patch(1, {"name": "x"})]
+    assert differ.update(rows("a", "x")) is None
 
-def test_rows_may_be_any_comparable_object(differ: TableDiffer, calls: CallLog) -> None:
+def test_rows_may_be_any_comparable_object(differ: TableDiffer) -> None:
     differ.update([1, 2, 3])
-    calls.clear()
-    differ.update([1, 9, 3])
-    assert calls == [Patch(1, 9)]
+    assert differ.update([1, 9, 3]) == {"kind": "patch", "rows": [{"index": 1, "row": 9}]}
 
 # -------------------------------------- TESTS: invalidate -----------------------------------------------------------
 
-def test_invalidate_forces_reset_on_identical_data(differ: TableDiffer, calls: CallLog) -> None:
+def test_invalidate_forces_a_reset_on_identical_data(differ: TableDiffer) -> None:
     differ.update(rows("a", "b"))
-    calls.clear()
     differ.invalidate()
-    differ.update(rows("a", "b"))
-    assert calls == [Reset(rows("a", "b"))]
+    assert differ.update(rows("a", "b")) == reset("a", "b")
 
-def test_invalidate_on_a_fresh_differ_is_harmless(differ: TableDiffer, calls: CallLog) -> None:
+def test_invalidate_on_a_fresh_differ_is_harmless(differ: TableDiffer) -> None:
     differ.invalidate()
+    assert differ.update(rows("a")) == reset("a")
+
+# -------------------------------------- TESTS: payload contract -------------------------------------------------------
+
+def test_kind_strings_are_the_documented_constants(differ: TableDiffer) -> None:
+    assert differ.update(rows("a"))["kind"] == TableDiffer.RESET
+    assert differ.update(rows("b"))["kind"] == TableDiffer.PATCH
+
+def test_patch_payload_carries_the_new_row_object(differ: TableDiffer) -> None:
     differ.update(rows("a"))
-    assert calls == [Reset(rows("a"))]
-
-# -------------------------------------- TESTS: registration ---------------------------------------------------------
-
-def test_all_registered_callbacks_fire_in_registration_order() -> None:
-    differ = TableDiffer(EventCounter())
-    calls: List[Any] = []
-    differ.on_reset(lambda table: calls.append(("first", Reset(table))))
-    differ.on_reset(lambda table: calls.append(("second", Reset(table))))
-    differ.on_row_patch(lambda index, row: calls.append(("first", Patch(index, row))))
-    differ.on_row_patch(lambda index, row: calls.append(("second", Patch(index, row))))
-
-    differ.update(rows("a"))
-    differ.update(rows("b"))
-
-    assert calls == [
-        ("first", Reset(rows("a"))),
-        ("second", Reset(rows("a"))),
-        ("first", Patch(0, {"name": "b"})),
-        ("second", Patch(0, {"name": "b"})),
-    ]
-
-def test_registration_works_as_a_decorator_and_returns_fn_unchanged() -> None:
-    differ = TableDiffer(EventCounter())
-    calls: CallLog = []
-
-    @differ.on_reset
-    def handle_reset(table: List[Any]) -> None:
-        calls.append(Reset(table))
-
-    @differ.on_row_patch
-    def handle_patch(index: int, row: Any) -> None:
-        calls.append(Patch(index, row))
-
-    differ.update(rows("a"))
-    differ.update(rows("b"))
-
-    assert calls == [Reset(rows("a")), Patch(0, {"name": "b"})]
-    assert handle_reset.__name__ == "handle_reset"
-    assert handle_patch.__name__ == "handle_patch"
-
-def test_differ_with_no_callbacks_still_tracks_state() -> None:
-    differ = TableDiffer(EventCounter())
-    differ.update(rows("a"))
-
-    calls: CallLog = []
-    differ.on_row_patch(lambda index, row: calls.append(Patch(index, row)))
-    differ.update(rows("b"))
-
-    assert calls == [Patch(0, {"name": "b"})]
+    table = rows("b")
+    assert differ.update(table)["rows"][0]["row"] is table[0]

--- a/tests/tests_table_differ.py
+++ b/tests/tests_table_differ.py
@@ -1,0 +1,191 @@
+# MIT License
+#
+# Copyright (c) [2026] [Ashwin Natarajan]
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# -------------------------------------- IMPORTS -----------------------------------------------------------------------
+
+from typing import Any, Dict, List, NamedTuple, Union
+
+import pytest
+
+from lib.table_differ import TableDiffer
+
+# -------------------------------------- TYPES -------------------------------------------------------------------------
+
+Row = Dict[str, str]
+
+class Reset(NamedTuple):
+    """A whole-table push, as seen by an on_reset callback."""
+    table: List[Any]
+
+class Patch(NamedTuple):
+    """A single-row push, as seen by an on_row_patch callback."""
+    index: int
+    row: Any
+
+CallLog = List[Union[Reset, Patch]]
+
+# -------------------------------------- FIXTURES ----------------------------------------------------------------------
+
+@pytest.fixture
+def calls() -> CallLog:
+    """Ordered log of everything the differ emitted. Empty means it stayed silent."""
+    return []
+
+@pytest.fixture
+def differ(calls: CallLog) -> TableDiffer:
+    obj = TableDiffer()
+    obj.on_reset(lambda table: calls.append(Reset(table)))
+    obj.on_row_patch(lambda index, row: calls.append(Patch(index, row)))
+    return obj
+
+def rows(*names: str) -> List[Row]:
+    return [{"name": name} for name in names]
+
+# -------------------------------------- TESTS: reset ----------------------------------------------------------------
+
+def test_first_update_fires_reset(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update(rows("a", "b"))
+    assert calls == [Reset(rows("a", "b"))]
+
+def test_first_update_with_empty_table_fires_reset(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update([])
+    assert calls == [Reset([])]
+
+def test_row_count_growth_fires_reset(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update(rows("a"))
+    calls.clear()
+    differ.update(rows("a", "b"))
+    assert calls == [Reset(rows("a", "b"))]
+
+def test_row_count_shrink_fires_reset(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update(rows("a", "b"))
+    calls.clear()
+    differ.update(rows("a"))
+    assert calls == [Reset(rows("a"))]
+
+def test_clearing_to_empty_fires_reset(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update(rows("a", "b"))
+    calls.clear()
+    differ.update([])
+    assert calls == [Reset([])]
+
+def test_empty_to_empty_fires_nothing(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update([])
+    calls.clear()
+    differ.update([])
+    assert calls == []
+
+# -------------------------------------- TESTS: patches --------------------------------------------------------------
+
+def test_identical_update_fires_nothing(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update(rows("a", "b"))
+    calls.clear()
+    differ.update(rows("a", "b"))
+    assert calls == []
+
+def test_single_changed_row_fires_one_patch(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update(rows("a", "b", "c"))
+    calls.clear()
+    differ.update(rows("a", "x", "c"))
+    assert calls == [Patch(1, {"name": "x"})]
+
+def test_multiple_changed_rows_patch_in_index_order(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update(rows("a", "b", "c"))
+    calls.clear()
+    differ.update(rows("x", "b", "y"))
+    assert calls == [Patch(0, {"name": "x"}), Patch(2, {"name": "y"})]
+
+def test_patches_compare_against_the_latest_table(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update(rows("a", "b"))
+    calls.clear()
+    differ.update(rows("a", "x"))
+    differ.update(rows("a", "x"))
+    assert calls == [Patch(1, {"name": "x"})]
+
+def test_rows_may_be_any_comparable_object(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update([1, 2, 3])
+    calls.clear()
+    differ.update([1, 9, 3])
+    assert calls == [Patch(1, 9)]
+
+# -------------------------------------- TESTS: invalidate -----------------------------------------------------------
+
+def test_invalidate_forces_reset_on_identical_data(differ: TableDiffer, calls: CallLog) -> None:
+    differ.update(rows("a", "b"))
+    calls.clear()
+    differ.invalidate()
+    differ.update(rows("a", "b"))
+    assert calls == [Reset(rows("a", "b"))]
+
+def test_invalidate_on_a_fresh_differ_is_harmless(differ: TableDiffer, calls: CallLog) -> None:
+    differ.invalidate()
+    differ.update(rows("a"))
+    assert calls == [Reset(rows("a"))]
+
+# -------------------------------------- TESTS: registration ---------------------------------------------------------
+
+def test_all_registered_callbacks_fire_in_registration_order() -> None:
+    differ = TableDiffer()
+    calls: List[Any] = []
+    differ.on_reset(lambda table: calls.append(("first", Reset(table))))
+    differ.on_reset(lambda table: calls.append(("second", Reset(table))))
+    differ.on_row_patch(lambda index, row: calls.append(("first", Patch(index, row))))
+    differ.on_row_patch(lambda index, row: calls.append(("second", Patch(index, row))))
+
+    differ.update(rows("a"))
+    differ.update(rows("b"))
+
+    assert calls == [
+        ("first", Reset(rows("a"))),
+        ("second", Reset(rows("a"))),
+        ("first", Patch(0, {"name": "b"})),
+        ("second", Patch(0, {"name": "b"})),
+    ]
+
+def test_registration_works_as_a_decorator_and_returns_fn_unchanged() -> None:
+    differ = TableDiffer()
+    calls: CallLog = []
+
+    @differ.on_reset
+    def handle_reset(table: List[Any]) -> None:
+        calls.append(Reset(table))
+
+    @differ.on_row_patch
+    def handle_patch(index: int, row: Any) -> None:
+        calls.append(Patch(index, row))
+
+    differ.update(rows("a"))
+    differ.update(rows("b"))
+
+    assert calls == [Reset(rows("a")), Patch(0, {"name": "b"})]
+    assert handle_reset.__name__ == "handle_reset"
+    assert handle_patch.__name__ == "handle_patch"
+
+def test_differ_with_no_callbacks_still_tracks_state() -> None:
+    differ = TableDiffer()
+    differ.update(rows("a"))
+
+    calls: CallLog = []
+    differ.on_row_patch(lambda index, row: calls.append(Patch(index, row)))
+    differ.update(rows("b"))
+
+    assert calls == [Patch(0, {"name": "b"})]


### PR DESCRIPTION
## What and why

Every table overlay re-assigned its whole table as one QML property per tick, so a
single changed cell destroyed and rebuilt every delegate in the view.

`TableDiffer` (new, in `lib/`) now diffs rows in Python and returns one payload per
tick — a whole-table reset, or just the rows that changed. `DiffedTableModel.qml`
applies it to a `ListModel`, so a changed row updates one delegate instead of all
of them. All five tables are migrated: lap times, pace comparison, traffic monitor,
tyre wear, and the timing tower (race + TT).

Timing tower row keys were renamed from kebab to camel case (`delta-to-leader` →
`deltaToLeader`, `lap-time-str` → `lapTimeStr`) because `ListModel` role names have
to be valid QML property names — a delegate cannot declare `required property
string delta-to-leader`. Outgoing keys only; the incoming telemetry keys are
unchanged.

Also included: present smoothness is no longer reported for event-driven overlays,
where nearly every sample is discarded as an idle gap and the few that survive
measure telemetry arrival rather than rendering health.

Fixes #299

## Test plan

- [x] Integration tests pass — `poetry run python tests/integration_test/runner.py`

  ```
  ================================================================================
  2026-08-12 23:05:32,971 [TEST] [runner.py:435] - TEST STATISTICS
  2026-08-12 23:05:32,971 [TEST] [runner.py:436] - ================================================================================
  2026-08-12 23:05:32,972 [TEST] [runner.py:437] - Files processed:        36
  2026-08-12 23:05:32,972 [TEST] [runner.py:438] - Telemetry sent:         36
  2026-08-12 23:05:32,972 [TEST] [runner.py:439] - Telemetry failed:       0
  2026-08-12 23:05:32,972 [TEST] [runner.py:440] - Endpoint checks passed: 972
  2026-08-12 23:05:32,973 [TEST] [runner.py:441] - Endpoint checks failed: 0
  2026-08-12 23:05:32,973 [TEST] [runner.py:442] - Saves checked:          4
  2026-08-12 23:05:32,973 [TEST] [runner.py:443] - Saves skipped by app:   3
  2026-08-12 23:05:32,974 [TEST] [runner.py:444] - Saves unreadable:       0
  2026-08-12 23:05:32,975 [TEST] [runner.py:445] - Invariant violations:   0
  2026-08-12 23:05:32,976 [TEST] [runner.py:454] - Telemetry success rate: 100.0%
  2026-08-12 23:05:32,976 [TEST] [runner.py:458] - Endpoint success rate:  100.0%
  2026-08-12 23:05:32,976 [TEST] [runner.py:460] - ================================================================================
  2026-08-12 23:05:32,976 [TEST] [runner.py:826] - 
  Total execution time: 29:44.927
  ```

- [x] Manually tested in the app

  ```
  Replayed the same capture on each branch back to back, with the integration
  test config (all 16 overlays enabled), plus race/TT mode switches and page
  switching on the MFD.

  Event handler duration -- time spent building rows, diffing and writing to
  QML, measured inside the overlay's handler on the GUI thread:

                                  base     branch
    timing tower       p50     14.03ms     1.90ms   7.4x
                       p95     19.41ms     3.49ms
                       max     36.40ms     5.82ms
    traffic monitor    p50      5.28ms     0.75ms   7.0x
                       p95      7.58ms     2.02ms
    tyre wear          p50      1.40ms     0.39ms   3.5x
                       p95      2.08ms     0.72ms
    pace comparison    p50      0.12ms     0.12ms   flat
    lap times          avg      0.10ms     0.40ms   slower

  Summed across every table overlay, per-tick handler time falls from 27.7ms to
  10.2ms, so about 17.5ms of work per tick leaves the shared GUI thread.

  Lap times is a small real regression -- the whole distribution shifted, not one
  outlier. At five rows it never paid for a delegate rebuild, so the diff plus
  per-row set() is net overhead there. Pace comparison early-exits on nearly
  every tick in this capture, so it is flat rather than unaffected.

  The same effect measured from the other end, dispatch wait p50 -- time from the
  HUD broadcasting a payload to an overlay receiving it, i.e. how long it waits
  behind other overlays' work on that same GUI thread:

                             base     branch
    hud_overlay            16.47ms    3.99ms   4.1x
    circuit_info           16.60ms    4.06ms   4.1x
    mfd                    16.67ms    4.11ms   4.1x
    weather                18.51ms    4.58ms   4.0x
    fuel_info              16.70ms    4.14ms   4.0x
    pit_rejoin             18.57ms    4.63ms   4.0x
    tyre wear              16.76ms    4.19ms   4.0x
    pace comparison        25.04ms   11.47ms   2.2x
    traffic monitor        25.45ms   11.71ms   2.2x
    timing tower            1.74ms    1.67ms   flat
    lap_timer               0.89ms    0.94ms   flat

  Most of those overlays contain no table code -- they are faster because the
  table overlays stopped occupying the GUI thread ahead of them. On the
  stream_overlay_update path, p95 fell from ~30ms to ~8.7ms for every
  subscriber, including untouched ones.

  These are single runs of 51s and 81s, so treat the sub-millisecond deltas as
  directional.

  Correctness checks from the same runs (perf DB counters): rows patched always
  equalled rows written, one reset per overlay activation, no writes dropped for
  want of a target, and the tables rendered correctly through session restart,
  error state, and race <-> TT switches. A 30 minute integration run patched
  27000 rows across ~80 page switches with no dropped patches and no QML
  warnings.
  ```

- [ ] No testable change

## Summary by Sourcery

Introduce a shared row-diffing model for HUD tables to reduce UI churn and improve overlay performance, and migrate timing and MFD table overlays to use it safely with QML role constraints.

New Features:
- Add lib.table_differ.TableDiffer and base DiffedTableModel.qml to support row-level patching of table overlays instead of full-table rewrites.

Bug Fixes:
- Ensure timing tower and time-trial table roles use camelCase names compatible with QML properties.
- Prevent nullable flags and missing keys from breaking ListModel role creation by seeding complete placeholder rows and normalizing boolean values.
- Remove the duplicate _get_cell_text_colour definition that would cause a SyntaxError in the lap times page.

Enhancements:
- Refactor timing tower, lap times, pace comparison, traffic monitor, and tyre wear overlays to drive their QML tables via DiffedTableModel payloads.
- Tighten QML property handling by separating unconditional push_qml_property from cached set_qml_property and tracking table-differ stats.
- Adjust QML overlays and telemetry-mapped role names to use valid, flat property roles suitable for ListModel patching.

Build:
- Bundle DiffedTableModel.qml in the application spec so it is available at runtime.

CI:
- Extend the QML lint script to print the number of linted files and the tool return code for easier diagnostics.

Documentation:
- Document table_differ.py in lib/README.md as the shared row-diffing utility for UI patching.

Tests:
- Add unit tests for TableDiffer covering reset vs patch behavior, payload structure, invalidation, and event-counter integration.

