### PR TITLE
Making F1SubPacketBase slotted

### DIFF
--- a/lib/f1_types/base_pkt.py
+++ b/lib/f1_types/base_pkt.py
@@ -286,6 +286,10 @@ class F1SubPacketBase:
     All derived classes must use __slots__.
     """
 
+    # F1PacketBase can guarantee that m_header is present,
+    # F1SubPacketBase cannot make any such guarantees. Hence the empty __slots__ tuple
+    __slots__ = ()
+
     @abstractmethod
     def toJSON(self) -> Dict[str, Any]:
         raise NotImplementedError(f"{self.__class__.__name__} must implement toJSON()")

--- a/lib/f1_types/packet_12_tyre_sets_packet.py
+++ b/lib/f1_types/packet_12_tyre_sets_packet.py
@@ -73,6 +73,7 @@ class TyreSetData(F1SubPacketBase):
     PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
     __slots__ = (
+        "m_packetFormat",
         "m_actualTyreCompound",
         "m_visualTyreCompound",
         "m_wear",

--- a/lib/f1_types/packet_1_session_data.py
+++ b/lib/f1_types/packet_1_session_data.py
@@ -190,14 +190,14 @@ class WeatherForecastSample(F1SubPacketBase):
     PACKET_LEN = COMPILED_PACKET_STRUCT.size
 
     __slots__ = (
-        "m_session_type",
-        "m_time_offset",
+        "m_sessionType",
+        "m_timeOffset",
         "m_weather",
-        "m_track_temperature",
-        "m_track_temperature_change",
-        "m_air_temperature",
-        "m_air_temperature_change",
-        "m_rain_percentage",
+        "m_trackTemperature",
+        "m_trackTemperatureChange",
+        "m_airTemperature",
+        "m_airTemperatureChange",
+        "m_rainPercentage",
     )
 
     class WeatherCondition(F1BaseEnum):

--- a/lib/f1_types/packet_2_lap_data.py
+++ b/lib/f1_types/packet_2_lap_data.py
@@ -214,6 +214,8 @@ class LapData(F1SubPacketBase):
         "m_pitStopShouldServePen",
         "m_speedTrapFastestSpeed",
         "m_speedTrapFastestLap",
+        "m_deltaToCarInFrontMinutes",
+        "m_deltaToRaceLeaderMinutes",
     )
 
     class DriverStatus(F1BaseEnum):

--- a/lib/f1_types/packet_5_car_setups_data.py
+++ b/lib/f1_types/packet_5_car_setups_data.py
@@ -117,6 +117,7 @@ class CarSetupData(F1SubPacketBase):
     PACKET_LEN_24 = COMPILED_PACKET_STRUCT_24.size
 
     __slots__ = (
+        "m_packetFormat",
         "m_frontWing",
         "m_rearWing",
         "m_onThrottle",

--- a/lib/f1_types/packet_8_final_classification_data.py
+++ b/lib/f1_types/packet_8_final_classification_data.py
@@ -103,6 +103,7 @@ class FinalClassificationData(F1SubPacketBase):
     PACKET_LEN_25 = COMPILED_PACKET_STRUCT_25.size
 
     __slots__ = (
+        "m_packetFormat",
         "m_position",
         "m_numLaps",
         "m_gridPosition",

--- a/lib/f1_types/packet_9_lobby_info_data.py
+++ b/lib/f1_types/packet_9_lobby_info_data.py
@@ -109,6 +109,7 @@ class LobbyInfoData(F1SubPacketBase):
     PACKET_LEN_26 = COMPILED_PACKET_STRUCT_26.size
 
     __slots__ = (
+        "m_packetFormat",
         "m_aiControlled",
         "m_teamId",
         "m_nationality",
@@ -138,7 +139,7 @@ class LobbyInfoData(F1SubPacketBase):
             packet_format (int): The packet format version.
         """
 
-        self.packet_format = packet_format
+        self.m_packetFormat = packet_format
         self._parse(data, packet_format)
         self._cast_enums(packet_format)
 
@@ -252,7 +253,7 @@ class LobbyInfoData(F1SubPacketBase):
         """
 
         return (
-            self.packet_format == other.packet_format and
+            self.m_packetFormat == other.m_packetFormat and
             self.m_aiControlled == other.m_aiControlled and
             self.m_teamId == other.m_teamId and
             self.m_nationality == other.m_nationality and
@@ -285,7 +286,7 @@ class LobbyInfoData(F1SubPacketBase):
             bytes: Raw data representing the LobbyInfoData instance.
         """
 
-        if self.packet_format == 2023:
+        if self.m_packetFormat == 2023:
             return self.COMPILED_PACKET_STRUCT_23.pack(
                 self.m_aiControlled,
                 self.m_teamId.value,
@@ -295,7 +296,7 @@ class LobbyInfoData(F1SubPacketBase):
                 self.m_carNumber,
                 self.m_readyStatus.value,
             )
-        if self.packet_format == 2024:
+        if self.m_packetFormat == 2024:
             return self.COMPILED_PACKET_STRUCT_24.pack(
                 self.m_aiControlled,
                 self.m_teamId.value,
@@ -308,7 +309,7 @@ class LobbyInfoData(F1SubPacketBase):
                 self.m_techLevel,
                 self.m_readyStatus.value,
             )
-        if self.packet_format == 2025:
+        if self.m_packetFormat == 2025:
             return self.COMPILED_PACKET_STRUCT_25.pack(
                 self.m_aiControlled,
                 self.m_teamId.value,
@@ -321,7 +322,7 @@ class LobbyInfoData(F1SubPacketBase):
                 self.m_techLevel,
                 self.m_readyStatus.value,
             )
-        if self.packet_format >= 2026:
+        if self.m_packetFormat >= 2026:
             return self.COMPILED_PACKET_STRUCT_26.pack(
                 self.m_aiControlled,
                 self.m_teamId.value,
@@ -335,7 +336,7 @@ class LobbyInfoData(F1SubPacketBase):
                 self.m_readyStatus.value,
             )
 
-        raise NotImplementedError(f"Unsupported packet format: {self.packet_format}")
+        raise NotImplementedError(f"Unsupported packet format: {self.m_packetFormat}")
 
     @classmethod
     def from_values(cls,

--- a/tests/f1_types/tests_base.py
+++ b/tests/f1_types/tests_base.py
@@ -343,3 +343,38 @@ class TestF1RawValueEnumIsValid:
     def test_members_themselves_are_valid(self):
         # Call sites pass members as well as raw values
         assert Shape.isValid(Shape.CIRCLE)
+
+def test_subpacket_instances_are_fully_slotted():
+    class TestSubPacket(F1SubPacketBase):
+        __slots__ = ("value",)
+
+        def __init__(self):
+            self.value = 42
+
+        def toJSON(self):
+            return {"value": self.value}
+
+    packet = TestSubPacket()
+
+    assert not hasattr(packet, "__dict__")
+
+    with pytest.raises(AttributeError):
+        packet.undeclared_attribute = 123
+
+def test_packet_instances_are_fully_slotted():
+    class TestPacket(F1PacketBase):
+        __slots__ = ()
+
+        def __init__(self, header):
+            super().__init__(header)
+
+        def toJSON(self, include_header=False):
+            return {}
+
+    packet = TestPacket(None)
+
+    assert not hasattr(packet, "__dict__")
+
+    with pytest.raises(AttributeError):
+        packet.undeclared_attribute = 123
+


### PR DESCRIPTION
## What and why

Unlike F1PacketBase, F1SubPacketBase (which has way more objects alive at point of time) was never slotted.
This change makes F1SubPacketBase slotted as well, and has a couple of tests asserting this behaviour.
A few other parsers had to be fixed since they missed some fields in the __slots__ registration (which previously did nothing)

Fixes #

## Test plan

- [ ] Integration tests pass — `poetry run python tests/integration_test/runner.py`

  ```
  paste output here
  ```

- [x] Manually tested in the app

  ```
  UT pass is good enough, since any breakage related to this change would just cause the obj ctor to raise an exception
  ```

- [ ] No testable change

## Summary by Sourcery

Make sub-packet models fully slotted and validate their memory-saving attribute restrictions.

Enhancements:
- Make F1SubPacketBase and its derived packet data classes fully slotted to reduce per-instance memory usage and prevent undeclared attributes.
- Correct missing and mismatched slot declarations and standardize packet-format field handling across affected parsers.

Tests:
- Add coverage verifying that packet and sub-packet instances do not expose a __dict__ and reject undeclared attributes.